### PR TITLE
@since decorator work with test classes

### DIFF
--- a/auth_roles_test.py
+++ b/auth_roles_test.py
@@ -16,9 +16,9 @@ role2_role = ['role2', False, False]
 cassandra_role = ['cassandra', True, True]
 
 
+@since('3.0')
 class TestAuthRoles(Tester):
 
-    @since('3.0')
     def create_drop_role_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -30,7 +30,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE role1")
         assert_one(cassandra, "LIST ROLES", cassandra_role)
 
-    @since('3.0')
     def conditional_create_drop_role_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -44,7 +43,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE IF EXISTS role1")
         assert_one(cassandra, "LIST ROLES", cassandra_role)
 
-    @since('3.0')
     def create_drop_role_validation_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -66,7 +64,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE role1")
         assert_invalid(cassandra, "DROP ROLE role1", "role1 doesn't exist")
 
-    @since('3.0')
     def role_admin_validation_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -121,7 +118,6 @@ class TestAuthRoles(Tester):
                        "User mike does not have sufficient privileges to perform the requested operation",
                        Unauthorized)
 
-    @since('3.0')
     def creator_of_db_resource_granted_all_permissions_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -145,7 +141,6 @@ class TestAuthRoles(Tester):
                                        cassandra,
                                        "LIST ALL PERMISSIONS")
 
-    @since('3.0')
     def create_and_grant_roles_with_superuser_status_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -169,7 +164,6 @@ class TestAuthRoles(Tester):
                                                       ['non_superuser', False, False],
                                                       ['role1', False, False]])
 
-    @since('3.0')
     def drop_and_revoke_roles_with_superuser_status_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -190,7 +184,6 @@ class TestAuthRoles(Tester):
         mike.execute("DROP ROLE role1")
 
 
-    @since('3.0')
     def drop_role_removes_memberships_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -213,7 +206,6 @@ class TestAuthRoles(Tester):
         assert_one(cassandra, "LIST ROLES OF mike", mike_role)
         assert_all(cassandra, "LIST ROLES", [cassandra_role, mike_role, role2_role])
 
-    @since('3.0')
     def drop_role_revokes_permissions_granted_on_it_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -232,7 +224,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE role2")
         assert cassandra.execute("LIST ALL PERMISSIONS OF mike") is None
 
-    @since('3.0')
     def grant_revoke_roles_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -252,7 +243,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("REVOKE role1 FROM role2")
         assert_one(cassandra, "LIST ROLES OF role2", role2_role)
 
-    @since('3.0')
     def grant_revoke_role_validation_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -287,7 +277,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("REVOKE role1 FROM john")
         mike.execute("REVOKE role2 from john")
 
-    @since('3.0')
     def list_roles_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -322,7 +311,6 @@ class TestAuthRoles(Tester):
         assert_all(mike, "LIST ROLES", [cassandra_role, mike_role, role1_role, role2_role])
 
 
-    @since('3.0')
     def grant_revoke_permissions_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -352,7 +340,6 @@ class TestAuthRoles(Tester):
                        "mike has no MODIFY permission on <table ks.cf> or any of its parents",
                        Unauthorized)
 
-    @since('3.0')
     def filter_granted_permissions_by_resource_type_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -418,7 +405,6 @@ class TestAuthRoles(Tester):
                        SyntaxException)
 
 
-    @since('3.0')
     def list_permissions_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -488,7 +474,6 @@ class TestAuthRoles(Tester):
                                        mike,
                                        "LIST ALL PERMISSIONS OF mike")
 
-    @since('3.0')
     def list_permissions_validation_test(self):
         self.prepare()
 
@@ -527,7 +512,6 @@ class TestAuthRoles(Tester):
                        "You are not authorized to view john's permissions",
                        Unauthorized)
 
-    @since('3.0')
     def role_caching_authenticated_user_test(self):
         # This test is to show that the role caching in AuthenticatedUser
         # works correctly and revokes the roles from a logged in user
@@ -559,7 +543,6 @@ class TestAuthRoles(Tester):
 
         assert unauthorized is not None
 
-    @since('3.0')
     def prevent_circular_grants_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -577,7 +560,6 @@ class TestAuthRoles(Tester):
                        "mike is a member of role2",
                        InvalidRequest)
 
-    @since('3.0')
     def create_user_as_alias_for_create_role_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -587,7 +569,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("CREATE USER super_user WITH PASSWORD '12345' SUPERUSER")
         assert_one(cassandra, "LIST ROLES OF super_user", ["super_user", True, True])
 
-    @since('3.0')
     def role_requires_login_privilege_to_authenticate_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -603,7 +584,6 @@ class TestAuthRoles(Tester):
         assert_one(cassandra, "LIST ROLES OF mike", ["mike", False, True])
         self.get_session(user='mike', password='12345')
 
-    @since('3.0')
     def roles_do_not_inherit_login_privilege_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -617,7 +597,6 @@ class TestAuthRoles(Tester):
 
         self.assert_unauthenticated("mike is not permitted to log in", "mike", "12345")
 
-    @since('3.0')
     def role_requires_password_to_login_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')
@@ -626,7 +605,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("ALTER ROLE mike WITH PASSWORD '12345'")
         self.get_session(user='mike', password='12345')
 
-    @since('3.0')
     def superuser_status_is_inherited_test(self):
         self.prepare()
         cassandra = self.get_session(user='cassandra', password='cassandra')

--- a/cfid_test.py
+++ b/cfid_test.py
@@ -4,9 +4,9 @@ import unittest, os, sys, time
 from ccmlib.cluster import Cluster
 from ccmlib import common
 
+@since('2.1')
 class TestCFID(Tester):
 
-    @since('2.1')
     def cfid_test(self):
         """ Test through adding/dropping cf's that the path to sstables for each cf are unique and formatted correctly """
         cluster = self.cluster

--- a/consistent_bootstrap_test.py
+++ b/consistent_bootstrap_test.py
@@ -6,10 +6,10 @@ from tools import (create_c1c2_table, insert_c1c2, query_c1c2, retry_till_succes
                    insert_columns, new_node, no_vnodes, since)
 from cassandra import ConsistencyLevel
 
+@since('2.1')
 class TestBootstrapConsistency(Tester):
 
     @no_vnodes()
-    @since('2.1')
     def consistent_reads_after_move_test(self):
         debug("Creating a ring")
         cluster = self.cluster
@@ -50,7 +50,6 @@ class TestBootstrapConsistency(Tester):
         for n in xrange(30,1000):
             query_c1c2(n2cursor, n, ConsistencyLevel.ALL)
 
-    @since('2.1')
     def consistent_reads_after_bootstrap_test(self):
         debug("Creating a ring")
         cluster = self.cluster

--- a/cql_prepared_test.py
+++ b/cql_prepared_test.py
@@ -7,6 +7,7 @@ from ccmlib.cluster import Cluster
 
 cql_version="3.0.0"
 
+@since("1.2")
 class TestCQL(Tester):
 
     def prepare(self):
@@ -20,7 +21,6 @@ class TestCQL(Tester):
         self.create_ks(cursor, 'ks', 1)
         return cursor
 
-    @since("1.2")
     def batch_preparation_test(self):
         """ Test preparation of batch statement (#4202) """
         cursor = self.prepare()

--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -8,6 +8,7 @@ import time
 import os
 from assertions import assert_invalid, assert_one, assert_all, assert_none
 
+@since('2.1')
 class TestIncRepair(Tester):
 
     def __init__(self, *args, **kwargs):
@@ -17,7 +18,6 @@ class TestIncRepair(Tester):
         ]
         Tester.__init__(self, *args, **kwargs)
 
-    @since('2.1')
     def sstable_marking_test(self):
         cluster = self.cluster
         cluster.populate(3).start()
@@ -45,12 +45,11 @@ class TestIncRepair(Tester):
 
         with open("sstables.txt", 'r') as r:
             output = r.read().replace('\n', '')
-        
+
         self.assertNotIn('repairedAt: 0', output)
 
         os.remove('sstables.txt')
 
-    @since('2.1')
     def multiple_repair_test(self):
         cluster = self.cluster
         cluster.populate(3).start()
@@ -109,7 +108,6 @@ class TestIncRepair(Tester):
 
         assert_one(cursor, "SELECT COUNT(*) FROM ks.cf LIMIT 200", [149])
 
-    @since('2.1')
     def sstable_repairedset_test(self):
         cluster = self.cluster
         cluster.populate(2).start()

--- a/paging_test.py
+++ b/paging_test.py
@@ -178,14 +178,13 @@ class BasePagingTester(Tester):
         cursor.row_factory = dict_factory
         return cursor
 
-
+@since('2.0')
 class TestPagingSize(BasePagingTester, PageAssertionMixin):
     """
     Basic tests relating to page size (relative to results set)
     and validation of page size setting.
     """
 
-    @since('2.0')
     def test_with_no_results(self):
         """
         No errors when a page is requested and query has no results.
@@ -204,7 +203,6 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
         self.assertEqual([], pf.all_data())
         self.assertFalse(pf.has_more_pages)
 
-    @since('2.0')
     def test_with_less_results_than_page_size(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -229,7 +227,6 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
         self.assertFalse(pf.has_more_pages)
         self.assertEqual(len(expected_data), len(pf.all_data()))
 
-    @since('2.0')
     def test_with_more_results_than_page_size(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -261,7 +258,6 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
         # make sure expected and actual have same data elements (ignoring order)
         self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
-    @since('2.0')
     def test_with_equal_results_to_page_size(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -289,7 +285,6 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
         # make sure expected and actual have same data elements (ignoring order)
         self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
-    @since('2.0')
     def test_undefined_page_size_default(self):
         """
         If the page size isn't sent then the default fetch size is used.
@@ -319,11 +314,11 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
         self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
 
+@since('2.0')
 class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when CQL modifiers (such as order, limit, allow filtering) are used.
     """
-    @since('2.0')
     def test_with_order_by(self):
         """"
         Paging over a single partition with ordering should work.
@@ -373,7 +368,6 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
             stmt = SimpleStatement("select * from paging_test where id in (1,2) order by value asc", consistency_level=CL.ALL)
             cursor.execute(stmt)
 
-    @since('2.0')
     def test_with_order_by_reversed(self):
         """"
         Paging over a single partition with ordering and a reversed clustering order.
@@ -431,7 +425,6 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
         # these should be equal (in the same order)
         self.assertEqual(pf.all_data(), list(reversed(expected_data)))
 
-    @since('2.0')
     def test_with_limit(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -514,7 +507,6 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
 
         run_scenarios(scenarios, handle_scenario, deferred_exceptions=(AssertionError,))
 
-    @since('2.0')
     def test_with_allow_filtering(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -560,9 +552,8 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
             )
         )
 
-
+@since('2.0')
 class TestPagingData(BasePagingTester, PageAssertionMixin):
-    @since('2.0')
     def test_paging_a_single_wide_row(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -588,7 +579,6 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
-    @since('2.0')
     def test_paging_across_multi_wide_rows(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -615,7 +605,6 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
-    @since('2.0')
     def test_paging_using_secondary_indexes(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -654,11 +643,11 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
         self.assertEqualIgnoreOrder(expected_data, pf.all_data())
 
 
+@since('2.0')
 class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when the queried dataset changes while pages are being retrieved.
     """
-    @since('2.0')
     def test_data_change_impacting_earlier_page(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -692,7 +681,6 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
 
         self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
-    @since('2.0')
     def test_data_change_impacting_later_page(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -727,7 +715,6 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
         expected_data.append({u'id': 2, u'mytext': u'foo'})
         self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
-    @since('2.0')
     def test_data_delete_removing_remainder(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -758,7 +745,6 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
         self.assertEqual(pf.pagecount(), 1)
         self.assertEqual(pf.num_results_all(), [500])
 
-    @since('2.0')
     def test_row_TTL_expiry_during_paging(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -801,7 +787,6 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
         self.assertEqual(pf.pagecount(), 3)
         self.assertEqual(pf.num_results_all(), [300, 300, 200])
 
-    @since('2.0')
     def test_cell_TTL_expiry_during_paging(self):
         cursor = self.prepare()
         self.create_ks(cursor, 'test_paging_size', 2)
@@ -866,7 +851,6 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
         page3 = pf.page_data(3)
         self.assertEqualIgnoreOrder(page3, page3expected)
 
-    @since('2.0')
     def test_node_unavailabe_during_paging(self):
         cluster = self.cluster
         cluster.populate(3).start()
@@ -901,11 +885,11 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
         # TODO: can we resume the node and expect to get more results from the result set or is it done?
 
 
+@since('2.0')
 class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with isolation of paged queries (queries can't affect each other).
     """
-    @since('2.0')
     def test_query_isolation(self):
         """
         Interleave some paged queries and make sure nothing bad happens.

--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -10,6 +10,7 @@ import time
 from threading import Thread
 from ccmlib.cluster import Cluster
 
+@since('2.0.6')
 class TestPaxos(Tester):
 
     def prepare(self, ordered=False, create_keyspace=True, use_cache=False, nodes=1, rf=1):
@@ -30,7 +31,6 @@ class TestPaxos(Tester):
             self.create_ks(cursor, 'ks', rf)
         return cursor
 
-    @since('2.0.6')
     def replica_availability_test(self):
         #See CASSANDRA-8640
         session = self.prepare(nodes=3, rf=3)
@@ -49,7 +49,6 @@ class TestPaxos(Tester):
         self.cluster.nodelist()[2].start()
         session.execute("INSERT INTO test (k, v) VALUES (4, 4) IF NOT EXISTS")
 
-    @since('2.0.6')
     @no_vnodes()
     def cluster_availability_test(self):
         #Warning, a change in partitioner or a change in CCM token allocation
@@ -72,11 +71,9 @@ class TestPaxos(Tester):
         self.cluster.nodelist()[2].start()
         session.execute("INSERT INTO test (k, v) VALUES (6, 6) IF NOT EXISTS")
 
-    @since('2.0.6')
     def contention_test_multi_iterations(self):
         self._contention_test(8, 100)
 
-    @since('2.0.6')
     ##Warning, this test will require you to raise the open
     ##file limit on OSX. Use 'ulimit -n 1000'
     def contention_test_many_threds(self):

--- a/schema_test.py
+++ b/schema_test.py
@@ -4,8 +4,8 @@ from tools import since, rows_to_list
 from assertions import assert_invalid
 import time
 
+@since('2.0')
 class TestSchema(Tester):
-    @since('2.0')
     def drop_column_compact_test(self):
         cursor = self.prepare()
 
@@ -14,7 +14,6 @@ class TestSchema(Tester):
 
         assert_invalid(cursor, "ALTER TABLE cf DROP c1", "Cannot drop columns from a")
 
-    @since('2.0')
     def drop_column_compaction_test(self):
         cursor = self.prepare()
         cursor.execute("USE ks")
@@ -49,7 +48,6 @@ class TestSchema(Tester):
         rows = cursor.execute("SELECT c1 FROM ks.cf")
         self.assertEqual([[None], [None], [None], [4]], sorted(rows_to_list(rows)))
 
-    @since('2.0')
     def drop_column_queries_test(self):
         cursor = self.prepare()
 

--- a/ttl_test.py
+++ b/ttl_test.py
@@ -13,7 +13,7 @@ from assertions import (
     assert_unavailable
 )
 
-
+@since('2.0')
 class TestTTL(Tester):
     """ Test Time To Live Feature """
 
@@ -53,7 +53,6 @@ class TestTTL(Tester):
         if real_time_to_wait > 0:
             time.sleep(real_time_to_wait)
 
-    @since('2.0')
     def default_ttl_test(self):
         """ Test default_time_to_live specified on a table """
 
@@ -65,7 +64,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 1.5)
         assert_row_count(self.cursor1, 'ttl_table', 0)
 
-    @since('2.0')
     def insert_ttl_has_priority_on_defaut_ttl_test(self):
         """ Test that a ttl specified during an insert has priority on the default table ttl """
 
@@ -80,7 +78,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 3.5)
         assert_row_count(self.cursor1, 'ttl_table', 0)
 
-    @since('2.0')
     def insert_ttl_works_without_defaut_ttl_test(self):
         """ Test that a ttl specified during an insert works even if a table has no default ttl """
 
@@ -93,7 +90,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 1.5)
         assert_row_count(self.cursor1, 'ttl_table', 0)
 
-    @since('2.0')
     def default_ttl_can_be_removed_test(self):
         """ Test that default_time_to_live can be removed """
 
@@ -107,7 +103,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 1.5)
         assert_row_count(self.cursor1, 'ttl_table', 1)
 
-    @since('2.0')
     def removing_default_ttl_does_not_affect_existing_rows_test(self):
         """ Test that removing a default_time_to_live doesn't affect the existings rows """
 
@@ -130,7 +125,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 5.5)
         assert_row_count(self.cursor1, 'ttl_table', 1)
 
-    @since('2.0')
     def update_single_column_ttl_test(self):
         """ Test that specifying a TTL on a single column works """
 
@@ -145,7 +139,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 2.5)
         assert_all(self.cursor1, "SELECT * FROM ttl_table;", [[1, None, 1, 1]])
 
-    @since('2.0')
     def update_multiple_columns_ttl_test(self):
         """ Test that specifying a TTL on multiple columns works """
 
@@ -162,7 +155,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 2.5)
         assert_all(self.cursor1, "SELECT * FROM ttl_table;", [[1, None, None, None]])
 
-    @since('2.0')
     def update_column_ttl_with_default_ttl_test(self):
         """
         Test that specifying a column ttl works when a default ttl is set.
@@ -182,7 +174,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 4.5)
         assert_row_count(self.cursor1, 'ttl_table', 0)
 
-    @since('2.0')
     def update_column_ttl_with_default_ttl_test2(self):
         """
         Test that specifying a column ttl works when a default ttl is set.
@@ -201,7 +192,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 4.5)
         assert_row_count(self.cursor1, 'ttl_table', 0)
 
-    @since('2.0')
     def remove_column_ttl_test(self):
         """
         Test that removing a column ttl works.
@@ -217,7 +207,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 2.5)
         assert_all(self.cursor1, "SELECT * FROM ttl_table;", [[1, 42, None, None]])
 
-    @since('2.0')
     def remove_column_ttl_with_default_ttl_test(self):
         """
         Test that we cannot remove a column ttl when a default ttl is set.
@@ -240,7 +229,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 4.5)
         assert_row_count(self.cursor1, 'ttl_table', 0)
 
-    @since('2.0')
     def collection_list_ttl_test(self):
         """
         Test that ttl has a granularity of elements using a list collection.
@@ -262,7 +250,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 5.5)
         assert_row_count(self.cursor1, 'ttl_table', 0)
 
-    @since('2.0')
     def collection_set_ttl_test(self):
         """
         Test that ttl has a granularity of elements using a set collection.
@@ -292,7 +279,6 @@ class TestTTL(Tester):
         self.smart_sleep(start, 5.5)
         assert_row_count(self.cursor1, 'ttl_table', 0)
 
-    @since('2.0')
     def collection_map_ttl_test(self):
         """
         Test that ttl has a granularity of elements using a map collection.

--- a/udtencoding_test.py
+++ b/udtencoding_test.py
@@ -5,9 +5,9 @@ from tools import since
 import os, sys, time
 from ccmlib.cluster import Cluster
 
+@since('2.1')
 class TestUDTEncoding(Tester):
 
-    @since('2.1')
     def udt_test(self):
         """ Test (somewhat indirectly) that user queries involving UDT's are properly encoded (due to driver not recognizing UDT syntax) """
         cluster = self.cluster

--- a/upgrade_supercolumns_test.py
+++ b/upgrade_supercolumns_test.py
@@ -3,9 +3,10 @@ from ccmlib.cluster import Cluster
 from ccmlib.common import get_version_from_build
 from tools import since
 import random, os, time, re
-
 # Tests upgrade between 1.2->2.0 for super columns (since that's where
 # we removed then internally)
+
+@since('2.0')
 class TestSCUpgrade(Tester):
 
     def __init__(self, *args, **kwargs):
@@ -17,7 +18,6 @@ class TestSCUpgrade(Tester):
         ]
         Tester.__init__(self, *args, **kwargs)
 
-    @since('2.0')
     def upgrade_with_index_creation_test(self):
         cluster = self.cluster
 
@@ -73,7 +73,6 @@ class TestSCUpgrade(Tester):
         cli.close()
 
     #CASSANDRA-7188
-    @since('2.0')
     def upgrade_with_counters_test(self):
         cluster = self.cluster
 

--- a/user_functions_test.py
+++ b/user_functions_test.py
@@ -5,6 +5,7 @@ from assertions import assert_invalid, assert_one, assert_all, assert_none
 from tools import since, rows_to_list
 
 
+@since('3.0')
 class TestUserFunctions(Tester):
 
     def prepare(self, create_keyspace=True, nodes=1, rf=1):
@@ -19,7 +20,6 @@ class TestUserFunctions(Tester):
             self.create_ks(cursor, 'ks', rf)
         return cursor
 
-    @since('3.0')
     def test_migration(self):
         """ Test migration of user functions """
         cluster = self.cluster
@@ -81,7 +81,6 @@ class TestUserFunctions(Tester):
         #try creating function returning the wrong type, should error
         assert_invalid(cursor1, "CREATE FUNCTION bad_sin ( input double ) RETURNS double LANGUAGE java AS 'return Math.sin(input.doubleValue());'", "Could not compile function 'ks.bad_sin' from Java source:")
 
-    @since('3.0')
     def udf_overload_test(self):
 
         session = self.prepare(nodes=3)
@@ -117,7 +116,6 @@ class TestUserFunctions(Tester):
         #should now work - unambiguous
         session.execute("DROP FUNCTION overloaded");
 
-    @since("3.0")
     def udf_scripting_test(self):
         session = self.prepare()
         session.execute("create table nums (key int primary key, val double);")
@@ -141,7 +139,6 @@ class TestUserFunctions(Tester):
 
         assert_one(session, "select plustwo(key) from nums where key = 3", [5])
 
-    @since("3.0")
     def default_aggregate_test(self):
         session = self.prepare()
         session.execute("create table nums (key int primary key, val double);")
@@ -156,7 +153,6 @@ class TestUserFunctions(Tester):
         assert_one(session, "SELECT count(*) FROM nums", [9])
 
 
-    @since("3.0")
     def aggregate_udf_test(self):
         session = self.prepare()
         session.execute("create table nums (key int primary key, val int);")
@@ -176,7 +172,6 @@ class TestUserFunctions(Tester):
 
         assert_invalid(session, "create aggregate aggthree(int) sfunc test stype int finalfunc aggtwo")
 
-    @since("3.0")
     def udf_with_udt_test(self):
         session = self.prepare()
 

--- a/user_types_test.py
+++ b/user_types_test.py
@@ -28,6 +28,7 @@ def listify(item):
     return decoded
 
 
+@since('2.1')
 class TestUserTypes(Tester):
 
     def __init__(self, *args, **kwargs):
@@ -38,7 +39,6 @@ class TestUserTypes(Tester):
             cursor.execute(query)
         assert re.search(message, cm.exception.message), "Expected: %s" % message
 
-    @since('2.1')
     def test_type_dropping(self):
         """
         Tests that a type cannot be dropped when in use, and otherwise can be dropped.
@@ -105,7 +105,6 @@ class TestUserTypes(Tester):
         rows = cursor.execute(stmt)
         self.assertEqual(0, len(rows))
 
-    @since('2.1')
     def test_nested_type_dropping(self):
         """
         Confirm a user type can't be dropped when being used by another user type.
@@ -159,7 +158,6 @@ class TestUserTypes(Tester):
         rows = cursor.execute(stmt)
         self.assertEqual(0, len(rows))
 
-    @since('2.1')
     def test_type_enforcement(self):
         """
         Confirm error when incorrect data type used for user type
@@ -210,7 +208,6 @@ class TestUserTypes(Tester):
         rows = cursor.execute(stmt)
         self.assertEqual(0, len(rows))
 
-    @since('2.1')
     def test_nested_user_types(self):
         """Tests user types within user types"""
         cluster = self.cluster
@@ -318,7 +315,6 @@ class TestUserTypes(Tester):
             items = rows[0][0]
             self.assertEqual(listify(items), [[[u'stuff3', [u'one_2_other', u'two_2_other']], [u'stuff4', [u'one_3_other', u'two_3_other']]]])
 
-    @since('2.1')
     def test_type_as_part_of_pkey(self):
         """Tests user types as part of a composite pkey"""
         # make sure we can define a table with a user type as part of the pkey
@@ -377,7 +373,6 @@ class TestUserTypes(Tester):
         self.assertEqual(first_name, u'Nero')
         self.assertEqual(like, u'arson')
 
-    @since('2.1')
     def test_type_secondary_indexing(self):
         """
         Confirm that user types are secondary-indexable
@@ -503,7 +498,6 @@ class TestUserTypes(Tester):
         self.assertEqual(first_name, u'Abraham')
         self.assertEqual(like, u'preserving unions')
 
-    @since('2.1')
     def test_type_keyspace_permission_isolation(self):
         """
         Confirm permissions are respected for types in different keyspaces
@@ -570,7 +564,6 @@ class TestUserTypes(Tester):
         rows = superuser_cursor.execute("SELECT * from system.schema_usertypes")
         self.assertEqual(0, len(rows))
 
-    @since('2.1')
     def test_nulls_in_user_types(self):
         """Tests user types with null values"""
         cluster = self.cluster
@@ -615,7 +608,6 @@ class TestUserTypes(Tester):
         rows = cursor.execute("SELECT my_item FROM bucket WHERE id=1")
         self.assertEqual(listify(rows[0]), [[u'test', None]])
 
-    @since('2.1')
     def test_no_counters_in_user_types(self):
         # CASSANDRA-7672
         cluster = self.cluster
@@ -636,7 +628,6 @@ class TestUserTypes(Tester):
 
         assert_invalid(cursor, stmt, 'A user type cannot contain counters')
 
-    @since('2.1')
     def test_type_as_clustering_col(self):
         """Tests user types as clustering column"""
         # make sure we can define a table with a user type as a clustering column


### PR DESCRIPTION
Addresses #152 -- this solves the same problem as #175, but the pull request is sent to the correct branch :fireworks:

The proposed solution in #175 worked by replacing every test function on the class with a wrapped version. This implementation works by replacing the class's `setUp` method, which is called before every test.

It'd be nice to just wrap the class itself, rather than one of its methods, but we can't find the C* version for a class until after `setUp` executes and the cluster gets initialized (so far as I can tell). I tried instantiating the class and getting the version inside `since`, but that messed up class creation somehow and removed the `runTest` method. It might be useful to add functionality to `Tester` that allows us to find the version without instantiating the test class.