### PR TITLE
Bootstrap size

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -4,6 +4,18 @@ from tools import new_node, insert_c1c2, query_c1c2
 from assertions import assert_almost_equal
 from ccmlib.cluster import Cluster
 from cassandra import ConsistencyLevel
+from decimal import Decimal
+
+
+def get_size(node):
+    """Uses nodetool info to get load on node"""
+    info = node.nodetool('info', capture_output=True)[0]
+    load_line = filter(lambda s: s.startswith('Load'),
+                       info.split('\n'))[0].split()
+    load_num, load_units = load_line[2], load_line[3]
+    # no unit conversions, so enforce consistent units
+    assert load_units == 'KB'
+    return Decimal(load_num)
 
 
 class TestBootstrap(Tester):
@@ -28,6 +40,7 @@ class TestBootstrap(Tester):
         cluster.populate(1, tokens=[tokens[0]]).start(wait_other_notice=True)
         node1 = cluster.nodes["node1"]
 
+        debug('connecting...')
         session = self.patient_cql_connection(node1)
         self.create_ks(session, 'ks', 1)
         self.create_cf(session, 'cf', columns={ 'c1' : 'text', 'c2' : 'text' })
@@ -36,7 +49,7 @@ class TestBootstrap(Tester):
             insert_c1c2(session, n, ConsistencyLevel.ONE)
 
         node1.flush()
-        initial_size = node1.data_size()
+        initial_size = get_size(node1)
 
         # Reads inserted data all during the boostrap process. We shouldn't
         # get any error
@@ -46,15 +59,21 @@ class TestBootstrap(Tester):
         node2 = new_node(cluster, token=tokens[1])
         node2.start(wait_for_binary_proto=True)
 
+        debug('reading...')
         reader.check()
         node1.cleanup()
         time.sleep(.5)
         reader.check()
 
-        size1 = node1.data_size()
-        size2 = node2.data_size()
+        size1, size2 = get_size(node1), get_size(node2)
+
+        debug('initial_size: {}'.format(initial_size))
+        debug('size1: {}'.format(size1))
+        debug('size2: {}'.format(size2))
+
         assert_almost_equal(size1, size2, error=0.3)
         assert_almost_equal(initial_size, 2 * size1)
+
 
     def read_from_bootstrapped_node_test(self):
         """Test bootstrapped node sees existing data, eg. CASSANDRA-6648"""


### PR DESCRIPTION
Part of addressing #182. Adds a function that uses `nodetool` to calculate the load on a node, and uses that function in `bootstrap_test:TestBootstrap.simple_bootstrap_test`. Caveats:

- As discussed in #182, `get_size` isn't robust enough to be used elsewhere - it's a one-off.
- The test fails -- the relationship between `node1`'s initial size and it's final size is off.
- `patient_cql_connection` throws an error, though it doesn't in other tests, as far as I've seen. See #182.
- Because of the failures mentioned above, I've gotten a little debug-statement happy. These should probably be removed, though maybe not until the problems are fixed.