### PR TITLE
Require class decorator

### DIFF
--- a/global_indexes_test.py
+++ b/global_indexes_test.py
@@ -8,6 +8,8 @@ from cassandra.query import BatchStatement, SimpleStatement
 from cassandra.protocol import ConfigurationException
 
 
+@since('3.0')
+@require('6477')
 class TestGlobalIndexes(Tester):
 
     def prepare(self):
@@ -24,18 +26,13 @@ class TestGlobalIndexes(Tester):
         cursor.execute("CREATE GLOBAL INDEX ON ks.users (state) DENORMALIZED (password, session_token);")
 
         return cursor
-    
-    @since('3.0')
-    @require('6477')
+
     def test_create_index(self):
         cursor = self.prepare()
-        
+
         result = cursor.execute("SELECT * FROM system.schema_globalindexes WHERE keyspace_name='ks' AND columnfamily_name='users'")
         assert len(result) == 1, "Expecting 1 global index, got" + str(result)
 
-
-    @since('3.0')
-    @require('6477')
     def test_index_insert(self):
         cursor = self.prepare()
 
@@ -45,12 +42,9 @@ class TestGlobalIndexes(Tester):
         cursor.execute("INSERT INTO users (KEY, password, gender, state, birth_year) VALUES ('user3', 'ch@ngem3c', 'f', 'FL', 1978);")
         cursor.execute("INSERT INTO users (KEY, password, gender, state, birth_year) VALUES ('user4', 'ch@ngem3d', 'm', 'TX', 1974);")
 
-
-    @since('3.0')
-    @require('6477')
     def test_index_query(self):
         cursor = self.prepare()
-        
+
         # insert data
         cursor.execute("INSERT INTO users (KEY, password, gender, state, birth_year) VALUES ('user1', 'ch@ngem3a', 'f', 'TX', 1968);")
         cursor.execute("INSERT INTO users (KEY, password, gender, state, birth_year) VALUES ('user2', 'ch@ngem3b', 'm', 'CA', 1971);")
@@ -66,12 +60,9 @@ class TestGlobalIndexes(Tester):
         result = cursor.execute("SELECT state, password, session_token FROM users WHERE state='MA';")
         assert len(result) == 0, "Expecting 0 users, got" + str(result)
 
-
-    @since('3.0')
-    @require('6477')
     def test_index_prepared_statement(self):
         cursor = self.prepare()
-        
+
         insertPrepared = cursor.prepare("INSERT INTO users (KEY, password, gender, state, birth_year) VALUES (?, ?, ?, ?, ?);")
         selectPrepared = cursor.prepare("SELECT state, password, session_token FROM users WHERE state=?;")
 
@@ -90,8 +81,6 @@ class TestGlobalIndexes(Tester):
         result = cursor.execute(selectPrepared.bind(['MA']))
         assert len(result) == 0, "Expecting 0 users, got" + str(result)
 
-    @since('3.0')
-    @require('6477')
     def test_drop_index(self):
         cursor = self.prepare()
 
@@ -103,16 +92,12 @@ class TestGlobalIndexes(Tester):
         result = cursor.execute("SELECT * FROM system.schema_globalindexes WHERE keyspace_name='ks' AND columnfamily_name='users'")
         assert len(result) == 0, "Expecting 0 global indexes, got" + str(result)
 
-    @since('3.0')
-    @require('6477')
     def test_drop_indexed_column(self):
         cursor = self.prepare()
 
         assert_invalid(cursor, "ALTER TABLE ks.users DROP state")
         assert_invalid(cursor, "ALTER TABLE ks.users ALTER state TYPE blob")
 
-    @since('3.0')
-    @require('6477')
     def test_double_indexing_column(self):
         cursor = self.prepare()
 
@@ -122,8 +107,6 @@ class TestGlobalIndexes(Tester):
         cursor.execute("CREATE INDEX ON ks.users (gender)")
         assert_invalid(cursor, "CREATE GLOBAL INDEX ON ks.users (gender) DENORMALIZED (birth_year)")
 
-    @since('3.0')
-    @require('6477')
     def test_drop_indexed_table(self):
         cursor = self.prepare()
 

--- a/tools.py
+++ b/tools.py
@@ -214,14 +214,9 @@ class no_vnodes(object):
         wrapped.__doc__ = f.__doc__
         return wrapped
 
-class require(object):
-    def __init__(self, msg):
-        self.msg = msg
 
-    def __call__(self, f):
-        def wrapped(obj):
-            obj.skip("require " + self.msg)
-            f(obj)
-        wrapped.__name__ = f.__name__
-        wrapped.__doc__ = f.__doc__
-        return wrapped
+def require(msg):
+    """Skips the decorated class or method with a message about which Jira
+    ticket it requires."""
+    # equivalent to decorating with @unittest.skip
+    return unittest.skip('require ' + msg)


### PR DESCRIPTION
- Simplifies the `@require` decorator and makes it work on classes.
- Moves `@since` and `@require` decorations from methods to class level on `TestGlobalIndexes`.