### PR TITLE
removes unused not_implemented decorator

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -150,13 +150,6 @@ def replace_in_file(filepath, search_replacements):
             line = re.sub(regex, replacement, line)
         sys.stdout.write(line)
 
-def not_implemented(f):
-    def wrapped(obj):
-        obj.skip("this test not implemented")
-        f(obj)
-    wrapped.__name__ = f.__name__
-    wrapped.__doc__ = f.__doc__
-    return wrapped
 
 class since(object):
     def __init__(self, cass_version, max_version=None):


### PR DESCRIPTION
This decorator wasn't used anywhere. I think an unimplemented test is the usual use case for `unittest.skip`, so I don't see any point to keeping this decorator around. 

Objections?