### PR TITLE
No vnodes class decorator

### DIFF
--- a/replication_test.py
+++ b/replication_test.py
@@ -38,6 +38,7 @@ murmur3_hashes = {
 }
 
 
+@no_vnodes()
 class ReplicationTest(Tester):
     """This test suite looks at how data is replicated across a cluster
     and who the coordinator, replicas and forwarders involved are.
@@ -156,7 +157,6 @@ class ReplicationTest(Tester):
                 print("%s\t%s\t%s\t%s" % (t.source, t.source_elapsed, t.description, t.thread_name))
             print("-" * 40)
 
-    @no_vnodes()
     def simple_test(self):
         """Test the SimpleStrategy on a 3 node cluster"""
         self.cluster.populate(3).start()
@@ -194,7 +194,6 @@ class ReplicationTest(Tester):
             #acknowledged the write:
             self.assertEqual(stats['nodes_sent_write'], stats['nodes_responded_write'])
 
-    @no_vnodes()
     def network_topology_test(self):
         """Test the NetworkTopologyStrategy on a 2DC 3:3 node cluster"""
         self.cluster.populate([3,3]).start()

--- a/tools.py
+++ b/tools.py
@@ -6,7 +6,7 @@ import re, os, sys, fileinput, time, unittest, functools
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
-from dtest import Tester
+from dtest import Tester, DISABLE_VNODES
 
 def rows_to_list(rows):
     new_list = [list(row) for row in rows]
@@ -202,17 +202,9 @@ class since(object):
         return self._wrap_function(skippable)
 
 
-from dtest import DISABLE_VNODES
-# Use this decorator to skip a test when vnodes are enabled.
-class no_vnodes(object):
-    def __call__(self, f):
-        def wrapped(obj):
-            if not DISABLE_VNODES:
-                obj.skip("Test disabled for vnodes")
-            f(obj)
-        wrapped.__name__ = f.__name__
-        wrapped.__doc__ = f.__doc__
-        return wrapped
+def no_vnodes():
+    """Skips the decorated test or test class if using vnodes."""
+    return unittest.skipIf(not DISABLE_VNODES, 'Test disabled for vnodes')
 
 class require(object):
     def __init__(self, msg):

--- a/topology_test.py
+++ b/topology_test.py
@@ -6,9 +6,9 @@ import os, sys, time
 from ccmlib.cluster import Cluster
 from cassandra import ConsistencyLevel
 
+@no_vnodes()
 class TestTopology(Tester):
 
-    @no_vnodes()
     def movement_test(self):
         cluster = self.cluster
 
@@ -48,7 +48,6 @@ class TestTopology(Tester):
         assert_almost_equal(sizes[0], sizes[2])
         assert_almost_equal(sizes[1], sizes[2])
 
-    @no_vnodes()
     def decomission_test(self):
         cluster = self.cluster
 
@@ -115,7 +114,6 @@ class TestTopology(Tester):
             for i in xrange(0, len(sizes)):
                 assert_almost_equal(sizes[i], three_node_sizes[i])
 
-    @no_vnodes()
     def move_single_node_test(self):
         """ Test moving a node in a single-node cluster (#4200) """
         cluster = self.cluster


### PR DESCRIPTION
- Makes the `no_vnodes` decorator work on classes and simplifies its implementation.
- Moves `no_vnodes` off of methods and onto classes where possible.