### PR TITLE
increments minimum # of notifications to wait for

### DIFF
--- a/pushed_notifications_test.py
+++ b/pushed_notifications_test.py
@@ -10,7 +10,7 @@ class NotificationWaiter(object):
     Cassandra over the native protocol.
     """
 
-    def __init__(self, tester, node, notification_type, num_notifications=1):
+    def __init__(self, tester, node, notification_type):
         """
         `address` should be a ccmlib.node.Node instance
         `notification_type` should either be "TOPOLOGY_CHANGE", "STATUS_CHANGE",
@@ -28,7 +28,6 @@ class NotificationWaiter(object):
 
         # the pushed notification
         self.notifications = []
-        self.num_notifications = num_notifications
 
         # register a callback for the notification type
         connection.register_watcher(
@@ -40,31 +39,31 @@ class NotificationWaiter(object):
         """
 
         debug("Source %s sent %s for %s" % (self.address, notification["change_type"], notification["address"][0],))
-        
+
         self.notifications.append(notification)
         self.event.set()
 
-    def wait_for_notifications(self, timeout):
+    def wait_for_notifications(self, timeout, num_notifications=None):
         """
-        Waits up to `timeout` seconds for a notifications from Cassandra.
+        Waits up to `timeout` seconds for a notifications from Cassandra. If
+        passed `num_notifications`, stop waiting when that many notifications
+        are observed.
         """
 
         deadline = time.time() + timeout
         while time.time() < deadline:
             self.event.wait(deadline - time.time())
             self.event.clear()
-            if len(self.notifications) >= self.num_notifications:
+            done = (num_notifications is not None
+                    and len(self.notifications) >= num_notifications)
+            if done:
                 break
 
-        if len(self.notifications) < self.num_notifications:
-            raise Exception("Timed out waiting for %s notifications from %s"
-                            % (self.notification_type, self.address))
-        else:
-            return self.notifications
+        return self.notifications
 
     def clear_notifications(self):
         self.notifications = []
-        self.event.clear()        
+        self.event.clear()
 
 
 class TestPushedNotifications(Tester):
@@ -98,12 +97,12 @@ class TestPushedNotifications(Tester):
     def restart_node_test(self):
         """
         Restarting a node should generate exactly one DOWN and one UP notification
-        """        
+        """
 
         self.cluster.populate(2).start()
         node1, node2 = self.cluster.nodelist()
 
-        waiter = NotificationWaiter(self, node1, "STATUS_CHANGE", num_notifications=2)
+        waiter = NotificationWaiter(self, node1, "STATUS_CHANGE")
 
         for i in range(5):
             debug("Restarting second node...")
@@ -117,6 +116,3 @@ class TestPushedNotifications(Tester):
             self.assertEquals(self.get_ip_from_node(node2), notifications[1]["address"][0])
             self.assertEquals("UP", notifications[1]["change_type"])
             waiter.clear_notifications()
-
-
-


### PR DESCRIPTION
This PR fixes a problem with `pushed_notifications_test`. I know @aboudreault know's what's going on with these tests, so he may be the best reviewer.

I'm not sure this is the best solution. It might be better to have a `NotificationWaiter` initialized with `num_notifications=x` to wait for `x+1` notifications. The existing API is a little dangerous -- I think it encourages bugs like the one this PR fixes.

See the commit message, reproduced below:

****

This is a subtle bug in the test logic. In the initial implementation of the first test, we're waiting for 1 notification, so we used the default `num_notifications` value of 1. Because of the way NotificationWaiter works, though, that means it will stop waiting once it observes a single notification. That means that as long as the first notification meets the expectations of the test, the test will pass, no matter how  many more notifications would have been observed. The assertion "the NotificationWaiter must have only observed one notification" really means "the node received 1 *or more* notifications", since the NotificationWaiter stops waiting after the first.

Similarly, the second test's initial implementation will succeed when the first two notifications are 'DOWN' and 'UP', regardless of what notifications follow.

To avoid this, this commit increments the number of notifications to wait for in each of these tests.

It also removes the check in NotificationWaiter that makes sure it observed exactly num_notifications notifications -- that belongs in the test logic, not the observer.