### PR TITLE
removes commented-out tests

### DIFF
--- a/cql_tests.py
+++ b/cql_tests.py
@@ -1035,63 +1035,6 @@ class TestCQL(Tester):
         # Reserved keywords
         assert_invalid(cursor, "CREATE TABLE test1 (select int PRIMARY KEY, column int)", expected=SyntaxException)
 
-    #def keyspace_test(self):
-    #    cursor = self.prepare()
-
-    #    assert_invalid(cursor, "CREATE KEYSPACE test1")
-    #    cursor.execute("CREATE KEYSPACE test2 WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
-    #    assert_invalid(cursor, "CREATE KEYSPACE My_much_much_too_long_identifier_that_should_not_work WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
-
-    #    cursor.execute("DROP KEYSPACE test2")
-    #    assert_invalid(cursor, "DROP KEYSPACE non_existing")
-    #    cursor.execute("CREATE KEYSPACE test2 WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
-
-    #def table_test(self):
-    #    cursor = self.prepare()
-
-    #    cursor.execute("""
-    #        CREATE TABLE test1 (
-    #            k int PRIMARY KEY,
-    #            c int
-    #        )
-    #    """)
-
-    #    cursor.execute("""
-    #        CREATE TABLE test2 (
-    #            k int,
-    #            name int,
-    #            value int,
-    #            PRIMARY KEY(k, name)
-    #        ) WITH COMPACT STORAGE
-    #    """)
-
-    #    cursor.execute("""
-    #        CREATE TABLE test3 (
-    #            k int,
-    #            c int,
-    #            PRIMARY KEY (k),
-    #        )
-    #    """)
-
-    #    # existing table
-    #    assert_invalid(cursor, "CREATE TABLE test3 (k int PRIMARY KEY, c int)")
-    #    # repeated column
-    #    assert_invalid(cursor, "CREATE TABLE test4 (k int PRIMARY KEY, c int, k text)")
-
-    #    # compact storage limitations
-    #    assert_invalid(cursor, "CREATE TABLE test4 (k int, name, int, c1 int, c2 int, PRIMARY KEY(k, name)) WITH COMPACT STORAGE")
-
-    #    cursor.execute("DROP TABLE test1")
-    #    cursor.execute("TRUNCATE test2")
-
-    #    cursor.execute("""
-    #        CREATE TABLE test1 (
-    #            k int PRIMARY KEY,
-    #            c1 int,
-    #            c2 int,
-    #        )
-    #    """)
-
     def batch_test(self):
         cursor = self.prepare()
 
@@ -3689,18 +3632,6 @@ class TestCQL(Tester):
 
         # we're not allowed to create a value index if we already have a key one
         assert_invalid(cursor, "CREATE INDEX ON test(m)")
-
-    #def nan_infinity_test(self):
-    #    cursor = self.prepare()
-
-    #    cursor.execute("CREATE TABLE test (f float PRIMARY KEY)")
-
-    #    cursor.execute("INSERT INTO test(f) VALUES (NaN)")
-    #    cursor.execute("INSERT INTO test(f) VALUES (-NaN)")
-    #    cursor.execute("INSERT INTO test(f) VALUES (Infinity)")
-    #    cursor.execute("INSERT INTO test(f) VALUES (-Infinity)")
-
-    #    assert_all(cursor, "SELECT * FROM test", [[nan], [inf], [-inf]])
 
     @since('2.0')
     def static_columns_test(self):


### PR DESCRIPTION
These tests have been commented out for over a year. They should either be updated or removed; the latter is ready to go with this PR.

If you want to play along at home, check out this branch:

https://github.com/mambocab/cassandra-dtest/tree/uncomment-cqlsh-tests

and run the tests with:

    nosetests -v cql_tests.py:TestCQL.keyspace_test cql_tests.py:TestCQL.table_test cql_tests.py:TestCQL.nan_infinity_test

Results from running on trunk here:

https://gist.github.com/mambocab/9f229774b82bbe3d6be3