### PR TITLE
Revert "Merge pull request #184 from mambocab/bootstrap-size"

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -4,18 +4,6 @@ from tools import new_node, insert_c1c2, query_c1c2
 from assertions import assert_almost_equal
 from ccmlib.cluster import Cluster
 from cassandra import ConsistencyLevel
-from decimal import Decimal
-
-
-def get_size(node):
-    """Uses nodetool info to get load on node"""
-    info = node.nodetool('info', capture_output=True)[0]
-    load_line = filter(lambda s: s.startswith('Load'),
-                       info.split('\n'))[0].split()
-    load_num, load_units = load_line[2], load_line[3]
-    # no unit conversions, so enforce consistent units
-    assert load_units == 'KB'
-    return Decimal(load_num)
 
 
 class TestBootstrap(Tester):
@@ -40,7 +28,6 @@ class TestBootstrap(Tester):
         cluster.populate(1, tokens=[tokens[0]]).start(wait_other_notice=True)
         node1 = cluster.nodes["node1"]
 
-        debug('connecting...')
         session = self.patient_cql_connection(node1)
         self.create_ks(session, 'ks', 1)
         self.create_cf(session, 'cf', columns={ 'c1' : 'text', 'c2' : 'text' })
@@ -49,7 +36,7 @@ class TestBootstrap(Tester):
             insert_c1c2(session, n, ConsistencyLevel.ONE)
 
         node1.flush()
-        initial_size = get_size(node1)
+        initial_size = node1.data_size()
 
         # Reads inserted data all during the boostrap process. We shouldn't
         # get any error
@@ -59,21 +46,15 @@ class TestBootstrap(Tester):
         node2 = new_node(cluster, token=tokens[1])
         node2.start(wait_for_binary_proto=True)
 
-        debug('reading...')
         reader.check()
         node1.cleanup()
         time.sleep(.5)
         reader.check()
 
-        size1, size2 = get_size(node1), get_size(node2)
-
-        debug('initial_size: {}'.format(initial_size))
-        debug('size1: {}'.format(size1))
-        debug('size2: {}'.format(size2))
-
+        size1 = node1.data_size()
+        size2 = node2.data_size()
         assert_almost_equal(size1, size2, error=0.3)
         assert_almost_equal(initial_size, 2 * size1)
-
 
     def read_from_bootstrapped_node_test(self):
         """Test bootstrapped node sees existing data, eg. CASSANDRA-6648"""


### PR DESCRIPTION
Blocked on https://github.com/pcmanus/ccm/pull/245, which puts the behavior of `get_size` in `Node.data_size`.

I can add back the debug statements if anyone was particularly attached.

*****

This reverts commit 65dfa9607299006533f9dd6b9bb7aebd0b7348d5, reversing
changes made to 2cbf96f5d6ee2a95e7f7986e315567f6e3a2c4c8.

The changes introduced in the merged branch have been integrated into
ccmlib itself, making it unnecessary to do this calculation in the tests
themselves.