### PR TITLE
Slowdown multiple subsequent repairs test to not use 200 threads

### DIFF
--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -216,7 +216,7 @@ class TestIncRepair(Tester):
         [node1,node2,node3] = cluster.nodelist()
 
         expected_load_size = 4.5  # In GB
-        node1.stress(['write', 'n=5000000', '-schema', 'replication(factor=3)'])
+        node1.stress(['write', 'n=5000000', '-rate', 'threads=50', '-schema', 'replication(factor=3)'])
 
         node1.flush()
         node2.flush()


### PR DESCRIPTION
Slowdown multiple subsequent repairs test to not use 200 threads

@mshuler feel free to merge if this is enough to fix your yesterday's issue.