### PR TITLE
convert @require's argument to a string

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -206,7 +206,7 @@ def require(msg):
     """Skips the decorated class or method with a message about which Jira
     ticket it requires."""
     # equivalent to decorating with @unittest.skip
-    return unittest.skip('require ' + msg)
+    return unittest.skip('require ' + str(msg))
 
 class InterruptBootstrap(Thread):
     def __init__(self, node):


### PR DESCRIPTION
This allows uses like

    @require(42)
    def func():
        pass

rather than unnecessarily requiring

    @require('42')
    def func():
        pass

Strings will still work; this change just supports the [common use case](https://github.com/riptano/cassandra-dtest/search?utf8=%E2%9C%93&q=%22%40require%22) where the only information passed in represents the integer ID of a Jira ticket.