### PR TITLE
test that memtable size calculation includes tombstones

### DIFF
--- a/deletion_test.py
+++ b/deletion_test.py
@@ -2,6 +2,9 @@ from dtest import Tester
 
 import os, sys, time
 from ccmlib.cluster import Cluster
+from tools import require, since
+from jmxutils import make_mbean, JolokiaAgent
+
 
 class TestDeletion(Tester):
 
@@ -37,3 +40,36 @@ class TestDeletion(Tester):
         result = cursor.execute('select * from cf;')
         assert len(result) == 1 and len(result[0]) == 2, result
 
+    @require(9194)
+    def tombstone_size_test(self):
+        self.cluster.populate(1).start(wait_for_binary_proto=True)
+        [node1] = self.cluster.nodelist()
+        cursor = self.patient_cql_connection(node1)
+        self.create_ks(cursor, 'ks', 1)
+        cursor.execute('CREATE TABLE test (i int PRIMARY KEY)')
+
+        stmt = cursor.prepare('DELETE FROM test where i = ?')
+        for i in range(100):
+            cursor.execute(stmt, [i])
+
+        self.assertEqual(memtable_count(node1, 'ks', 'test'), 100)
+        self.assertGreater(memtable_size(node1, 'ks', 'test'), 0)
+
+
+def memtable_size(node, keyspace, table):
+    new_name = node.get_cassandra_version() >= '2.1'
+    name = 'MemtableLiveDataSize' if new_name else 'MemtableDataSize'
+    return columnfamily_metric(node, keyspace, table, name)
+
+
+def memtable_count(node, keyspace, table):
+    return columnfamily_metric(node, keyspace, table, 'MemtableColumnsCount')
+
+
+def columnfamily_metric(node, keyspace, table, name):
+    with JolokiaAgent(node) as jmx:
+        mbean = make_mbean('metrics', type='ColumnFamily',
+                           name=name, keyspace=keyspace, scope=table)
+        value = jmx.read_attribute(mbean, 'Value')
+
+    return value

--- a/jmxutils.py
+++ b/jmxutils.py
@@ -6,8 +6,28 @@ import subprocess
 JOLOKIA_JAR = os.path.join('lib', 'jolokia-jvm-1.2.3-agent.jar')
 
 
-def make_mbean(package, mbean):
-    return 'org.apache.cassandra.%s:type=%s' % (package, mbean)
+def make_mbean(package, type, **kwargs):
+    '''
+    Builds the name for an mbean.
+
+    `package` is appended to the org.apache.cassandra domain.
+
+    `type` is used as the 'type' property.
+
+    All other keyword arguments are used as properties in the mbean's name.
+
+    Example usage:
+
+    >>> make_mbean('db', 'IndexSummaries')
+    'org.apache.cassandra.db:type=IndexSummaries'
+    >>> make_mbean('metrics', type='ColumnFamily', name='MemtableColumnsCount', keyspace='ks', scope='table')
+    'org.apache.cassandra.metrics:type=ColumnFamily,keyspace=ks,name=MemtableColumnsCount,scope=table'
+    '''
+    rv = 'org.apache.cassandra.%s:type=%s' % (package, type)
+    if kwargs:
+        rv += ',' + ','.join('{k}={v}'.format(k=k, v=v)
+                             for k, v in kwargs.iteritems())
+    return rv
 
 
 class JolokiaAgent(object):


### PR DESCRIPTION
Defect reported in [#9194](https://issues.apache.org/jira/browse/CASSANDRA-9194).

[Fails](https://gist.github.com/mambocab/87681ed3770e19345a21) on all 2.0 and 2.1 releases going back to 2.0.2. `nodetool cfstats` earlier than that doesn't support the way I get the memtable data size, so I don't know if it worked then.