### PR TITLE
Test for CASSANDRA-9220

### DIFF
--- a/sslkeytool.py
+++ b/sslkeytool.py
@@ -1,0 +1,90 @@
+import os
+import os.path
+import tempfile
+import subprocess
+
+
+def generate_credentials(ip, cakeystore=None, cacert=None):
+
+    tmpdir = tempfile.mkdtemp()
+
+    if not cakeystore:
+        cakeystore = generate_cakeypair(tmpdir, 'ca')
+    if not cacert:
+        cacert = generate_cert(tmpdir, "ca", cakeystore)
+
+    # create keystore with new private key
+    name = "ip" + ip
+    jkeystore = generate_ipkeypair(tmpdir, name, ip)
+
+    # create signed cert
+    csr = generate_sign_request(tmpdir, name, jkeystore, ['-ext', 'san=ip:' + ip])
+    cert = sign_request(tmpdir, "ca", cakeystore, csr, ['-ext', 'san=ip:' + ip])
+
+    # import cert chain into keystore
+    import_cert(tmpdir, "ca", cacert, jkeystore)
+    import_cert(tmpdir, name, cert, jkeystore)
+
+    return SecurityCredentials(jkeystore, cert, cakeystore, cacert)
+
+
+def generate_cakeypair(dir, name):
+    return generate_keypair(dir, name, name, ['-ext', 'bc:c'])
+
+
+def generate_ipkeypair(dir, name, ip):
+    return generate_keypair(dir, name, ip, ['-ext', 'san=ip:' + ip])
+
+
+def generate_dnskeypair(dir, name, hostname):
+    return generate_keypair(dir, name, hostname, ['-ext', 'san=dns:' + hostname])
+
+
+def generate_keypair(dir, name, cn, opts):
+    kspath = os.path.join(dir, name + '.keystore')
+    return _exec_keytool(dir, kspath, ['-alias', name, '-genkeypair', '-keyalg', 'RSA', '-dname',
+                                       "cn={}, ou=cassandra, o=apache.org, c=US".format(cn), '-keypass', 'cassandra'] + opts)
+
+
+def generate_cert(dir, name, keystore, opts=[]):
+    fn = os.path.join(dir, name + '.pem')
+    _exec_keytool(dir, keystore, ['-alias', name, '-exportcert', '-rfc', '-file', fn] + opts)
+    return fn
+
+
+def generate_sign_request(dir, name, keystore, opts=[]):
+    fn = os.path.join(dir, name + '.csr')
+    _exec_keytool(dir, keystore, ['-alias', name, '-keypass', 'cassandra', '-certreq', '-file', fn] + opts)
+    return fn
+
+
+def sign_request(dir, name, keystore, csr, opts=[]):
+    fnout = os.path.splitext(csr)[0] + '.pem'
+    _exec_keytool(dir, keystore, ['-alias', name, '-keypass', 'cassandra', '-gencert',
+                                  '-rfc', '-infile', csr, '-outfile', fnout] + opts)
+    return fnout
+
+
+def import_cert(dir, name, cert, keystore, opts=[]):
+    _exec_keytool(dir, keystore, ['-alias', name, '-keypass', 'cassandra', '-importcert', '-noprompt', '-file', cert] + opts)
+    return cert
+
+
+def _exec_keytool(dir, keystore, opts):
+    args = ['keytool', '-keystore', keystore, '-storepass', 'cassandra'] + opts
+    subprocess.check_call(args)
+    return keystore
+
+
+class SecurityCredentials():
+
+    def __init__(self, keystore, cert, cakeystore, cacert):
+        self.keystore = keystore
+        self.cert = cert
+        self.cakeystore = cakeystore
+        self.cacert = cacert
+        self.basedir = os.path.dirname(self.keystore)
+
+    def __str__(self):
+        return "keystore: {}, cert: {}, cakeystore: {}, cacert: {}".format(
+               self.keystore, self.cert, self.cakeystore, self.cacert)

--- a/sslnodetonode_test.py
+++ b/sslnodetonode_test.py
@@ -1,0 +1,117 @@
+from dtest import Tester
+import os
+import os.path
+import time
+import shutil
+import sslkeytool
+
+
+_LOG_ERR_SIG = "^javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: Certificate signature validation failed$"
+_LOG_ERR_IP = "^javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: No subject alternative names matching IP address [0-9.]+ found$"
+_LOG_ERR_HOST = "^javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: No name matching \S+ found$"
+
+
+class TestNodeToNodeSSLEncryption(Tester):
+
+    def ssl_enabled_test(self):
+        """Should be able to start with valid ssl options"""
+
+        credNode1 = sslkeytool.generate_credentials("127.0.0.1")
+        credNode2 = sslkeytool.generate_credentials("127.0.0.2", credNode1.cakeystore, credNode1.cacert)
+
+        self.setup_nodes(credNode1, credNode2)
+        self.cluster.start()
+        self.cql_connection(self.node1)
+
+    def ssl_wrong_hostname_no_validation_test(self):
+        """Should be able to start with valid ssl options"""
+
+        credNode1 = sslkeytool.generate_credentials("127.0.0.80")
+        credNode2 = sslkeytool.generate_credentials("127.0.0.81", credNode1.cakeystore, credNode1.cacert)
+
+        self.setup_nodes(credNode1, credNode2, endpointVerification=False)
+        self.cluster.start()
+        time.sleep(2)
+        self.cql_connection(self.node1)
+
+    def ssl_wrong_hostname_with_validation_test(self):
+        """Should be able to start with valid ssl options"""
+
+        credNode1 = sslkeytool.generate_credentials("127.0.0.80")
+        credNode2 = sslkeytool.generate_credentials("127.0.0.81", credNode1.cakeystore, credNode1.cacert)
+
+        self.setup_nodes(credNode1, credNode2, endpointVerification=True)
+
+        self.allow_log_errors = True
+        self.cluster.start(no_wait=True)
+
+        found = self._grep_msg(self.node1, _LOG_ERR_IP, _LOG_ERR_HOST)
+        self.assertTrue(found)
+
+        found = self._grep_msg(self.node2, _LOG_ERR_IP, _LOG_ERR_HOST)
+        self.assertTrue(found)
+
+        self.cluster.stop()
+        self.assertTrue(found)
+
+    def ca_mismatch_test(self):
+        """CA mismatch should cause nodes to fail to connect"""
+
+        credNode1 = sslkeytool.generate_credentials("127.0.0.1")
+        credNode2 = sslkeytool.generate_credentials("127.0.0.2")  # mismatching CA!
+
+        self.setup_nodes(credNode1, credNode2)
+
+        self.allow_log_errors = True
+        self.cluster.start(no_wait=True)
+
+        found = self._grep_msg(self.node1, _LOG_ERR_SIG)
+        self.cluster.stop()
+        self.assertTrue(found)
+
+    def _grep_msg(self, node, *kwargs):
+        tries = 30
+        while tries > 0:
+            try:
+                print("Checking logs for error")
+                for err in kwargs:
+                    m = node.grep_log(err)
+                    if m:
+                        print("Found log message: {}".format(m[0]))
+                        return True
+            except IOError:
+                pass  # log does not exists yet
+            time.sleep(1)
+            tries -= 1
+
+        return False
+
+    def setup_nodes(self, credentials1, credentials2, endpointVerification=False):
+
+        cluster = self.cluster
+
+        def copy_cred(credentials, node):
+            dir = node.get_conf_dir()
+            print("Copying credentials to node %s" % dir)
+            kspath = os.path.join(dir, 'keystore.jks')
+            tspath = os.path.join(dir, 'truststore.jks')
+            shutil.copyfile(credentials.keystore, kspath)
+            shutil.copyfile(credentials.cakeystore, tspath)
+
+            node.set_configuration_options(values={
+                'server_encryption_options': {
+                    'internode_encryption': 'all',
+                    'keystore': kspath,
+                    'keystore_password': 'cassandra',
+                    'truststore': tspath,
+                    'truststore_password': 'cassandra',
+                    'require_endpoint_verification': endpointVerification
+                }
+            })
+
+        cluster = cluster.populate(2)
+        self.node1 = cluster.nodelist()[0]
+        copy_cred(credentials1, self.node1)
+
+        self.node2 = cluster.nodelist()[1]
+        copy_cred(credentials2, self.node2)


### PR DESCRIPTION
This set of tests can be run to test if server ssl options will have the expected effect on node-to-node communication. It provides a module for interacting with the keytool and will start the cluster with various ssl settings. 
Depends on [CASSANDRA-9220](https://issues.apache.org/jira/browse/CASSANDRA-9220) for hostname verification and log output with detailed handshake errors.
The test needs to have keytool and openssl in the current path.
