### PR TITLE
changes mbean used for querying memtable heap size

### DIFF
--- a/deletion_test.py
+++ b/deletion_test.py
@@ -57,8 +57,8 @@ class TestDeletion(Tester):
 
 
 def memtable_size(node, keyspace, table):
-    new_name = node.get_cassandra_version() >= '2.1'
-    name = 'MemtableLiveDataSize' if new_name else 'MemtableDataSize'
+    version = node.get_cassandra_version()
+    name = 'MemtableOnHeapSize' if version >= '2.1' else 'MemtableDataSize'
     return columnfamily_metric(node, keyspace, table, name)
 
 


### PR DESCRIPTION
Don't merge just yet -- I think this is the correct change, but I'm waiting for confirmation from Benedict [here](https://issues.apache.org/jira/browse/CASSANDRA-9194?focusedCommentId=14505980&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14505980) that this is the right metric to use.