### PR TITLE
Tester.teardown: accounts for lists of error lines

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -427,7 +427,8 @@ class Tester(TestCase):
         try:
             for node in self.cluster.nodelist():
                 if self.allow_log_errors == False:
-                    errors = list(self.__filter_errors([ msg for msg in node.grep_log_for_errors()]))
+                    errors = list(self.__filter_errors(
+                        [' '.join(msg) for msg in node.grep_log_for_errors()]))
                     if len(errors) is not 0:
                         failed = True
                         raise AssertionError('Unexpected error in %s node log: %s' % (node.name, errors))


### PR DESCRIPTION
Addresses #246. `ccmlib.Node.grep_log_for_errors` returns a list of lists of strings. This fix joins each of the lists into a single string to be compared in `__filter_errors`.

To demonstrate the problem and its fix, run

```UPGRADE_PATH=1_2:2_1 nosetests -x upgrade_through_versions_test.py:TestRandomPartitionerUpgrade```

That particular upgrade path will always throw an error, and since the tests in this `TestRandomPartitionerUpgrade` use the log filter, the errors will be used in the regex comparison that was throwing the `TypeError`. It should error out with a `TypeError` on HEAD fail correctly after applying this change.