### PR TITLE
Add cassandra-attack.jar from CASSANDRA-6285

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
 logs
 last_test_dir
-cassandra-attack.jar
 upgrade
 *.iml
 html/

--- a/lib/cassandra-attack.jar.txt
+++ b/lib/cassandra-attack.jar.txt
@@ -1,0 +1,2 @@
+This is the test reproduction jar from https://issues.apache.org/jira/browse/CASSANDRA-6285
+Source code is available as an attachment on that JIRA - https://issues.apache.org/jira/secure/attachment/12633659/cassandra-attack-src.zip

--- a/thrift_hsha_test.py
+++ b/thrift_hsha_test.py
@@ -2,7 +2,7 @@ from dtest import Tester, debug, DEFAULT_DIR
 import unittest, time, os, subprocess, shlex, pycassa, glob, sys
 
 JNA_PATH = '/usr/share/java/jna.jar'
-ATTACK_JAR = 'cassandra-attack.jar'
+ATTACK_JAR = 'lib/cassandra-attack.jar'
 
 # Use jna.jar in {CASSANDRA_DIR,DEFAULT_DIR}/lib/, since >=2.1 needs correct version
 try:


### PR DESCRIPTION
Some devs were a little stumped as to where this jar lived. In testing, we have been wget'ing the file from the test master server, prior to dtest runs. Let's just add the jar to dtest, so there is no mystery.