### PR TITLE
Require filter branch

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -28,6 +28,7 @@ config = ConfigParser.RawConfigParser()
 if len(config.read(os.path.expanduser('~/.cassandra-dtest'))) > 0:
     if config.has_option('main', 'default_dir'):
         DEFAULT_DIR=os.path.expanduser(config.get('main', 'default_dir'))
+CASSANDRA_DIR = os.environ.get('CASSANDRA_DIR', DEFAULT_DIR)
 
 NO_SKIP = os.environ.get('SKIP', '').lower() in ('no', 'false')
 DEBUG = os.environ.get('DEBUG', '').lower() in ('yes', 'true')
@@ -135,7 +136,7 @@ class Tester(TestCase):
             self.test_path = subprocess.Popen(["cygpath", "-m", self.test_path], stdout = subprocess.PIPE, stderr = subprocess.STDOUT).communicate()[0].rstrip()
         debug("cluster ccm directory: "+self.test_path)
         version = os.environ.get('CASSANDRA_VERSION')
-        cdir = os.environ.get('CASSANDRA_DIR', DEFAULT_DIR)
+        cdir = CASSANDRA_DIR
 
         if version:
             cluster = Cluster(self.test_path, name, cassandra_version=version)
@@ -176,7 +177,7 @@ class Tester(TestCase):
 
     def set_node_to_current_version(self, node):
         version = os.environ.get('CASSANDRA_VERSION')
-        cdir = os.environ.get('CASSANDRA_DIR', DEFAULT_DIR)
+        cdir = CASSANDRA_DIR
 
         if version:
             node.set_install_dir(version=version)
@@ -459,7 +460,7 @@ class Tester(TestCase):
         """Setup JaCoCo code coverage support"""
         # use explicit agent and execfile locations
         # or look for a cassandra build if they are not specified
-        cdir = os.environ.get('CASSANDRA_DIR', DEFAULT_DIR)
+        cdir = CASSANDRA_DIR
 
         agent_location = os.environ.get('JACOCO_AGENT_JAR', os.path.join(cdir, 'build/lib/jars/jacocoagent.jar'))
         jacoco_execfile = os.environ.get('JACOCO_EXECFILE', os.path.join(cdir, 'build/jacoco/jacoco.exec'))


### PR DESCRIPTION
This addresses #238. My request for review has 3 parts:

1. Verify that the name-matching behavior described in `@require`'s docstring is the desired behavior.
1. This makes a hopefully non-invasive change to `dtest` and `dtest.Tester`. Previously, the directory used was calculated at object-definition/method-call time by grabbing `CASSANDRA_DIR` from the environment. Now, it's calculated at load time. This allows `@require` to grab the directory of the currently-running C* install without actually starting a cluster. Please check that this change makes sense before +1'ing this patch.
1. Since this behavior depends on some external state, I'm concerned that it :tada: _works on my machine_ :tada:. I'd like a reviewer to run the [shell script with the tests linked at this gist](https://gist.github.com/mambocab/28805fef05fda0a11c86). Just follow the instructions in the comment at the bottom. 