### PR TITLE
Remove all instances of the ignored arg 'version'

### DIFF
--- a/auth_roles_test.py
+++ b/auth_roles_test.py
@@ -1136,7 +1136,7 @@ class TestAuthRoles(Tester):
     def assert_unauthenticated(self, message, user, password):
         with self.assertRaises(NoHostAvailable) as response:
             node = self.cluster.nodelist()[0]
-            self.cql_connection(node, version="3.1.7", user=user, password=password)
+            self.cql_connection(node, user=user, password=password)
         host, error = response.exception.errors.popitem()
         pattern = 'Failed to authenticate to %s: code=0100 \[Bad credentials\] message="%s"' % (host, message)
         assert type(error) == AuthenticationFailed, "Expected AuthenticationFailed, got %s" % type(error)
@@ -1161,7 +1161,7 @@ class TestAuthRoles(Tester):
 
     def get_session(self, node_idx=0, user=None, password=None):
         node = self.cluster.nodelist()[node_idx]
-        conn = self.patient_cql_connection(node, version="3.1.7", user=user, password=password)
+        conn = self.patient_cql_connection(node, user=user, password=password)
         return conn
 
     def assert_permissions_listed(self, expected, cursor, query):

--- a/auth_test.py
+++ b/auth_test.py
@@ -580,7 +580,7 @@ class TestAuth(Tester):
 
     def get_cursor(self, node_idx=0, user=None, password=None):
         node = self.cluster.nodelist()[node_idx]
-        conn = self.patient_cql_connection(node, version="3.0.1", user=user, password=password)
+        conn = self.patient_cql_connection(node, user=user, password=password)
         return conn
 
     def assertPermissionsListed(self, expected, cursor, query):

--- a/batch_test.py
+++ b/batch_test.py
@@ -6,8 +6,6 @@ from cassandra import ConsistencyLevel, Timeout
 from cassandra.query import SimpleStatement
 from cassandra.policies import RetryPolicy
 
-cql_version="3.0.0"
-
 class TestBatch(Tester):
 
     def counter_batch_accepts_counter_mutations_test(self):
@@ -203,7 +201,7 @@ class TestBatch(Tester):
             self.cluster.populate(nodes).start(wait_other_notice=True)
 
         node1 = self.cluster.nodelist()[0]
-        session = self.patient_cql_connection(node1, version=cql_version)
+        session = self.patient_cql_connection(node1)
         self.create_ks(session, 'ks', nodes)
         session.execute("""
             CREATE TABLE clicks (

--- a/counter_tests.py
+++ b/counter_tests.py
@@ -48,9 +48,7 @@ class TestCounters(Tester):
         cluster.populate(2).start()
         nodes = cluster.nodelist()
 
-        cql_version=None
-
-        cursor = self.patient_cql_connection(nodes[0], version=cql_version)
+        cursor = self.patient_cql_connection(nodes[0])
         self.create_ks(cursor, 'ks', 2)
 
         query = """
@@ -68,7 +66,7 @@ class TestCounters(Tester):
         updates = 50
 
         def make_updates():
-            cursor = self.patient_cql_connection(nodes[0], keyspace='ks', version=cql_version)
+            cursor = self.patient_cql_connection(nodes[0], keyspace='ks')
             upd = "UPDATE counterTable SET c = c + 1 WHERE k = %d;"
             batch = " ".join(["BEGIN COUNTER BATCH"] + [upd % x for x in keys] + ["APPLY BATCH;"])
 
@@ -78,7 +76,7 @@ class TestCounters(Tester):
                 cursor.execute(query)
 
         def check(i):
-            cursor = self.patient_cql_connection(nodes[0], keyspace='ks', version=cql_version)
+            cursor = self.patient_cql_connection(nodes[0], keyspace='ks')
             query = SimpleStatement("SELECT * FROM counterTable", consistency_level=ConsistencyLevel.QUORUM)
             rows = cursor.execute(query)
 

--- a/cql_prepared_test.py
+++ b/cql_prepared_test.py
@@ -5,8 +5,6 @@ import os, sys, time, tools
 from uuid import UUID
 from ccmlib.cluster import Cluster
 
-cql_version="3.0.0"
-
 @since("1.2")
 class TestCQL(Tester):
 
@@ -17,7 +15,7 @@ class TestCQL(Tester):
         node1 = cluster.nodelist()[0]
         time.sleep(0.2)
 
-        cursor = self.patient_cql_connection(node1, version=cql_version)
+        cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 1)
         return cursor
 

--- a/cql_tests.py
+++ b/cql_tests.py
@@ -20,9 +20,6 @@ from cassandra.protocol import ProtocolException, SyntaxException, Configuration
 from cassandra.query import SimpleStatement
 from cassandra.util import sortedset
 
-cql_version = "3.0.0"
-
-
 @canReuseCluster
 class TestCQL(Tester):
 
@@ -44,7 +41,7 @@ class TestCQL(Tester):
         node1 = cluster.nodelist()[0]
         time.sleep(0.2)
 
-        session = self.patient_cql_connection(node1, version=cql_version, protocol_version=protocol_version)
+        session = self.patient_cql_connection(node1, protocol_version=protocol_version)
         if create_keyspace:
             if self._preserve_cluster:
                 session.execute("DROP KEYSPACE IF EXISTS ks")
@@ -1346,7 +1343,7 @@ class TestCQL(Tester):
         node1 = cluster.nodelist()[0]
         time.sleep(0.2)
 
-        cursor = self.patient_cql_connection(node1, version=cql_version)
+        cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 1)
 
         cursor.execute("""
@@ -1868,7 +1865,7 @@ class TestCQL(Tester):
         node1 = cluster.nodelist()[0]
         time.sleep(0.2)
 
-        cursor = self.patient_cql_connection(node1, version=cql_version)
+        cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 1)
 
         cursor.execute("""

--- a/dtest.py
+++ b/dtest.py
@@ -253,13 +253,13 @@ class Tester(TestCase):
             if not is_win():
                 os.symlink(basedir, name)
 
-    def cql_connection(self, node, keyspace=None, version=None, user=None,
+    def cql_connection(self, node, keyspace=None, user=None,
                        password=None, compression=True, protocol_version=None):
 
         return self._create_session(node, keyspace, user, password, compression,
                                     protocol_version)
 
-    def exclusive_cql_connection(self, node, keyspace=None, version=None, user=None,
+    def exclusive_cql_connection(self, node, keyspace=None,
                                  password=None, compression=True, protocol_version=None):
 
         node_ip = self.get_ip_from_node(node)
@@ -298,7 +298,7 @@ class Tester(TestCase):
         self.connections.append(session)
         return session
 
-    def patient_cql_connection(self, node, keyspace=None, version=None,
+    def patient_cql_connection(self, node, keyspace=None,
         user=None, password=None, timeout=10, compression=True,
         protocol_version=None):
         """
@@ -313,7 +313,6 @@ class Tester(TestCase):
             self.cql_connection,
             node,
             keyspace=keyspace,
-            version=version,
             user=user,
             password=password,
             timeout=timeout,
@@ -322,7 +321,7 @@ class Tester(TestCase):
             bypassed_exception=NoHostAvailable
         )
 
-    def patient_exclusive_cql_connection(self, node, keyspace=None, version=None,
+    def patient_exclusive_cql_connection(self, node, keyspace=None,
         user=None, password=None, timeout=10, compression=True,
         protocol_version=None):
         """
@@ -337,7 +336,6 @@ class Tester(TestCase):
             self.exclusive_cql_connection,
             node,
             keyspace=keyspace,
-            version=version,
             user=user,
             password=password,
             timeout=timeout,

--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -26,7 +26,7 @@ class TestPaxos(Tester):
         node1 = cluster.nodelist()[0]
         time.sleep(0.2)
 
-        cursor = self.patient_cql_connection(node1, version="3.0.0")
+        cursor = self.patient_cql_connection(node1)
         if create_keyspace:
             self.create_ks(cursor, 'ks', rf)
         return cursor
@@ -145,7 +145,7 @@ class TestPaxos(Tester):
         nodes = self.cluster.nodelist()
         workers = []
 
-        c = self.patient_cql_connection(nodes[0], version="3.0.0", keyspace='ks')
+        c = self.patient_cql_connection(nodes[0], keyspace='ks')
         q = c.prepare("""
                 BEGIN BATCH
                    UPDATE test SET v = ? WHERE k = 0 IF v = ?;

--- a/schema_test.py
+++ b/schema_test.py
@@ -44,7 +44,7 @@ class TestSchema(Tester):
         time.sleep(.5)
 
         # test that c1 values have been compacted away.
-        cursor = self.patient_cql_connection(node, version='3.0.10')
+        cursor = self.patient_cql_connection(node)
         rows = cursor.execute("SELECT c1 FROM ks.cf")
         self.assertEqual([[None], [None], [None], [4]], sorted(rows_to_list(rows)))
 
@@ -91,6 +91,6 @@ class TestSchema(Tester):
         cluster.populate(1).start()
         time.sleep(.5)
         nodes = cluster.nodelist()
-        cursor = self.patient_cql_connection(nodes[0], version='3.0.10')
+        cursor = self.patient_cql_connection(nodes[0])
         self.create_ks(cursor, 'ks', 1)
         return cursor

--- a/secondary_indexes_test.py
+++ b/secondary_indexes_test.py
@@ -54,7 +54,7 @@ class TestSecondaryIndexes(Tester):
         cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
-        conn = self.patient_cql_connection(node1, version='3.0.0')
+        conn = self.patient_cql_connection(node1)
         cursor = conn
         cursor.max_trace_wait = 120
         cursor.execute("CREATE KEYSPACE ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': '1'};")

--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -290,7 +290,7 @@ class TestUpgradeThroughVersions(Tester):
                 vers[:curr_index] + ['***' + current_tag + '***'] + vers[curr_index + 1:]))
 
     def _create_schema(self):
-        cursor = self.patient_cql_connection(self.node2, version="3.0.0", protocol_version=1)
+        cursor = self.patient_cql_connection(self.node2, protocol_version=1)
 
         cursor.execute("""CREATE KEYSPACE upgrade WITH replication = {'class':'SimpleStrategy',
             'replication_factor':2};
@@ -329,7 +329,7 @@ class TestUpgradeThroughVersions(Tester):
 
     def _increment_counters(self, opcount=25000):
         debug("performing {opcount} counter increments".format(opcount=opcount))
-        cursor = self.patient_cql_connection(self.node2, version="3.0.0", protocol_version=1)
+        cursor = self.patient_cql_connection(self.node2, protocol_version=1)
         cursor.execute("use upgrade;")
 
         update_counter_query = ("UPDATE countertable SET c = c + 1 WHERE k1='{key1}' and k2={key2}")
@@ -357,7 +357,7 @@ class TestUpgradeThroughVersions(Tester):
 
     def _check_counters(self):
         debug("Checking counter values...")
-        cursor = self.patient_cql_connection(self.node2, version="3.0.0", protocol_version=1)
+        cursor = self.patient_cql_connection(self.node2, protocol_version=1)
         cursor.execute("use upgrade;")
 
         for key1 in self.expected_counts.keys():
@@ -375,10 +375,10 @@ class TestUpgradeThroughVersions(Tester):
                     actual_value = None
 
                 assert actual_value == expected_value, "Counter not at expected value. Got %s, expected %s" % (actual_value, expected_value)
-    
+
     def _check_select_count(self, consistency_level=ConsistencyLevel.ALL):
         debug("Checking SELECT COUNT(*)")
-        cursor = self.patient_cql_connection(self.node2, version="3.0.0", protocol_version=1)
+        cursor = self.patient_cql_connection(self.node2, protocol_version=1)
         cursor.execute("use upgrade;")
 
         expected_num_rows = len(self.row_values)
@@ -471,7 +471,7 @@ class PointToPointUpgradeBase(TestUpgradeThroughVersions):
         self.upgrade_scenario(populate=False, create_schema=False, after_upgrade_call=(self._bootstrap_new_node_multidc,))
 
     def _multidc_schema_create(self):
-        cursor = self.patient_cql_connection(self.cluster.nodelist()[0], version="3.0.0", protocol_version=1)
+        cursor = self.patient_cql_connection(self.cluster.nodelist()[0], protocol_version=1)
 
         if self.cluster.version() >= '1.2':
             # DDL for C* 1.2+


### PR DESCRIPTION
Was accepted to cql_connection and its family of
functions, but never used. Leftover from the old thrift
connection functions.

@mambocab or @aboudreault to review