### PR TITLE
skip test that fails because of jolokia problems

### DIFF
--- a/deletion_test.py
+++ b/deletion_test.py
@@ -1,6 +1,6 @@
 from dtest import Tester
 
-import os, sys, time
+import os, sys, time, unittest
 from ccmlib.cluster import Cluster
 from tools import require, since
 from jmxutils import make_mbean, JolokiaAgent
@@ -40,6 +40,7 @@ class TestDeletion(Tester):
         result = cursor.execute('select * from cf;')
         assert len(result) == 1 and len(result[0]) == 2, result
 
+    @unittest.skip('Jolokia connection fails')
     def tombstone_size_test(self):
         self.cluster.populate(1).start(wait_for_binary_proto=True)
         [node1] = self.cluster.nodelist()


### PR DESCRIPTION
This test is failing because of an error connecting via Jolokia, e.g. [here](http://cassci.datastax.com/view/trunk/job/trunk_dtest/163/testReport/deletion_test/TestDeletion/tombstone_size_test/). thobbs, author of our `jmxutils`, is on the scene, but for the moment, let's skip this test since we know it fails.