### PR TITLE
skip copy tests pre-2.1

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -26,6 +26,7 @@ DEFAULT_FLOAT_PRECISION = 5  # magic number copied from cqlsh script
 
 
 @canReuseCluster
+@since('2.1')  # version differences break formatting code on 2.0.x
 class CqlshCopyTest(Tester):
     '''
     Tests the COPY TO and COPY FROM features in cqlsh.


### PR DESCRIPTION
The copy tests are broken pre-2.1, for example [here](http://cassci.datastax.com/job/cassandra-2.0_novnode_dtest/24/testReport/junit/cqlsh_copy_tests/CqlshCopyTest/test_undefined_as_null_indicator/). Until I figure out formatting for 2.0, we should skip these tests.