### PR TITLE
add formatting for 2.1 compatibility

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -24,6 +24,7 @@ from cqlsh_tools import (csv_rows, random_list, DummyColorMap,
                          unmonkeypatch_driver)
 
 DEFAULT_FLOAT_PRECISION = 5  # magic number copied from cqlsh script
+DEFAULT_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'  # based on cqlsh script; timezone stripped
 
 
 @canReuseCluster
@@ -137,7 +138,7 @@ class CqlshCopyTest(Tester):
         return format_value(type(val), val,
                             encoding=encoding_name,
                             date_time_format=date_time_format,
-                            time_format='',
+                            time_format=DEFAULT_TIME_FORMAT,
                             float_precision=DEFAULT_FLOAT_PRECISION,
                             colormap=DummyColorMap(),
                             nullval=None).strval


### PR DESCRIPTION
This adds a format string, like in cqlsh itself, for `datetime`s in the cqlsh copy tests. This should fix [this test](http://cassci.datastax.com/job/cassandra-2.1_dtest/106/testReport/cqlsh_copy_tests/CqlshCopyTest/test_all_datatypes_write/), which is broken on 2.1.