### PR TITLE
fix deserialize problems

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -36,11 +36,11 @@ class CqlshCopyTest(Tester):
     """
     @classmethod
     def setUpClass(cls):
-        monkeypatch_driver(cls)
+        cls._cached_driver_methods = monkeypatch_driver()
 
     @classmethod
     def tearDownClass(cls):
-        unmonkeypatch_driver(cls)
+        unmonkeypatch_driver(cls._cached_driver_methods)
 
     def prepare(self):
         if not self.cluster.nodelist():

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -26,11 +26,11 @@ class TestCqlsh(Tester):
 
     @classmethod
     def setUpClass(cls):
-        monkeypatch_driver(cls)
+        cls._cached_driver_methods = monkeypatch_driver()
 
     @classmethod
     def tearDownClass(cls):
-        unmonkeypatch_driver(cls)
+        unmonkeypatch_driver(cls._cached_driver_methods)
 
     def test_simple_insert(self):
 


### PR DESCRIPTION
Don't attach the cached functions to a class -- that makes it so it's treated as a method, so deserialize can't be called as a function afterwards. This puts them in a dictionary instead.

Causing failures on cassci like [this one](http://cassci.datastax.com/view/All_Jobs/job/trunk_novnode_dtest/65/testReport/cql_tests/TestCQL/select_with_alias_test/). I repro'd the test bug locally with this command:

```
$ CASSANDRA_VERSION=git:trunk nosetests cqlsh_tests/cqlsh_copy_tests.py:CqlshCopyTest.test_all_datatypes_round_trip cql_tests.py:TestCQL.empty_blob_test --verbosity=3
```

Fails on master, succeeds with this PR.