### PR TITLE
CASSANDRA-9492: Using stable ordering for all JDKs

### DIFF
--- a/cql_tests.py
+++ b/cql_tests.py
@@ -2170,10 +2170,7 @@ class TestCQL(Tester):
         """ Test for the validation bug of #4706 """
 
         cursor = self.prepare()
-        if self.cluster.version() >= '3.0':
-            assert_invalid(cursor, "CREATE TABLE test (id bigint PRIMARY KEY, count counter, things set<text>)", matching="Cannot add a non counter column", expected=ConfigurationException)
-        else:
-            assert_invalid(cursor, "CREATE TABLE test (id bigint PRIMARY KEY, count counter, things set<text>)", matching="Cannot add a counter column", expected=ConfigurationException)
+        assert_invalid(cursor, "CREATE TABLE test (id bigint PRIMARY KEY, count counter, things set<text>)", matching="Cannot add a non counter column", expected=ConfigurationException)
 
     def reversed_compact_test(self):
         """ Test for #4716 bug and more generally for good behavior of ordering"""


### PR DESCRIPTION
This goes with CASSANDRA-9492, since the counter column is first alphabetically, we'll use that as the default validator