### PR TITLE
Clean up dtest for output of pyflakes

### DIFF
--- a/auth_roles_test.py
+++ b/auth_roles_test.py
@@ -1,11 +1,11 @@
-import time
+import time, re
 
-from cassandra import AuthenticationFailed, Unauthorized
+from cassandra import AuthenticationFailed, Unauthorized, InvalidRequest
 from cassandra.cluster import NoHostAvailable
 from cassandra.protocol import SyntaxException
 from auth_test import data_resource_creator_permissions, role_creator_permissions, function_resource_creator_permissions
-from dtest import debug,Tester
-from assertions import *
+from dtest import Tester
+from assertions import assert_one, assert_all, assert_invalid
 from tools import since
 
 #Second value is superuser status

--- a/auth_test.py
+++ b/auth_test.py
@@ -5,7 +5,6 @@ from cassandra.cluster import NoHostAvailable
 from dtest import debug, Tester
 from tools import since
 from assertions import assert_invalid
-from tools import require
 
 class TestAuth(Tester):
 

--- a/batch_test.py
+++ b/batch_test.py
@@ -4,7 +4,6 @@ from assertions import assert_invalid, assert_unavailable
 from dtest import Tester
 from cassandra import ConsistencyLevel, Timeout
 from cassandra.query import SimpleStatement
-from cassandra.policies import RetryPolicy
 
 class TestBatch(Tester):
 

--- a/cfid_test.py
+++ b/cfid_test.py
@@ -1,8 +1,6 @@
 from dtest import Tester
 from tools import since
-import unittest, os, sys, time
-from ccmlib.cluster import Cluster
-from ccmlib import common
+import os
 
 @since('2.1')
 class TestCFID(Tester):

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -1,9 +1,6 @@
-from dtest import Tester, debug, DISABLE_VNODES
-import unittest
-from ccmlib.cluster import Cluster
-from ccmlib.node import Node, NodeError, TimeoutError
-import time, re
-from assertions import assert_invalid, assert_all, assert_none, assert_one
+from dtest import Tester, debug
+import time
+from assertions import assert_none, assert_one
 import tempfile
 import os
 

--- a/concurrent_schema_changes_test.py
+++ b/concurrent_schema_changes_test.py
@@ -139,7 +139,7 @@ class TestConcurrentSchemaChanges(Tester):
         debug("changes_to_different_nodes_test()")
         cluster = self.cluster
         cluster.populate(2).start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
         wait(2)
         cursor = self.cql_connection(node1)
         self.prepare_for_changes(cursor, namespace='ns1')
@@ -168,7 +168,7 @@ class TestConcurrentSchemaChanges(Tester):
         debug("changes_while_node_down_test()")
         cluster = self.cluster
         cluster.populate(2).start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
         wait(2)
         cursor = self.patient_cql_connection(node2)
 
@@ -196,7 +196,7 @@ class TestConcurrentSchemaChanges(Tester):
         debug("changes_while_node_toggle_test()")
         cluster = self.cluster
         cluster.populate(2).start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
         wait(2)
         cursor = self.patient_cql_connection(node2)
 
@@ -230,7 +230,7 @@ class TestConcurrentSchemaChanges(Tester):
                     None)
         cluster.add(node2, False)
 
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
         node1.start(wait_for_binary_proto=True)
         node2.start(wait_for_binary_proto=True)
         wait(2)
@@ -265,7 +265,7 @@ class TestConcurrentSchemaChanges(Tester):
         debug("snapshot_test()")
         cluster = self.cluster
         cluster.populate(2).start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
         wait(2)
         cursor = self.cql_connection(node1)
         self.prepare_for_changes(cursor, namespace='ns2')

--- a/configuration_test.py
+++ b/configuration_test.py
@@ -1,7 +1,6 @@
 from dtest import Tester
 
-import re, ast
-from ccmlib.cluster import Cluster
+import ast
 
 class TestConfiguration(Tester):
 

--- a/consistency_test.py
+++ b/consistency_test.py
@@ -153,7 +153,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={ 'hinted_handoff_enabled' : False}, batch_commitlog=True)
 
         cluster.populate(3).start(wait_other_notice=True)
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 3)
@@ -185,7 +185,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={ 'hinted_handoff_enabled' : False}, batch_commitlog=True)
 
         cluster.populate(2).start(wait_other_notice=True)
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 3)
@@ -254,7 +254,7 @@ class TestConsistency(Tester):
         else:
             tokens = cluster.balanced_tokens(2)
             cluster.populate(2, tokens=tokens).start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 2)
@@ -285,7 +285,7 @@ class TestConsistency(Tester):
         else:
             tokens = cluster.balanced_tokens(2)
             cluster.populate(2, tokens=tokens).start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 2)
@@ -317,7 +317,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={ 'hinted_handoff_enabled' : False}, batch_commitlog=True)
 
         cluster.populate(3).start(wait_other_notice=True)
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 3)
@@ -351,7 +351,7 @@ class TestConsistency(Tester):
         else:
             tokens = cluster.balanced_tokens(3)
             cluster.populate(3, tokens=tokens).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
         cluster.start()
 
         debug("Set to talk to node 2")

--- a/consistent_bootstrap_test.py
+++ b/consistent_bootstrap_test.py
@@ -1,9 +1,6 @@
-import time
-
 from dtest import Tester, debug
-from assertions import assert_unavailable
-from tools import (create_c1c2_table, insert_c1c2, query_c1c2, retry_till_success,
-                   insert_columns, new_node, no_vnodes, since)
+from tools import (create_c1c2_table, insert_c1c2, query_c1c2,
+                   new_node, no_vnodes, since)
 from cassandra import ConsistencyLevel
 
 @since('2.1')

--- a/cql_prepared_test.py
+++ b/cql_prepared_test.py
@@ -1,9 +1,7 @@
 from dtest import Tester
 from tools import since
 
-import os, sys, time, tools
-from uuid import UUID
-from ccmlib.cluster import Cluster
+import time
 
 @since("1.2")
 class TestCQL(Tester):

--- a/delete_insert_test.py
+++ b/delete_insert_test.py
@@ -1,7 +1,7 @@
-from dtest import Tester, debug
+from dtest import Tester
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
-import uuid, os, threading, random
+import uuid, threading, random
 
 class DeleteInsertTest(Tester):
     """
@@ -19,10 +19,6 @@ class DeleteInsertTest(Tester):
         self.create_ks(cursor, 'delete_insert_search_test', rf)
         cursor.execute('CREATE TABLE test (id uuid PRIMARY KEY, val1 text, group text)')
         cursor.execute('CREATE INDEX group_idx ON test (group)')
-
-    def delete_all_rows(self, cursor):
-        for id, val, group in self.rows:
-            cursor.execute("DELETE FROM test WHERE id=%s" % u)
 
     def delete_group_rows(self, cursor, group):
         """Delete rows from a given group and return them"""

--- a/dtest.py
+++ b/dtest.py
@@ -1,11 +1,9 @@
 from __future__ import with_statement
-import os, tempfile, sys, shutil, subprocess, types, time, threading, traceback, ConfigParser, logging, fnmatch, re, copy
+import os, tempfile, sys, shutil, subprocess, types, time, threading, traceback, ConfigParser, logging, re, copy
 
 from ccmlib.cluster import Cluster
 from ccmlib.cluster_factory import ClusterFactory
-from ccmlib.node import Node
 from ccmlib.common import is_win
-from uuid import UUID
 from nose.exc import SkipTest
 from unittest import TestCase
 from cassandra.cluster import NoHostAvailable

--- a/global_indexes_test.py
+++ b/global_indexes_test.py
@@ -1,11 +1,6 @@
-import random, re, time, uuid
-
-from dtest import Tester, debug
+from dtest import Tester
 from tools import since, require
 from assertions import assert_invalid
-from cassandra import InvalidRequest
-from cassandra.query import BatchStatement, SimpleStatement
-from cassandra.protocol import ConfigurationException
 
 
 @since('3.0')

--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -23,7 +23,7 @@ class TestIncRepair(Tester):
     def sstable_marking_test(self):
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         node3.stop(gently=True)
 
@@ -55,7 +55,7 @@ class TestIncRepair(Tester):
     def multiple_repair_test(self):
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 3)
@@ -113,7 +113,7 @@ class TestIncRepair(Tester):
     def sstable_repairedset_test(self):
         cluster = self.cluster
         cluster.populate(2).start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
         node1.stress(['write', 'n=10000', '-schema', 'replication(factor=2)'])
 
         node1.flush()
@@ -172,7 +172,7 @@ class TestIncRepair(Tester):
     def compaction_test(self):
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 3)

--- a/jmx_test.py
+++ b/jmx_test.py
@@ -1,11 +1,5 @@
-from dtest import Tester, debug, DISABLE_VNODES
-from ccmlib.node import Node, NodeError, TimeoutError
-from cassandra import ConsistencyLevel, Unavailable, ReadTimeout
-from cassandra.query import SimpleStatement
-from tools import since, InterruptBootstrap
-import time
+from dtest import Tester, debug
 from jmxutils import make_mbean, JolokiaAgent
-from multiprocessing import Process
 
 class TestJMX(Tester):
 

--- a/largecolumn_test.py
+++ b/largecolumn_test.py
@@ -1,6 +1,5 @@
 from dtest import Tester, debug
-from tools import new_node, since
-import time
+from tools import since
 
 """
 Check that inserting and reading large columns to the database doesn't cause off heap memory usage

--- a/multidc_putget_test.py
+++ b/multidc_putget_test.py
@@ -1,6 +1,5 @@
 from dtest import Tester
 from tools import putget
-from ccmlib.cluster import Cluster
 
 class TestMultiDCPutGet(Tester):
 

--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -1,10 +1,5 @@
-from dtest import Tester, debug, DISABLE_VNODES
-from ccmlib.node import Node, NodeError, TimeoutError
-from cassandra import ConsistencyLevel, Unavailable, ReadTimeout
-from cassandra.query import SimpleStatement
-from tools import since
+from dtest import Tester, debug
 import re
-import subprocess
 import os
 
 class TestOfflineTools(Tester):
@@ -91,7 +86,7 @@ class TestOfflineTools(Tester):
         """
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1,node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
 
         # NOTE - As of now this does not return when it encounters Exception and causes test to hang, temporarily commented out
@@ -141,18 +136,6 @@ class TestOfflineTools(Tester):
         for x in range(0, len(final_levels)):
             initial = "intial level: " + str(initial_levels[x])
             self.assertEqual(final_levels[x], 0, msg=initial)
-
-    def get_levels(self, data):
-        levels = []
-        for sstable in data:
-            (metadata, error, rc) = sstable
-            level = int(re.findall("SSTable Level: [0-9]", metadata)[0][-1])
-            levels.append(level)
-        return levels
-
-        for x in range(0, len(final_levels)):
-            lev = "initial: " + str(initial_levels[x]) + " final: " + str(final_levels[x])
-            self.assertGreaterEqual(final_levels[x], initial_level[x], msg=lev)
 
     def sstableverify_test(self):
         """

--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -8,7 +8,6 @@ from cassandra.query import SimpleStatement
 
 import time
 from threading import Thread
-from ccmlib.cluster import Cluster
 
 @since('2.0.6')
 class TestPaxos(Tester):

--- a/prepared_statements_test.py
+++ b/prepared_statements_test.py
@@ -1,4 +1,4 @@
-from dtest import Tester, debug
+from dtest import Tester
 from cassandra import InvalidRequest
 from tools import since
 

--- a/putget_test.py
+++ b/putget_test.py
@@ -3,7 +3,7 @@ import tools as tools
 from tools import no_vnodes, create_c1c2_table, retry_till_success
 from cassandra import ConsistencyLevel
 
-import time, re
+import time
 
 from thrift.transport import TTransport, TSocket
 from thrift.protocol import TBinaryProtocol
@@ -32,7 +32,7 @@ class TestPutGet(Tester):
         cluster = self.cluster
 
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 3)
@@ -45,7 +45,7 @@ class TestPutGet(Tester):
         cluster = self.cluster
 
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 2)
@@ -62,7 +62,7 @@ class TestPutGet(Tester):
         cluster = self.cluster
 
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 2)
@@ -75,7 +75,7 @@ class TestPutGet(Tester):
         cluster = self.cluster
 
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 1)
@@ -120,7 +120,7 @@ class TestPutGet(Tester):
         cluster = self.cluster
         cluster.set_configuration_options(values={'partitioner': 'org.apache.cassandra.dht.ByteOrderedPartitioner'})
         cluster.populate(2)
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
         node1.set_configuration_options(values={'initial_token': "a".encode('hex')  })
         node1.set_configuration_options(values={'initial_token': "b".encode('hex')  })
         cluster.start()

--- a/range_ghost_test.py
+++ b/range_ghost_test.py
@@ -1,7 +1,6 @@
 from dtest import Tester
 
-import os, sys, time
-from ccmlib.cluster import Cluster
+import time
 
 class TestRangeGhosts(Tester):
 

--- a/repair_test.py
+++ b/repair_test.py
@@ -87,7 +87,7 @@ class TestRepair(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False}, batch_commitlog=True)
         debug("Starting cluster..")
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 3)
@@ -153,7 +153,7 @@ class TestRepair(Tester):
         cluster.populate(2)
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False}, batch_commitlog=True)
         cluster.start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         # create keyspace with RF=2 to be able to be repaired

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -37,7 +37,7 @@ class TestReplaceAddress(Tester):
         debug("Starting cluster with 3 nodes.")
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         if DISABLE_VNODES:
             numNodes = 1
@@ -100,7 +100,7 @@ class TestReplaceAddress(Tester):
         debug("Starting cluster with 3 nodes.")
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         #replace active node 3 with node 4
         debug("Starting node 4 to replace active node 3")
@@ -120,7 +120,7 @@ class TestReplaceAddress(Tester):
         debug("Starting cluster with 3 nodes.")
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         debug('Start node 4 and replace an address with no node')
         node4 = Node('node4', cluster, True, ('127.0.0.4', 9160), ('127.0.0.4', 7000), '7400', '0', None, ('127.0.0.4', 9042))
@@ -137,7 +137,7 @@ class TestReplaceAddress(Tester):
         debug("Starting cluster with 3 nodes.")
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         if DISABLE_VNODES:
             numNodes = 1
@@ -212,7 +212,7 @@ class TestReplaceAddress(Tester):
 
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         node1.stress(['write', 'n=100000', '-schema', 'replication(factor=3)'])
 
@@ -261,7 +261,7 @@ class TestReplaceAddress(Tester):
 
         cluster = self.cluster
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         node1.stress(['write', 'n=100000', '-schema', 'replication(factor=3)'])
 

--- a/replication_test.py
+++ b/replication_test.py
@@ -1,7 +1,6 @@
 from dtest import Tester, debug, PRINT_DEBUG
 from tools import no_vnodes
-from ccmlib.cluster import Cluster
-import re, os, time
+import re, time
 from collections import defaultdict
 from cassandra.query import SimpleStatement
 from cassandra import ConsistencyLevel

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -135,7 +135,7 @@ class TestSSTableGenerationAndLoading(Tester):
 
         cluster = self.cluster
         cluster.populate(2).start()
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
         time.sleep(.5)
 
         def create_schema(cursor, compression):

--- a/sstablesplit_test.py
+++ b/sstablesplit_test.py
@@ -76,7 +76,6 @@ class TestSSTableSplit(Tester):
         cluster = self.cluster
         cluster.populate(1).start(wait_for_binary_proto=True)
         node = cluster.nodelist()[0]
-        version = cluster.version()
 
         debug("Run stress to insert data")
         node.stress(['write', 'n=2000000', '-rate', 'threads=50',

--- a/thrift_hsha_test.py
+++ b/thrift_hsha_test.py
@@ -1,5 +1,4 @@
 from dtest import Tester, debug, DEFAULT_DIR
-from tools import require
 import unittest, time, os, subprocess, shlex, pycassa, glob, sys
 
 JNA_PATH = '/usr/share/java/jna.jar'

--- a/thrift_tests.py
+++ b/thrift_tests.py
@@ -5,7 +5,7 @@ from thrift.transport import TSocket
 from thrift.protocol import TBinaryProtocol
 from thrift.Thrift import TApplicationException
 
-from dtest import Tester, debug, NUM_TOKENS, DISABLE_VNODES
+from dtest import Tester, NUM_TOKENS, DISABLE_VNODES
 from tools import since
 from thrift_bindings.v22 import Cassandra
 from thrift_bindings.v22.Cassandra import *

--- a/token_generator.py
+++ b/token_generator.py
@@ -6,7 +6,7 @@ import time
 
 from ccmlib import common
 from dtest import Tester, debug
-from tools import rows_to_list, require
+from tools import rows_to_list
 from cassandra.util import sortedset
 
 class TokenGenerator(Tester):

--- a/tools.py
+++ b/tools.py
@@ -1,14 +1,13 @@
 from ccmlib.node import Node
-from decorator  import decorator
 from distutils.version import LooseVersion
 from threading import Thread
-import re, os, sys, fileinput, time, unittest, functools
+import re, sys, fileinput, time, unittest, functools
 import subprocess
 
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
-from dtest import Tester, DISABLE_VNODES, CASSANDRA_DIR, debug
+from dtest import DISABLE_VNODES, CASSANDRA_DIR, debug
 
 def rows_to_list(rows):
     new_list = [list(row) for row in rows]

--- a/topology_test.py
+++ b/topology_test.py
@@ -2,9 +2,7 @@ from dtest import Tester
 from tools import insert_c1c2, query_c1c2, no_vnodes, new_node, debug, require, since
 from assertions import assert_almost_equal
 
-import os, sys, time
-from nose.tools import raises
-from ccmlib.cluster import Cluster
+import time
 from ccmlib.node import TimeoutError
 from cassandra import ConsistencyLevel
 
@@ -16,7 +14,7 @@ class TestTopology(Tester):
 
         # Create an unbalanced ring
         cluster.populate(3, tokens=[0, 2**48, 2**62]).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 1)
@@ -55,7 +53,7 @@ class TestTopology(Tester):
 
         tokens = cluster.balanced_tokens(4)
         cluster.populate(4, tokens=tokens).start()
-        [node1, node2, node3, node4] = cluster.nodelist()
+        node1, node2, node3, node4 = cluster.nodelist()
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 2)

--- a/udtencoding_test.py
+++ b/udtencoding_test.py
@@ -2,8 +2,7 @@ from dtest import Tester
 from assertions import assert_invalid
 from tools import since
 
-import os, sys, time
-from ccmlib.cluster import Cluster
+import time
 
 @since('2.1')
 class TestUDTEncoding(Tester):
@@ -13,7 +12,7 @@ class TestUDTEncoding(Tester):
         cluster = self.cluster
 
         cluster.populate(3).start()
-        [node1, node2, node3] = cluster.nodelist()
+        node1, node2, node3 = cluster.nodelist()
 
         time.sleep(.5)
         cursor = self.patient_cql_connection(node1)

--- a/upgrade_supercolumns_test.py
+++ b/upgrade_supercolumns_test.py
@@ -38,7 +38,7 @@ class TestSCUpgrade(Tester):
         cluster.set_install_dir(version="1.2.16")
         cluster.populate(2).start()
 
-        [node1, node2] = cluster.nodelist()
+        node1, node2 = cluster.nodelist()
 
         # wait for the rpc server to start
         session = self.patient_exclusive_cql_connection(node1)

--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -9,10 +9,8 @@ import uuid
 
 from collections import defaultdict
 from distutils.version import LooseVersion
-from dtest import Tester, debug, DISABLE_VNODES, DEFAULT_DIR
+from dtest import Tester, debug, DEFAULT_DIR
 from tools import new_node
-from ccmlib import common as ccmcommon
-import tarfile
 from cassandra import ConsistencyLevel, WriteTimeout
 from cassandra.query import SimpleStatement
 

--- a/user_functions_test.py
+++ b/user_functions_test.py
@@ -1,8 +1,8 @@
-import math, os, sys, time
+import math, time
 
-from dtest import Tester, debug
-from assertions import assert_invalid, assert_one, assert_all, assert_none
-from tools import since, rows_to_list
+from dtest import Tester
+from assertions import assert_invalid, assert_one, assert_none
+from tools import since
 
 
 @since('2.2')
@@ -90,7 +90,6 @@ class TestUserFunctions(Tester):
         session = self.prepare(nodes=3)
 
         session.execute("CREATE TABLE tab (k text PRIMARY KEY, v int)");
-        test = "foo"
         session.execute("INSERT INTO tab (k, v) VALUES ('foo' , 1);")
 
         # create overloaded udfs
@@ -132,7 +131,7 @@ class TestUserFunctions(Tester):
         assert_one(session, "SELECT key, val, x_sin(val) FROM nums where key = %d" % 1, [1, 1.0, math.sin(1.0)])
         assert_one(session, "SELECT key, val, x_sin(val) FROM nums where key = %d" % 2, [2, 2.0, math.sin(2.0)])
         assert_one(session, "SELECT key, val, x_sin(val) FROM nums where key = %d" % 3, [3, 3.0, math.sin(3.0)])
-        
+
         session.execute("create function y_sin(val double) called on null input returns double language javascript as 'Math.sin(val).toString()'")
 
         assert_invalid(session, "select y_sin(val) from nums where key = 1")

--- a/user_types_test.py
+++ b/user_types_test.py
@@ -1,7 +1,7 @@
 import time
 import uuid
 import re
-from dtest import Tester, debug
+from dtest import Tester
 from tools import since, require
 from assertions import assert_invalid
 from cassandra import Unauthorized, ConsistencyLevel

--- a/validation.py
+++ b/validation.py
@@ -1,6 +1,6 @@
 from dtest import Tester, debug
 from tools import since
-import subprocess, tempfile, os, shutil
+import subprocess, tempfile, os
 
 @since('2.2')
 class TestValidation(Tester):


### PR DESCRIPTION
I ran all of dtest through pyflakes. It found a lot of unused imports, some unused variables worth removing, and even a few unnecessary functions. I also snuck in a stylistic change in expanding tuples.