### PR TITLE
changes require for repair history table tests

### DIFF
--- a/repair_test.py
+++ b/repair_test.py
@@ -292,7 +292,7 @@ class TestRepairDataSystemTable(Tester):
         for table_name, table_contents in repair_tables_dict.items():
             self.assertFalse(table_contents, '{} is non-empty'.format(table_name))
 
-    @require('parent-repair-history-table.*')
+    @require(9534)
     def repair_parent_table_test(self):
         """
         Test that `system_distributed.parent_repair_history` is properly populated
@@ -305,6 +305,7 @@ class TestRepairDataSystemTable(Tester):
         parent_repair_history, _ = self.repair_table_contents(node=self.node1, include_system_keyspaces=False)
         self.assertTrue(len(parent_repair_history))
 
+    @require(9534)
     def repair_table_test(self):
         """
         Test that `system_distributed.repair_history` is properly populated


### PR DESCRIPTION
Apparently both of these flap! so skip 'em both. Failure for the newly-required test is [here](http://cassci.datastax.com/view/trunk/job/trunk_dtest/200/testReport/repair_test/TestRepairDataSystemTable/repair_table_test/)

Changes the existing @require to account for the new ticket, filed [here](https://issues.apache.org/jira/browse/CASSANDRA-9534)