### PR TITLE
Cassandra-5322 Making dtests more granular

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -152,6 +152,28 @@ class Tester(TestCase):
 
         return cluster
 
+    def var_debug(self, cluster):
+        general_DEBUG = os.environ.get('DEBUG', 'no').lower() not in ('no', 'false', 'yes', 'true')
+        classes_to_debug = []
+        if general_DEBUG:
+            classes_to_debug = os.environ.get('DEBUG').split(":")
+            cluster.set_log_level('DEBUG', None if len(classes_to_debug) == 0 else classes_to_debug)
+
+    def var_trace(self, cluster):
+        general_TRACE = os.environ.get('TRACE', 'no').lower() not in ('no', 'false', 'yes', 'true')
+        classes_to_trace = []
+        if general_TRACE:
+            classes_to_trace = os.environ.get('TRACE').split(":")
+            cluster.set_log_level('TRACE', None if len(classes_to_trace) == 0 else classes_to_trace)
+
+    def modify_log(self, cluster):
+        if DEBUG:
+            cluster.set_log_level("DEBUG")
+        if TRACE:
+            cluster.set_log_level("TRACE")
+        self.var_debug(cluster)
+        self.var_trace(cluster)
+
     def _cleanup_cluster(self):
         if SILENCE_DRIVER_ON_SHUTDOWN:
             # driver logging is very verbose when nodes start going down -- bump up the level
@@ -240,10 +262,8 @@ class Tester(TestCase):
         with open(LAST_TEST_DIR, 'w') as f:
             f.write(self.test_path + '\n')
             f.write(self.cluster.name)
-        if DEBUG:
-            self.cluster.set_log_level("DEBUG")
-        if TRACE:
-            self.cluster.set_log_level("TRACE")
+
+        self.modify_log(self.cluster)
         self.connections = []
         self.runners = []
 


### PR DESCRIPTION
Updated environment variables DEBUG and TRACE such that they also accept class names along with true/false/yes/no, By inputting class name(s) (separated with a colon), you can set only those classes to have that level of logging. 