### PR TITLE
Use ccm run cqlsh

### DIFF
--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -17,10 +17,6 @@ from tools import create_c1c2_table, insert_c1c2, rows_to_list, since
 
 
 class TestCqlsh(Tester):
-
-    def __init__(self, *args, **kwargs):
-        Tester.__init__(self, *args, **kwargs)
-
     @classmethod
     def setUpClass(cls):
         cls._cached_driver_methods = monkeypatch_driver()

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -437,16 +437,16 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
         ##If this assertion fails check CASSANDRA-7891
 
     def verify_output(self, query, node, expected):
-            output, err = node.run_cqlsh(query,
-                                         cqlsh_options=['-u', 'cassandra', '-p', 'cassandra'],
-                                         return_output=True)
-            if common.is_win():
-                output = output.replace('\r', '')
-            if len(err) > 0:
-                debug(err)
-                assert False, "Failed to execute cqlsh"
-            debug(output)
-            self.assertTrue(expected in output, "Output \n {%s} \n doesn't contain expected\n {%s}" % (output, expected))
+        output, err = node.run_cqlsh(query,
+                                        cqlsh_options=['-u', 'cassandra', '-p', 'cassandra'],
+                                        return_output=True)
+        if common.is_win():
+            output = output.replace('\r', '')
+        if len(err) > 0:
+            debug(err)
+            assert False, "Failed to execute cqlsh"
+        debug(output)
+        self.assertTrue(expected in output, "Output \n {%s} \n doesn't contain expected\n {%s}" % (output, expected))
 
     def test_list_queries(self):
         config = {'authenticator': 'org.apache.cassandra.auth.PasswordAuthenticator',

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
-from dtest import Tester, debug
-from cassandra import InvalidRequest
-from ccmlib import common
 import binascii
-from cassandra.concurrent import execute_concurrent_with_args
 import csv
 import datetime
 from decimal import Decimal
 from tempfile import NamedTemporaryFile
 from uuid import UUID, uuid4
-from tools import create_c1c2_table, insert_c1c2, since, rows_to_list
-from assertions import assert_all, assert_none
 
+from cassandra import InvalidRequest
+from cassandra.concurrent import execute_concurrent_with_args
+
+from assertions import assert_all, assert_none
+from ccmlib import common
 from cqlsh_tools import monkeypatch_driver, unmonkeypatch_driver
+from dtest import Tester, debug
+from tools import create_c1c2_table, insert_c1c2, rows_to_list, since
 
 
 class TestCqlsh(Tester):


### PR DESCRIPTION
7681edb is the meat of this PR. `TestCqlsh` uses a custom `run_cqlsh` method that can return the stdout and stderr output from the cqlsh command. Since https://github.com/pcmanus/ccm/pull/264 was merged, this is no longer necessary. This commit removes the function and replaces all instances of its being called with ccmlib.Node.run_cqlsh.

The other commits are more cleanup-y cleanup: they organize imports with `isort`, remove `TestCqlsh.__init__` (which had no effect), correct some indentation that was too deep, and :fireworks: add Doxygen docstrings to the test methods in `TestCqlsh` :fireworks:.

The tests still pass locally on `trunk` and `cassandra-2.{2,1,0}`