### PR TITLE
adds compact storage option to create_cf

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -393,7 +393,7 @@ class Tester(TestCase):
         session.execute('USE %s' % name)
 
     # We default to UTF8Type because it's simpler to use in tests
-    def create_cf(self, session, name, key_type="varchar", speculative_retry=None, read_repair=None, compression=None, gc_grace=None, columns=None, validation="UTF8Type"):
+    def create_cf(self, session, name, key_type="varchar", speculative_retry=None, read_repair=None, compression=None, gc_grace=None, columns=None, validation="UTF8Type", compact_storage=False):
         additional_columns = ""
         if columns is not None:
             for k, v in columns.items():
@@ -417,6 +417,9 @@ class Tester(TestCase):
         if self.cluster.version() >= "2.0":
             if speculative_retry is not None:
                 query = '%s AND speculative_retry=\'%s\'' % (query, speculative_retry)
+
+        if compact_storage:
+            query += ' AND COMPACT STORAGE'
 
         session.execute(query)
         time.sleep(0.2)

--- a/dtest.py
+++ b/dtest.py
@@ -393,7 +393,9 @@ class Tester(TestCase):
         session.execute('USE %s' % name)
 
     # We default to UTF8Type because it's simpler to use in tests
-    def create_cf(self, session, name, key_type="varchar", speculative_retry=None, read_repair=None, compression=None, gc_grace=None, columns=None, validation="UTF8Type", compact_storage=False):
+    def create_cf(self, session, name, key_type="varchar", speculative_retry=None, read_repair=None, compression=None,
+                  gc_grace=None, columns=None, validation="UTF8Type", compact_storage=False):
+
         additional_columns = ""
         if columns is not None:
             for k, v in columns.items():


### PR DESCRIPTION
This adds a `compact_storage` kwarg to `Tester.create_cf`. If truthy, it creates the table `WITH COMPACT STORAGE`. This is helping me with comparing the old row format to the new format that will be introduced in 3.0.

Since it's a kwarg at the end of the parameter list, it doesn't affect existing calls.