### PR TITLE
require and clean up rebuild test

### DIFF
--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -1,9 +1,11 @@
 import time
-from dtest import Tester, debug
-from tools import insert_c1c2, query_c1c2, new_node, require
-from ccmlib.node import Node, NodetoolError
-from cassandra import ConsistencyLevel
 from threading import Thread
+
+from cassandra import ConsistencyLevel
+
+from ccmlib.node import NodetoolError
+from dtest import Tester
+from tools import insert_c1c2, query_c1c2, require
 
 
 class TestRebuild(Tester):

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -1,6 +1,6 @@
 import time
 from dtest import Tester, debug
-from tools import insert_c1c2, query_c1c2, new_node
+from tools import insert_c1c2, query_c1c2, new_node, require
 from ccmlib.node import Node, NodetoolError
 from cassandra import ConsistencyLevel
 from threading import Thread
@@ -23,8 +23,11 @@ class TestRebuild(Tester):
         Tester.__init__(self, *args, **kwargs)
         self.allow_log_errors = True
 
+    @require(9119)
     def simple_rebuild_test(self):
         """
+        @jira_ticket 9119
+
         Test rebuild from other dc works as expected.
         """
 

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -23,7 +23,6 @@ class TestRebuild(Tester):
             r'Streaming error occurred'
         ]
         Tester.__init__(self, *args, **kwargs)
-        self.allow_log_errors = True
 
     @require(9119)
     def simple_rebuild_test(self):

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -49,7 +49,7 @@ class TestRebuild(Tester):
 
         # populate data in dc1
         session = self.patient_exclusive_cql_connection(node1)
-        self.create_ks(session, 'ks', {'dc1':1})
+        self.create_ks(session, 'ks', {'dc1': 1})
         self.create_cf(session, 'cf', columns={'c1': 'text', 'c2': 'text'})
         for i in xrange(0, keys):
             insert_c1c2(session, i, ConsistencyLevel.ALL)
@@ -95,4 +95,3 @@ class TestRebuild(Tester):
         # check data
         for i in xrange(0, keys):
             query_c1c2(session, i, ConsistencyLevel.ALL)
-


### PR DESCRIPTION
[9119](https://issues.apache.org/jira/browse/CASSANDRA-9119) hasn't been merged yet, so this test is failing on cassci; the first commit fixes that.

The next two commits are import and whitespace cleanup.

The final commit removes `allow_log_errors` from the class in `rebuild_test`; it still passes on the 9119 branch without it (at least locally), so we should catch errors if we can.