### PR TITLE
skip flapping deletion tests on pre-2.1

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -3,6 +3,7 @@ import time
 from assertions import assert_none, assert_one
 import tempfile
 import os
+from tools import since
 
 class TestCompaction(Tester):
 
@@ -84,6 +85,7 @@ class TestCompaction(Tester):
 
         self.assertLess(finalValue, initialValue)
 
+    @since('2.1')
     def sstable_deletion_test(self):
         """Test that sstables are deleted properly when able to be.
         Insert data setting gc_grace_seconds to 0, and determine sstable


### PR DESCRIPTION
This test flaps with LCS on 2.0, so let's skip it until it's fixed. There's a Jira [here](https://issues.apache.org/jira/browse/CASSANDRA-9595).