### PR TITLE
s/@jira_ticket N/@jira_ticket CASSANRA-N/g

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Description       | Brief description of the test
 @expected_errors  | What exceptions this test is expected to throw on normal behavior (should be caught and expected in the test)
 @throws           | What exceptions this test would throw upon failure (if expecting a specific regression)
 @since            | I am unsure what we will use this for. Do not use until we have reached a decision.
-@jira_ticket      | Associated JIRA ticket number
+@jira_ticket      | Associated JIRA ticket identifier, including the project name (e.g. `CASSANDRA-42`, not `42`).
 @expected_result  | Brief summary of what the expected results of this test are
 @test_assumptions | Test requirements (auth, hints disabled , etc)
 @note             | (future improvments, todo, etc)

--- a/configuration_test.py
+++ b/configuration_test.py
@@ -32,7 +32,7 @@ class TestConfiguration(Tester):
     @require(9560)
     def change_durable_writes_test(self):
         """
-        @jira_ticket 9560
+        @jira_ticket CASSANDRA-9560
 
         Test that changes to the DURABLE_WRITES option on keyspaces is
         respected in subsequent writes.

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -27,7 +27,7 @@ class TestRebuild(Tester):
     @require(9119)
     def simple_rebuild_test(self):
         """
-        @jira_ticket 9119
+        @jira_ticket CASSANDRA-9119
 
         Test rebuild from other dc works as expected.
         """


### PR DESCRIPTION
Updates CONTRIBUTING to reflect this style choice.

Follow up to feedback on #324. We use CASSANDRA-N instead of just N because some dtests will be related to tickets in other projects, such as the Python driver.

You can verify that there aren't any more instances of `@jira_ticket N` with

```
grep -r 'jira_ticket[ \d]*$'
```