### PR TITLE
adds style section to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,15 @@
+## Style
+
+We plan to move to Python 3 in the near future. Where possible, new code should be Python 3-compatible. In particular:
+
+- favor `format` over `%` for formatting strings.
+
+Contributions will be evaluated by PEP8, though we do not enforce compliance strictly. We do not enforce limits on line length, but please keep lines readable.
+
+We do not enforce import sorting, but if you choose to organize imports by some convention, use the `isort` tool (`pip install isort`).
+
+## Doxygen Docstrings
+
 We are now colocating our test plans directly with the source code. We have decided to do so in a manner compatible with Doxygen, to turn the test plans into easily navigated HTML. Please view the following list of tags, as well as an example test. While this full list of tags is available for use, there is no need to use every tag for a given test. The description and since fields should be included, but most others should only be used when appropriate. The test plan will live in a comment block below the test method declaration.
 
 


### PR DESCRIPTION
This is a starting point for the Python 3 `CONTRIBUTING` changes we discussed while reviewing #328. I couldn't think of any changes other than string formatting off the top of my head, but that list should probably get longer at some point.

I've taken the liberty of also mentioning PEP8 and import sorting. [`isort`](https://github.com/timothycrosley/isort) is the tool I used [here](https://github.com/riptano/cassandra-dtest/commit/2f29d9254a692e5954d5140e1dca7fcdb3696edd) and I think it's nice.

Feel free to propose things to add/remove. I tried to describe how we already do things and not to impose anything new.