### PR TITLE
Major compaction cleanup

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -4,9 +4,10 @@ from assertions import assert_none, assert_one
 import tempfile
 import os
 
+
 class TestCompaction(Tester):
 
-    __test__= False
+    __test__ = False
 
     def __init__(self, *args, **kwargs):
         kwargs['cluster_options'] = {'start_rpc': 'true'}
@@ -22,7 +23,6 @@ class TestCompaction(Tester):
 
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 1)
-
 
         cursor.execute("create table ks.cf (key int PRIMARY KEY, val int) with compaction = {'class':'" + self.strategy + "'} and gc_grace_seconds = 30;")
 
@@ -94,7 +94,7 @@ class TestCompaction(Tester):
         [node1] = cluster.nodelist()
         cursor = self.patient_cql_connection(node1)
         self.create_ks(cursor, 'ks', 1)
-        cursor.execute("create table cf (key int PRIMARY KEY, val int) with gc_grace_seconds = 0 and compaction= {'class':'" +self.strategy+"'}")
+        cursor.execute("create table cf (key int PRIMARY KEY, val int) with gc_grace_seconds = 0 and compaction= {'class':'" + self.strategy + "'}")
 
         for x in range(0, 100):
             cursor.execute('insert into cf (key, val) values (' + str(x) + ',1)')
@@ -131,7 +131,7 @@ class TestCompaction(Tester):
         # max sstable age is 0.5 minute:
         cursor.execute("create table cf (key int PRIMARY KEY, val int) with gc_grace_seconds = 0 and compaction= {'class':'DateTieredCompactionStrategy', 'max_sstable_age_days':0.00035, 'min_threshold':2}")
 
-        #insert data
+        # insert data
         for x in range(0, 300):
             cursor.execute('insert into cf (key, val) values (' + str(x) + ',1) USING TTL 35')
         node1.flush()
@@ -141,10 +141,10 @@ class TestCompaction(Tester):
         expired_sstable = expired_sstables[0]
         # write a new sstable to make DTCS check for expired sstables:
         for x in range(0, 100):
-            cursor.execute('insert into cf (key, val) values (%d, %d)'%(x,x))
+            cursor.execute('insert into cf (key, val) values (%d, %d)' % (x, x))
         node1.flush()
         time.sleep(5)
-        assert expired_sstable not in node1.get_sstables('ks','cf')
+        assert expired_sstable not in node1.get_sstables('ks', 'cf')
 
     def compaction_throughput_test(self):
         """Test setting compaction throughput.
@@ -181,7 +181,6 @@ class TestCompaction(Tester):
             cluster.populate(1).start(wait_for_binary_proto=True)
             [node1] = cluster.nodelist()
 
-
             for strat in strategies:
                 cursor = self.patient_cql_connection(node1)
                 self.create_ks(cursor, 'ks', 1)
@@ -198,8 +197,8 @@ class TestCompaction(Tester):
 
                 cursor.execute("alter table ks.cf with compaction = {'class':'" + strat + "'};")
 
-                for x in range(11,100):
-                    assert_one(cursor, "select * from ks.cf where key =" + str(x),[x, 1])
+                for x in range(11, 100):
+                    assert_one(cursor, "select * from ks.cf where key =" + str(x), [x, 1])
 
                 for x in range(0, 10):
                     assert_none(cursor, 'select * from cf where key = ' + str(x))
@@ -241,5 +240,4 @@ def stress_write(node):
 strategies = ['LeveledCompactionStrategy', 'SizeTieredCompactionStrategy', 'DateTieredCompactionStrategy']
 for strategy in strategies:
     cls_name = ('TestCompaction_with_' + strategy)
-    vars()[cls_name] = type(cls_name, (TestCompaction,), {'strategy': strategy, '__test__':True})
-
+    vars()[cls_name] = type(cls_name, (TestCompaction,), {'strategy': strategy, '__test__': True})

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -89,6 +89,7 @@ class TestCompaction(Tester):
         Insert data setting gc_grace_seconds to 0, and determine sstable
         is deleted upon data deletion.
         """
+        self.skip_if_no_major_compaction()
         cluster = self.cluster
         cluster.populate(1).start(wait_for_binary_proto=True)
         [node1] = cluster.nodelist()
@@ -213,6 +214,10 @@ class TestCompaction(Tester):
                 cluster.clear()
                 time.sleep(5)
                 cluster.start(wait_for_binary_proto=True)
+
+    def skip_if_no_major_compaction(self):
+        if self.cluster.version() < '2.2' and self.strategy == 'LeveledCompactionStrategy':
+            self.skipTest('major compaction not implemented for LCS in this version of Cassandra')
 
 
 def block_on_compaction_log(node):

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -154,8 +154,10 @@ class TestCompaction(Tester):
         cluster = self.cluster
         cluster.populate(1).start(wait_for_binary_proto=True)
         [node1] = cluster.nodelist()
+
+        # disableautocompaction only disables compaction for existing tables,
+        # so initialize stress tables with stress first
         stress_write(node1, keycount=1)
-        # disableautocompaction only disables compaction for existing tables, so disable after creating tables:
         node1.nodetool('disableautocompaction')
         stress_write(node1, keycount=200000)
 

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -57,7 +57,6 @@ class TestCompaction(Tester):
         cluster = self.cluster
         cluster.populate(1).start(wait_for_binary_proto=True)
         [node1] = cluster.nodelist()
-        cursor = self.patient_cql_connection(node1)
 
         stress_write(node1)
 
@@ -154,7 +153,6 @@ class TestCompaction(Tester):
         cluster = self.cluster
         cluster.populate(1).start(wait_for_binary_proto=True)
         [node1] = cluster.nodelist()
-        cursor = self.patient_cql_connection(node1)
 
         stress_write(node1)
 

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -159,16 +159,14 @@ class TestCompaction(Tester):
         # so initialize stress tables with stress first
         stress_write(node1, keycount=1)
         node1.nodetool('disableautocompaction')
+
         stress_write(node1, keycount=200000)
 
         threshold = "5"
-
         node1.nodetool('setcompactionthroughput -- ' + threshold)
 
         matches = block_on_compaction_log(node1)
-
         stringline = matches[0]
-
         throughput_pattern = re.compile('''.*          # it doesn't matter what the line starts with
                                            =           # wait for an equals sign
                                            ([\s\d\.]*) # capture a decimal number, possibly surrounded by whitespace

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -1,9 +1,10 @@
-from dtest import Tester, debug
-import time
-from assertions import assert_none, assert_one
-import tempfile
 import os
 import re
+import tempfile
+import time
+
+from assertions import assert_almost_equal, assert_none, assert_one
+from dtest import Tester, debug
 
 
 class TestCompaction(Tester):

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -15,8 +15,9 @@ class TestCompaction(Tester):
         Tester.__init__(self, *args, **kwargs)
 
     def compaction_delete_test(self):
-        """Test that executing a delete properly tombstones a row.
-        Insert data, delete a partition of data and check that the requesite rows are tombstoned
+        """
+        Test that executing a delete properly tombstones a row.
+        Insert data, delete a partition of data and check that the requesite rows are tombstoned.
         """
         cluster = self.cluster
         cluster.populate(1).start(wait_for_binary_proto=True)
@@ -51,7 +52,8 @@ class TestCompaction(Tester):
         self.assertEqual(numfound, 10)
 
     def data_size_test(self):
-        """Ensure that data size does not have unwarranted increases after compaction.
+        """
+        Ensure that data size does not have unwarranted increases after compaction.
         Insert data and check data size before and after a compaction.
         """
         cluster = self.cluster
@@ -85,7 +87,8 @@ class TestCompaction(Tester):
         self.assertLess(finalValue, initialValue)
 
     def sstable_deletion_test(self):
-        """Test that sstables are deleted properly when able to be.
+        """
+        Test that sstables are deleted properly when able after compaction.
         Insert data setting gc_grace_seconds to 0, and determine sstable
         is deleted upon data deletion.
         """
@@ -115,7 +118,9 @@ class TestCompaction(Tester):
             self.fail("Path to sstables not valid.")
 
     def dtcs_deletion_test(self):
-        """Test that sstables are deleted properly when able to be.
+        """
+        Test that sstables are deleted properly when able after compaction with
+        DateTieredCompactionStrategy.
         Insert data setting max_sstable_age_days low, and determine sstable
         is deleted upon data deletion past max_sstable_age_days.
         """
@@ -148,7 +153,8 @@ class TestCompaction(Tester):
         assert expired_sstable not in node1.get_sstables('ks', 'cf')
 
     def compaction_throughput_test(self):
-        """Test setting compaction throughput.
+        """
+        Test setting compaction throughput.
         Set throughput, insert data and ensure compaction performance corresponds.
         """
         cluster = self.cluster

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -249,10 +249,9 @@ def block_on_compaction_log(node):
 
 def stress_write(node, keycount=100000):
     if node.get_cassandra_version() < '2.1':
-        node.stress(['--num-keys=%d'%keycount])
+        node.stress(['--num-keys={keycount}'.format(keycount=keycount)])
     else:
-        node.stress(['write', 'n=%d'%keycount])
-
+        node.stress(['write', 'n={keycount}'.format(keycount=keycount)])
 
 
 strategies = ['LeveledCompactionStrategy', 'SizeTieredCompactionStrategy', 'DateTieredCompactionStrategy']


### PR DESCRIPTION
d0f67ce: As discussed in #327, this is a better solution to `TestCompaction_with_LeveledCompactionStrategy.sstable_deletion_test` flapping on 2.0. We still skip that particular test pre-2.2 (eb8c7ab), but the other tests are not skipped as they were in the previous PR. Instead, we use a flush, a major compaction, and log-waiting to block on a compaction.

587f821 should be reviewed on its own. It's justified in its commit message. It may expose a C* bug: compaction throughput runs at about 120-125% of the specified maximum.

The other commits are cleanup.

Requesting review from @shawnkumar since he wrote the tests and from @ptnapoleon since he reviewed the previous PR.