### PR TITLE
Trying to fix Jenkins failure, CASSANDRA-9102

### DIFF
--- a/consistency_test.py
+++ b/consistency_test.py
@@ -221,7 +221,7 @@ class TestAvailability(TestHelper):
                 for combination in combinations:
                     self._test_insert_query_from_node(session, i, rf_factors, nodes_alive, *combination)
 
-                self.cluster.nodelist()[node].stop()
+                self.cluster.nodelist()[node].stop(wait_other_notice=True)
                 nodes_alive[i] = nodes_alive[i] - 1
 
     def _test_insert_query_from_node(self, session, dc_idx, rf_factors, num_nodes_alive, write_cl, read_cl, serial_cl=None, check_ret=True):


### PR DESCRIPTION
It seems consistency_test.py:TestAvailability.test_network_topology_strategy fails on Jenkins on all branches. However I cannot reproduce it on my box, it passes every time. At LOCAL_QUORUM a write should fail if only one node is up and two are down, given that rf is three. So I am guessing we need to wait for other nodes to notice, but it is only my best guess as I don't know how to download the node log files from Jenkins.