### PR TITLE
Patch for CASSANDRA-9448

### DIFF
--- a/deletion_test.py
+++ b/deletion_test.py
@@ -61,16 +61,18 @@ class TestDeletion(Tester):
 def memtable_size(node, keyspace, table):
     version = node.get_cassandra_version()
     name = 'MemtableOnHeapSize' if version >= '2.1' else 'MemtableDataSize'
-    return columnfamily_metric(node, keyspace, table, name)
+    return table_metric(node, keyspace, table, name)
 
 
 def memtable_count(node, keyspace, table):
-    return columnfamily_metric(node, keyspace, table, 'MemtableColumnsCount')
+    return table_metric(node, keyspace, table, 'MemtableColumnsCount')
 
 
-def columnfamily_metric(node, keyspace, table, name):
+def table_metric(node, keyspace, table, name):
+    version = node.get_cassandra_version()
+    typeName = "ColumnFamily" if version <= '2.2.X' else 'Table'
     with JolokiaAgent(node) as jmx:
-        mbean = make_mbean('metrics', type='ColumnFamily',
+        mbean = make_mbean('metrics', type=typeName,
                            name=name, keyspace=keyspace, scope=table)
         value = jmx.read_attribute(mbean, 'Value')
 

--- a/jmx_test.py
+++ b/jmx_test.py
@@ -95,15 +95,19 @@ class TestJMX(Tester):
         remove_perf_disable_shared_mem(node1)
         cluster.start(wait_for_binary_proto=True)
 
-        if cluster.version() < "2.1":
+        version = cluster.version()
+        if version < "2.1":
             node1.stress(['-o', 'insert', '--num-keys=10000', '--replication-factor=3'])
         else:
             node1.stress(['write', 'n=10000', '-schema', 'replication(factor=3)'])
 
+        typeName = "ColumnFamily" if version <= '2.2.X' else 'Table'
+        debug('Version {} typeName {}'.format(version, typeName))
+
         # TODO the keyspace and table name are capitalized in 2.0
-        memtable_size = make_mbean('metrics', type='ColumnFamily', keyspace='keyspace1', scope='standard1', name='AllMemtablesHeapSize')
-        disk_size = make_mbean('metrics', type='ColumnFamily', keyspace='keyspace1', scope='standard1', name='LiveDiskSpaceUsed')
-        sstable_count = make_mbean('metrics', type='ColumnFamily', keyspace='keyspace1', scope='standard1', name='LiveSSTableCount')
+        memtable_size = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1', name='AllMemtablesHeapSize')
+        disk_size = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1', name='LiveDiskSpaceUsed')
+        sstable_count = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1', name='LiveSSTableCount')
 
         with JolokiaAgent(node1) as jmx:
             mem_size = jmx.read_attribute(memtable_size, "Value")

--- a/jmxmetrics_test.py
+++ b/jmxmetrics_test.py
@@ -1,58 +1,79 @@
 from dtest import Tester
+from tools import debug
 from jmxutils import JolokiaAgent, make_mbean, remove_perf_disable_shared_mem
 
-# Currently only have attributes that are incrementing.
-# MBEAN_VALUES are expressed in tuple with the first value being the class, 
-# the package (may be tuple), the attribute, and then the value. 
-def MBEAN_VALUES_PRE(version, ks, table):
-    typeName = 'ColumnFamily' if version <= '2.2.X' else 'Table'
 
-    ret = [ ('metrics', typeName, {'name' : 'AllMemtablesLiveDataSize'}, 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'AllMemtablesHeapSize'} , 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'AllMemtablesOffHeapSize'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'BloomFilterDiskSpaceUsed'}, 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'BloomFilterFalsePositives'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'IndexSummaryOffHeapMemoryUsed'}, 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'LiveDiskSpaceUsed'}, 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'LiveSSTableCount'}, 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'MemtableColumnsCount'}, 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'MemtableLiveDataSize'}, 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'MemtableOnHeapSize'}, 'Value', 'MBeanIncrement'),
-            ('metrics', typeName, {'name' : 'MemtableSwitchCount'}, 'Value', 'MBeanIncrement'),
+# We currently only have attributes that are incrementing.
+# MBEAN_VALUES are expressed in tuple with the first value being the class, then the type,
+# a dictionary of arguments for make_mbean(), the attribute, and then the value.
+# MBEAN_VALUES_PRE are values for up to release 2.2, MBEAN_VALUES_POST are for 3.0 and later.
+# In 3.0 "ColumnFamily" has been renamed to "Table" and "Row" to "Partition".
+# However, the old names are also supported for backward compatibility and we test them via
+# the mbean aliases, see begin_test().
+def MBEAN_VALUES_PRE(ks, table):
+    return [('db', 'Caches', {}, 'CounterCacheKeysToSave', 2147483647),
+            ('db', 'Caches', {}, 'CounterCacheSavePeriodInSeconds', 7200),
+            ('db', 'BatchlogManager', {}, 'TotalBatchesReplayed', 0),
+            ('db', 'Caches', {}, 'RowCacheSavePeriodInSeconds', 0),
             ('db', 'IndexSummaries', {}, 'MemoryPoolSizeInMB', 'MBeanIncrement'),
             ('db', 'IndexSummaries', {}, 'IndexIntervals', 'MBeanIncrement'),
-            ('db', 'Caches', {}, 'CounterCacheKeysToSave', 2147483647),
+            ('metrics', 'ColumnFamily', {'name': 'AllMemtablesLiveDataSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'AllMemtablesHeapSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'AllMemtablesOffHeapSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'BloomFilterDiskSpaceUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'BloomFilterFalsePositives'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'IndexSummaryOffHeapMemoryUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'LiveDiskSpaceUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'LiveSSTableCount'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'MemtableColumnsCount'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'MemtableLiveDataSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'MemtableOnHeapSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'MemtableSwitchCount'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'ColumnFamily', {'name': 'MemtableOffHeapSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'PendingCompactions'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'CompressionRatio'}, 'Value', 'MBeanDecrement'),
+            ('metrics', 'ColumnFamily', {'name': 'MaxRowSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'MinRowSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'MeanRowSize'}, 'Value', 'MBeanDecrement'),
+            ('metrics', 'ColumnFamily', {'name': 'RowCacheHit'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'RowCacheHitOutOfRange'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'RowCacheMiss'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'EstimatedRowSizeHistogram', 'keyspace': ks, 'scope': table}, 'Value', 'MBeanEqual'),
+            ('metrics', 'ColumnFamily', {'name': 'EstimatedRowCount', 'keyspace': ks, 'scope': table}, 'Value', 'MBeanEqual')]
+
+
+def MBEAN_VALUES_POST(ks, table):
+    return [('db', 'Caches', {}, 'CounterCacheKeysToSave', 2147483647),
             ('db', 'Caches', {}, 'CounterCacheSavePeriodInSeconds', 7200),
-            ('metrics', typeName, {'name' : 'MemtableOffHeapSize'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'PendingCompactions'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'CompressionRatio'}, 'Value', 'MBeanDecrement'),
             ('db', 'BatchlogManager', {}, 'TotalBatchesReplayed', 0),
-            ('db', 'Caches', {}, 'RowCacheSavePeriodInSeconds', 0)]
+            ('db', 'Caches', {}, 'RowCacheSavePeriodInSeconds', 0),
+            ('db', 'IndexSummaries', {}, 'MemoryPoolSizeInMB', 'MBeanIncrement'),
+            ('db', 'IndexSummaries', {}, 'IndexIntervals', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'AllMemtablesLiveDataSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'AllMemtablesHeapSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'AllMemtablesOffHeapSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'BloomFilterDiskSpaceUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'BloomFilterFalsePositives'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'IndexSummaryOffHeapMemoryUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'LiveDiskSpaceUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'LiveSSTableCount'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'MemtableColumnsCount'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'MemtableLiveDataSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'MemtableOnHeapSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'MemtableSwitchCount'}, 'Value', 'MBeanIncrement'),
+            ('metrics', 'Table', {'name': 'MemtableOffHeapSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'PendingCompactions'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'CompressionRatio'}, 'Value', 'MBeanDecrement'),
+            ('metrics', 'Table', {'name': 'MaxPartitionSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'MinPartitionSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'MeanPartitionSize'}, 'Value', 'MBeanDecrement'),
+            ('metrics', 'Table', {'name': 'PartitionCacheHit'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'PartitionCacheHitOutOfRange'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'PartitionCacheMiss'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'EstimatedPartitionSizeHistogram',  'keyspace': ks, 'scope': table}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'EstimatedPartitionCount', 'keyspace': ks, 'scope': table}, 'Value', 'MBeanEqual')]
 
-    if version <= '2.2.X':
-        ret.extend([
-            ('metrics', typeName, {'name' : 'MaxRowSize'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'MinRowSize'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'MeanRowSize'}, 'Value', 'MBeanDecrement'),
-            ('metrics', typeName, {'name' : 'RowCacheHit'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'RowCacheHitOutOfRange'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'RowCacheMiss'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'EstimatedRowSizeHistogram', 'keyspace' : ks, 'scope' : table}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'EstimatedRowCount', 'keyspace' : ks, 'scope' : table}, 'Value', 'MBeanEqual')])
-    else:
-        ret.extend([
-            ('metrics', typeName, {'name' : 'MaxPartitionSize'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'MinPartitionSize'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'MeanPartitionSize'}, 'Value', 'MBeanDecrement'),
-            ('metrics', typeName, {'name' : 'PartitionCacheHit'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'PartitionCacheHitOutOfRange'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'PartitionCacheMiss'}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'EstimatedPartitionSizeHistogram',  'keyspace' : ks, 'scope' : table}, 'Value', 'MBeanEqual'),
-            ('metrics', typeName, {'name' : 'EstimatedPartitionCount',  'keyspace' : ks, 'scope' : table}, 'Value', 'MBeanEqual')])
 
-    return ret
-
-# MBEAN_VALUES_POST_3.0 = 
 class TestJMXMetrics(Tester):
 
     def __init__(self, *args, **kwargs):
@@ -61,10 +82,14 @@ class TestJMXMetrics(Tester):
     def begin_test(self):
         """
         @jira_ticket CASSANDRA-7436
-        This test measures the values of MBeans before and after running a load. We expect 
-        the values to change a certain way, and thus deem them as 'MBeanEqual','MBeanDecrement', 
+        This test measures the values of MBeans before and after running a load. We expect
+        the values to change a certain way, and thus deem them as 'MBeanEqual','MBeanDecrement',
         'MBeanIncrement', or a constant to experss this expected change. If the value does not reflect
-        this expected change, then it raises an AssertionError. 
+        this expected change, then it raises an AssertionError.
+
+        @jira_ticket CASSANDRA-9448
+        This test also makes sure to cover all metrics that were renamed by CASSANDRA-9448, in post 3.0
+        we also check that the old alias names are the same as the new names.
         """
         cluster = self.cluster
         cluster.populate(1)
@@ -96,23 +121,40 @@ class TestJMXMetrics(Tester):
                         """)
 
         with JolokiaAgent(node) as jmx:
-            mbean_values = MBEAN_VALUES_PRE(cluster.version(), 'keyspace1', 'counter1')
+            debug("Cluster version {}".format(cluster.version()))
+            if cluster.version() <= '2.2.X':
+                mbean_values = MBEAN_VALUES_PRE('keyspace1', 'counter1')
+                mbean_aliases = None
+            else:
+                mbean_values = MBEAN_VALUES_POST('keyspace1', 'counter1')
+                mbean_aliases = MBEAN_VALUES_PRE('keyspace1', 'counter1')
+
             before = []
-            mbeans = []
-            errors = []
-            for package, bean, attribute, expected in MBEAN_VALUES:
+            for package, bean, bean_args, attribute, expected in mbean_values:
                 mbean = make_mbean(package, type=bean, **bean_args)
-                mbeans.append(mbean)
+                debug(mbean)
                 before.append(jmx.read_attribute(mbean, attribute))
+
+            if mbean_aliases:
+                alias_counter = 0
+                for package, bean, bean_args, attribute, expected in mbean_aliases:
+                    mbean = make_mbean(package, type=bean, **bean_args)
+                    debug(mbean)
+                    self.assertEqual(before[alias_counter], jmx.read_attribute(mbean, attribute))
+                    alias_counter += 1
 
             if cluster.version() < "2.1":
                 node.stress(['-o', 'insert', '-n', '100000', '-p', '7100'])
-            else: 
+            else:
                 node.stress(['write', 'n=100K', '-port jmx=7100'])
 
+            errors = []
+            after = []
             attr_counter = 0
             for package, bean, bean_args, attribute, expected in mbean_values:
-                a_value = jmx.read_attribute(mbeans[attr_counter], attribute)
+                mbean = make_mbean(package, type=bean, **bean_args)
+                a_value = jmx.read_attribute(mbean, attribute)
+                after.append(a_value)
                 b_value = before[attr_counter]
                 if expected == 'MBeanIncrement':
                     if b_value >= a_value:
@@ -134,5 +176,9 @@ class TestJMXMetrics(Tester):
 
             self.assertEqual(len(errors), 0, "\n" + "\n".join(errors))
 
-
-
+            if mbean_aliases:
+                alias_counter = 0
+                for package, bean, bean_args, attribute, expected in mbean_aliases:
+                    mbean = make_mbean(package, type=bean, **bean_args)
+                    self.assertEqual(after[alias_counter], jmx.read_attribute(mbean, attribute))
+                    alias_counter += 1

--- a/jmxmetrics_test.py
+++ b/jmxmetrics_test.py
@@ -67,9 +67,9 @@ def MBEAN_VALUES_POST(ks, table):
             ('metrics', 'Table', {'name': 'MaxPartitionSize'}, 'Value', 'MBeanEqual'),
             ('metrics', 'Table', {'name': 'MinPartitionSize'}, 'Value', 'MBeanEqual'),
             ('metrics', 'Table', {'name': 'MeanPartitionSize'}, 'Value', 'MBeanDecrement'),
-            ('metrics', 'Table', {'name': 'PartitionCacheHit'}, 'Value', 'MBeanEqual'),
-            ('metrics', 'Table', {'name': 'PartitionCacheHitOutOfRange'}, 'Value', 'MBeanEqual'),
-            ('metrics', 'Table', {'name': 'PartitionCacheMiss'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'RowCacheHit'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'RowCacheHitOutOfRange'}, 'Value', 'MBeanEqual'),
+            ('metrics', 'Table', {'name': 'RowCacheMiss'}, 'Value', 'MBeanEqual'),
             ('metrics', 'Table', {'name': 'EstimatedPartitionSizeHistogram',  'keyspace': ks, 'scope': table}, 'Value', 'MBeanEqual'),
             ('metrics', 'Table', {'name': 'EstimatedPartitionCount', 'keyspace': ks, 'scope': table}, 'Value', 'MBeanEqual')]
 
@@ -158,20 +158,20 @@ class TestJMXMetrics(Tester):
                 b_value = before[attr_counter]
                 if expected == 'MBeanIncrement':
                     if b_value >= a_value:
-                        errors.append(mbeans[attr_counter] + " has a before value of " + str(b_value) + " and after value of " + str(a_value) + " and did not increment" + "\n")
+                        errors.append(mbean + " has a before value of " + str(b_value) + " and after value of " + str(a_value) + " and did not increment" + "\n")
                 elif expected == 'MBeanDecrement':
                     if b_value <= a_value:
-                        errors.append(mbeans[attr_counter] + " has a before value of " + str(b_value) + " and after value of " + str(a_value) + " and did not decrement" + "\n")
+                        errors.append(mbean + " has a before value of " + str(b_value) + " and after value of " + str(a_value) + " and did not decrement" + "\n")
                 elif expected == 'MBeanEqual':
                     if b_value != a_value:
-                        errors.append(mbeans[attr_counter] + " has a before value of " + str(b_value) + " and after value of " + str(a_value) + ", which are not equal" + "\n")
+                        errors.append(mbean + " has a before value of " + str(b_value) + " and after value of " + str(a_value) + ", which are not equal" + "\n")
                 elif expected == 'MBeanZero':
                     if not (b_value == 0 and a_value == 0):
-                        errors.append(mbeans[attr_counter] + " has a before value of " + str(b_value) + " and after value of " + str(a_value) + " and they do not equal zero" + "\n")
+                        errors.append(mbean + " has a before value of " + str(b_value) + " and after value of " + str(a_value) + " and they do not equal zero" + "\n")
                 # If expected is none of the above, then expected should be a number.
                 else:
                     if a_value != expected:
-                        errors.append(mbeans[attr_counter] + " has an after value of " + str(a_value) + " which does not equal " + str(expected) + "\n")
+                        errors.append(mbean + " has an after value of " + str(a_value) + " which does not equal " + str(expected) + "\n")
                 attr_counter += 1
 
             self.assertEqual(len(errors), 0, "\n" + "\n".join(errors))

--- a/jmxmetrics_test.py
+++ b/jmxmetrics_test.py
@@ -1,37 +1,58 @@
 from dtest import Tester
 from jmxutils import JolokiaAgent, make_mbean, remove_perf_disable_shared_mem
 
-# Currently only have attributes that are incrementing. 
+# Currently only have attributes that are incrementing.
 # MBEAN_VALUES are expressed in tuple with the first value being the class, 
 # the package (may be tuple), the attribute, and then the value. 
-MBEAN_VALUES_PRE = [('metrics', ('ColumnFamily', 'AllMemtablesLiveDataSize'), 'Value', 'MBeanIncrement'),
-                        ('metrics', ('ColumnFamily', 'AllMemtablesHeapSize'), 'Value', 'MBeanIncrement'),
-                        ('metrics', ('ColumnFamily', 'AllMemtablesOffHeapSize'), 'Value', 'MBeanEqual'),
-                        ('metrics', ('ColumnFamily', 'BloomFilterDiskSpaceUsed'), 'Value', 'MBeanIncrement'),
-                        ('metrics', ('ColumnFamily', 'BloomFilterFalsePositives'), 'Value', 'MBeanEqual'),
-                        ('metrics', ('ColumnFamily', 'IndexSummaryOffHeapMemoryUsed'), 'Value', 'MBeanIncrement'),
-                        ('metrics', ('ColumnFamily', 'LiveDiskSpaceUsed'), 'Value', 'MBeanIncrement'),
-                        ('metrics', ('ColumnFamily', 'LiveSSTableCount'), 'Value', 'MBeanIncrement'), 
-                        ('metrics', ('ColumnFamily', 'MemtableColumnsCount'), 'Value', 'MBeanIncrement'),
-                        ('metrics', ('ColumnFamily', 'MemtableLiveDataSize'), 'Value', 'MBeanIncrement'),
-                        ('metrics', ('ColumnFamily', 'MemtableOnHeapSize'), 'Value', 'MBeanIncrement'),
-                        ('metrics', ('ColumnFamily', 'MemtableSwitchCount'), 'Value', 'MBeanIncrement'),
-                        ('db', 'IndexSummaries', 'MemoryPoolSizeInMB', 'MBeanIncrement'),
-                        ('db', 'IndexSummaries', 'IndexIntervals', 'MBeanIncrement'),
-                        ('db', 'Caches', 'CounterCacheKeysToSave', 2147483647),
-                        ('db', 'Caches', 'CounterCacheSavePeriodInSeconds', 7200),
-                        ('metrics', ('ColumnFamily', 'MaxRowSize'), 'Value', 'MBeanEqual'),
-                        ('metrics', ('ColumnFamily', 'MemtableOffHeapSize'), 'Value', 'MBeanEqual'),
-                        ('metrics', ('ColumnFamily', 'MinRowSize'), 'Value', 'MBeanEqual'),
-                        ('metrics', ('ColumnFamily', 'PendingCompactions'), 'Value', 'MBeanEqual'),
-                        ('metrics', ('ColumnFamily', 'RowCacheHit'), 'Value', 'MBeanEqual'),
-                        ('metrics', ('ColumnFamily', 'CompressionRatio'), 'Value', 'MBeanDecrement'),
-                        ('metrics', ('ColumnFamily', 'MeanRowSize'), 'Value', 'MBeanDecrement'),
-                        ('db', 'BatchlogManager', 'TotalBatchesReplayed', 0),
-                        ('db', 'Caches', 'RowCacheSavePeriodInSeconds', 0)]
+def MBEAN_VALUES_PRE(version, ks, table):
+    typeName = 'ColumnFamily' if version <= '2.2.X' else 'Table'
+
+    ret = [ ('metrics', typeName, {'name' : 'AllMemtablesLiveDataSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'AllMemtablesHeapSize'} , 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'AllMemtablesOffHeapSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'BloomFilterDiskSpaceUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'BloomFilterFalsePositives'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'IndexSummaryOffHeapMemoryUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'LiveDiskSpaceUsed'}, 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'LiveSSTableCount'}, 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'MemtableColumnsCount'}, 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'MemtableLiveDataSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'MemtableOnHeapSize'}, 'Value', 'MBeanIncrement'),
+            ('metrics', typeName, {'name' : 'MemtableSwitchCount'}, 'Value', 'MBeanIncrement'),
+            ('db', 'IndexSummaries', {}, 'MemoryPoolSizeInMB', 'MBeanIncrement'),
+            ('db', 'IndexSummaries', {}, 'IndexIntervals', 'MBeanIncrement'),
+            ('db', 'Caches', {}, 'CounterCacheKeysToSave', 2147483647),
+            ('db', 'Caches', {}, 'CounterCacheSavePeriodInSeconds', 7200),
+            ('metrics', typeName, {'name' : 'MemtableOffHeapSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'PendingCompactions'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'CompressionRatio'}, 'Value', 'MBeanDecrement'),
+            ('db', 'BatchlogManager', {}, 'TotalBatchesReplayed', 0),
+            ('db', 'Caches', {}, 'RowCacheSavePeriodInSeconds', 0)]
+
+    if version <= '2.2.X':
+        ret.extend([
+            ('metrics', typeName, {'name' : 'MaxRowSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'MinRowSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'MeanRowSize'}, 'Value', 'MBeanDecrement'),
+            ('metrics', typeName, {'name' : 'RowCacheHit'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'RowCacheHitOutOfRange'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'RowCacheMiss'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'EstimatedRowSizeHistogram', 'keyspace' : ks, 'scope' : table}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'EstimatedRowCount', 'keyspace' : ks, 'scope' : table}, 'Value', 'MBeanEqual')])
+    else:
+        ret.extend([
+            ('metrics', typeName, {'name' : 'MaxPartitionSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'MinPartitionSize'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'MeanPartitionSize'}, 'Value', 'MBeanDecrement'),
+            ('metrics', typeName, {'name' : 'PartitionCacheHit'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'PartitionCacheHitOutOfRange'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'PartitionCacheMiss'}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'EstimatedPartitionSizeHistogram',  'keyspace' : ks, 'scope' : table}, 'Value', 'MBeanEqual'),
+            ('metrics', typeName, {'name' : 'EstimatedPartitionCount',  'keyspace' : ks, 'scope' : table}, 'Value', 'MBeanEqual')])
+
+    return ret
 
 # MBEAN_VALUES_POST_3.0 = 
-
 class TestJMXMetrics(Tester):
 
     def __init__(self, *args, **kwargs):
@@ -75,15 +96,12 @@ class TestJMXMetrics(Tester):
                         """)
 
         with JolokiaAgent(node) as jmx:
+            mbean_values = MBEAN_VALUES_PRE(cluster.version(), 'keyspace1', 'counter1')
             before = []
             mbeans = []
             errors = []
-            for package, bean, attribute, expected in MBEAN_VALUES_PRE:
-                # In the case that the file name is longer, then we put it in the form of tuple in bean.
-                if type(bean) == tuple:
-                    mbean = make_mbean(package, type = bean[0], name = bean[1])
-                else:
-                    mbean = make_mbean(package, bean)
+            for package, bean, attribute, expected in MBEAN_VALUES:
+                mbean = make_mbean(package, type=bean, **bean_args)
                 mbeans.append(mbean)
                 before.append(jmx.read_attribute(mbean, attribute))
 
@@ -93,7 +111,7 @@ class TestJMXMetrics(Tester):
                 node.stress(['write', 'n=100K', '-port jmx=7100'])
 
             attr_counter = 0
-            for package, bean, attribute, expected in MBEAN_VALUES_PRE:
+            for package, bean, bean_args, attribute, expected in mbean_values:
                 a_value = jmx.read_attribute(mbeans[attr_counter], attribute)
                 b_value = before[attr_counter]
                 if expected == 'MBeanIncrement':


### PR DESCRIPTION
This is a patch for [CASSANDRA-9448] (https://issues.apache.org/jira/browse/CASSANDRA-9448) to support renaming of metrics in 3.0. I also modified the tests for CASSANDRA-7436, P.R. no 335.

It should be merged only when CASSANDRA-9448 is committed, else tests on trunk will fail.