### PR TITLE
Add a small pause when waiting for inbound pages

### DIFF
--- a/paging_test.py
+++ b/paging_test.py
@@ -114,6 +114,8 @@ class PageFetcher(object):
         while time.time() < expiry:
             if self.requested_pages == (self.retrieved_pages + self.retrieved_empty_pages):
                 return self
+            # small wait so we don't need excess cpu to keep checking
+            time.sleep(0.1)
 
         raise RuntimeError(
                 "Requested pages were not delivered before timeout." + \


### PR DESCRIPTION
@EnigmaCurry spotted this problem yesterday, we're probably needlessly consuming cpu
while waiting for something that might take a second or two.