### PR TITLE
re-includes tests from replace_address_test

### DIFF
--- a/conf/cassandra-2.2_test-select.cfg
+++ b/conf/cassandra-2.2_test-select.cfg
@@ -3,12 +3,3 @@
 upgrade_through_versions_test.py
   # workaround for https://github.com/EnigmaCurry/nose-test-select/issues/1
   tools.py:TestUpgrade_from_*
-# https://github.com/riptano/cassandra-dtest/issues/251
-#   replace_with_reset_resume_state_test frequently hangs at:
-#     node4.start(jvm_args=["-Dcassandra.replace_address_first_boot=127.0.0.3"])
-replace_address_test.py:TestReplaceAddress.replace_with_reset_resume_state_test
-  tools.py:TestReplaceAddress.replace_with_reset_resume_state_test
-#   resumable_replace_test frequently hangs at:
-#     same line as above..
-replace_address_test.py:TestReplaceAddress.resumable_replace_test
-  tools.py:TestReplaceAddress.resumable_replace_test

--- a/conf/trunk_test-select.cfg
+++ b/conf/trunk_test-select.cfg
@@ -3,12 +3,3 @@
 upgrade_through_versions_test.py
   # workaround for https://github.com/EnigmaCurry/nose-test-select/issues/1
   tools.py:TestUpgrade_from_*
-# https://github.com/riptano/cassandra-dtest/issues/251
-#   replace_with_reset_resume_state_test frequently hangs at:
-#     node4.start(jvm_args=["-Dcassandra.replace_address_first_boot=127.0.0.3"])
-replace_address_test.py:TestReplaceAddress.replace_with_reset_resume_state_test
-  tools.py:TestReplaceAddress.replace_with_reset_resume_state_test
-#   resumable_replace_test frequently hangs at:
-#     same line as above..
-replace_address_test.py:TestReplaceAddress.resumable_replace_test
-  tools.py:TestReplaceAddress.resumable_replace_test


### PR DESCRIPTION
At least running locally, they succeed now, as discussed over in #251.