### PR TITLE
Add travis config with linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install pep8 flake8
+script:
+  # we want pyflakes to check all files for unused imports only
+  # we use flake8 because it allows us to ignore other warnings
+  # exclude the thrift directories - they contain auto-generated code
+  - flake8 --ignore=E,W,F811,F812,F821,F822,F823,F831,F841,N8,C9 --exclude=thrift_bindings,cassandra-thrift .
+  # feed changed lines with no context around them to pep8
+  # I know we don't enforce line length but if you introduce
+  # 200-char lines you are doing something terribly wrong
+  - git diff master -U0 | pep8 --diff --max-line-length=200

--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -6,14 +6,10 @@ import datetime
 from decimal import Decimal
 import locale
 import os
-import random
 import sys
 from tempfile import NamedTemporaryFile
-import time
-import unittest
 from uuid import uuid1, uuid4
 
-import cassandra
 from cassandra.concurrent import execute_concurrent_with_args
 
 from dtest import debug, Tester, canReuseCluster

--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -1,23 +1,23 @@
 # coding: utf-8
 import codecs
-from contextlib import contextmanager
 import csv
 import datetime
-from decimal import Decimal
 import locale
 import os
 import sys
+from contextlib import contextmanager
+from decimal import Decimal
 from tempfile import NamedTemporaryFile
 from uuid import uuid1, uuid4
 
 from cassandra.concurrent import execute_concurrent_with_args
 
-from dtest import debug, Tester, canReuseCluster
+from cqlsh_tools import (DummyColorMap, assert_csvs_items_equal, csv_rows,
+                         monkeypatch_driver, random_list,
+                         strip_timezone_if_time_string, unmonkeypatch_driver,
+                         write_rows_to_csv)
+from dtest import Tester, canReuseCluster, debug
 from tools import rows_to_list, since
-from cqlsh_tools import (csv_rows, random_list, DummyColorMap,
-                         assert_csvs_items_equal, write_rows_to_csv,
-                         strip_timezone_if_time_string, monkeypatch_driver,
-                         unmonkeypatch_driver)
 
 DEFAULT_FLOAT_PRECISION = 5  # magic number copied from cqlsh script
 DEFAULT_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'  # based on cqlsh script; timezone stripped

--- a/cqlsh_tests/cqlsh_tools.py
+++ b/cqlsh_tests/cqlsh_tools.py
@@ -3,9 +3,8 @@ import datetime
 import random
 import time
 
-from nose.tools import assert_items_equal
-
 import cassandra
+from nose.tools import assert_items_equal
 
 
 class DummyColorMap(object):

--- a/cqlsh_tests/cqlsh_tools.py
+++ b/cqlsh_tests/cqlsh_tools.py
@@ -1,6 +1,5 @@
 import csv
 import datetime
-from datetime import tzinfo, timedelta
 import random
 import time
 

--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -1,6 +1,8 @@
-from dtest import Tester, DISABLE_VNODES
-from tools import require, create_c1c2_table, insert_c1c2, query_c1c2
 from cassandra import ConsistencyLevel
+
+from dtest import DISABLE_VNODES, Tester
+from tools import create_c1c2_table, insert_c1c2, query_c1c2, require
+
 
 @require("9035")
 class TestHintedHandoff(Tester):

--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -1,4 +1,4 @@
-from dtest import Tester, debug, DISABLE_VNODES
+from dtest import Tester, DISABLE_VNODES
 from tools import require, create_c1c2_table, insert_c1c2, query_c1c2
 from cassandra import ConsistencyLevel
 

--- a/thrift_tests.py
+++ b/thrift_tests.py
@@ -8,7 +8,17 @@ from thrift.Thrift import TApplicationException
 from dtest import Tester, NUM_TOKENS, DISABLE_VNODES
 from tools import since
 from thrift_bindings.v22 import Cassandra
-from thrift_bindings.v22.Cassandra import *
+from thrift_bindings.v22.Cassandra import (CfDef, Column, ColumnDef,
+                                           ColumnOrSuperColumn, ColumnParent,
+                                           ColumnPath, ColumnSlice,
+                                           ConsistencyLevel, CounterColumn,
+                                           Deletion, IndexExpression,
+                                           IndexOperator, IndexType,
+                                           InvalidRequestException, KeyRange,
+                                           KeySlice, KsDef, MultiSliceRequest,
+                                           Mutation, NotFoundException,
+                                           SlicePredicate, SliceRange,
+                                           SuperColumn)
 
 def get_thrift_client(host='127.0.0.1', port=9160):
     socket = TSocket.TSocket(host, port)
@@ -1071,7 +1081,7 @@ class TestMutations(ThriftTester):
                                               columns=[Column(_i64(6), 'value6', 0), Column(_i64(7), 'value7', 0)])]
 
         super_columns = [result.super_column for result in _big_slice('key1', ColumnParent('Super1'))]
-        assert super_columns == super_columns_expected, actual
+        assert super_columns == super_columns_expected, super_columns
 
         # Test resurrection.  First, re-insert the value w/ older timestamp,
         # and make sure it stays removed:

--- a/thrift_tests.py
+++ b/thrift_tests.py
@@ -1,12 +1,13 @@
-import time, uuid, re, struct
+import re
+import struct
+import time
+import uuid
 
-from thrift.transport import TTransport
-from thrift.transport import TSocket
 from thrift.protocol import TBinaryProtocol
 from thrift.Thrift import TApplicationException
+from thrift.transport import TSocket, TTransport
 
-from dtest import Tester, NUM_TOKENS, DISABLE_VNODES
-from tools import since
+from dtest import DISABLE_VNODES, NUM_TOKENS, Tester
 from thrift_bindings.v22 import Cassandra
 from thrift_bindings.v22.Cassandra import (CfDef, Column, ColumnDef,
                                            ColumnOrSuperColumn, ColumnParent,
@@ -19,6 +20,8 @@ from thrift_bindings.v22.Cassandra import (CfDef, Column, ColumnDef,
                                            Mutation, NotFoundException,
                                            SlicePredicate, SliceRange,
                                            SuperColumn)
+from tools import since
+
 
 def get_thrift_client(host='127.0.0.1', port=9160):
     socket = TSocket.TSocket(host, port)


### PR DESCRIPTION
![](http://makeameme.org/media/created/brace-yourselves-973uhu.jpg)

(Thank you, @knifewine)

This adds a travis configuration file to the repo. It'll run `pep8` on changed lines, so idiomatic-ness will only improve.

It also runs `pyflakes` via `flake8` on all files. It only reports on importing errors, since @ptnapoleon fixed all those and all of this type of error found should be new.

This PR also removes unused imports and `from module import *`, as found by `pyflakes`, so we don't start off with failing linters. It also cleans up the imports with `isort` because why not?

For the errors we've ignored and for PEP8 checking on the entire codebase, we can take it in chunks, or just improve things as we change tests, with the help of this linting.