### PR TITLE
Remove redefinition of is_win function

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -80,9 +80,6 @@ def retry_till_success(fun, *args, **kwargs):
                 # brief pause before next attempt
                 time.sleep(0.25)
 
-def is_win():
-    return True if sys.platform == "cygwin" or sys.platform == "win32" else False
-
 class Runner(threading.Thread):
     def __init__(self, func):
         threading.Thread.__init__(self)


### PR DESCRIPTION
We're already importing this from ccmlib.common here. In
zero tests do we ever use the dtest implementation, only ever the
ccmlib one. They're identical code.

@mambocab to review