### PR TITLE
Fix failing tests 9064

### DIFF
--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -600,10 +600,9 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
         self.assertIn("'max_threshold': '100'", stdout)
 
     def get_keyspace_output(self):
-        return \
-            "CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;" + \
-            self.get_test_table_output() + \
-            self.get_users_table_output()
+        return ("CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;" +
+                self.get_test_table_output() +
+                self.get_users_table_output())
 
     def get_test_table_output(self, has_val=True, has_val_idx=True):
         if has_val:

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -613,7 +613,7 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
             AND bloom_filter_fp_chance = 0.01
             AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
             AND comment = ''
-            AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+            AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
             AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
             AND dclocal_read_repair_chance = 0.1
             AND default_time_to_live = 0
@@ -640,7 +640,7 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
         ) WITH bloom_filter_fp_chance = 0.01
             AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
             AND comment = ''
-            AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+            AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
             AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
             AND dclocal_read_repair_chance = 0.1
             AND default_time_to_live = 0


### PR DESCRIPTION
`test_describe` started failing (I assume) because of changes to the Python driver introduced in [CASSANDRA-9064](https://issues.apache.org/jira/browse/CASSANDRA-9064) -- the test assumed that the `min_threshold` and `max_threshold` would always be printed, but they aren't if they use the default values.

I also added a test for the other case, where the thresholds are set to non-default values, to make sure they are printed.

I also removed a few line continuations because I think they're gross.

The tests still all pass on `cassandra-2.{0,1,2}` and trunk, except for `cqlsh_tests/cqlsh_tests.py:TestCqlsh.test_describe_round_trip`, which still fails on 2.0 because the fix for 9064 wasn't applied there.