### PR TITLE
Remove sstable2json tests

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -16,6 +16,7 @@ class TestCompaction(Tester):
         kwargs['cluster_options'] = {'start_rpc': 'true'}
         Tester.__init__(self, *args, **kwargs)
 
+    @since('0', '2.2.X')
     def compaction_delete_test(self):
         """
         Test that executing a delete properly tombstones a row.

--- a/json_tools_test.py
+++ b/json_tools_test.py
@@ -2,8 +2,10 @@ import os
 import tempfile
 
 from dtest import Tester, debug
-from tools import rows_to_list
+from tools import rows_to_list, since
 
+
+@since('0', '2.2.X')
 class TestJson(Tester):
 
     def json_tools_test(self):

--- a/json_tools_test.py
+++ b/json_tools_test.py
@@ -1,6 +1,8 @@
+import os
+import tempfile
+
 from dtest import Tester, debug
 from tools import rows_to_list
-import tempfile, os
 
 class TestJson(Tester):
 

--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -16,7 +16,7 @@ class TestOfflineTools(Tester):
     def sstablelevelreset_test(self):
         """
         Insert data and call sstablelevelreset on a series of
-        tables. Confirm level is reset to 0 using sstable2json to read tables.
+        tables. Confirm level is reset to 0 using its output.
         Test a variety of possible errors and ensure response is resonable.
         @since 2.1.5
         @jira_ticket CASSANDRA-7614


### PR DESCRIPTION
This deals with problems related to `sstable2json`. #361 is followup for some of it. The justification for each commit is in its message.