### PR TITLE
Removed @require tags for some committed tickets

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -225,7 +225,6 @@ class TestCompaction(Tester):
                 time.sleep(5)
                 cluster.start(wait_for_binary_proto=True)
 
-    @require("9643")
     @since("2.1")
     def large_compaction_warning_test(self):
         """
@@ -248,7 +247,7 @@ class TestCompaction(Tester):
         node.flush()
 
         node.nodetool('compact ks large')
-        node.watch_log_for('Compacting large row ks/large:user \(\d+ bytes\) incrementally', from_mark=mark)
+        node.watch_log_for('Compacting large partition ks/large:user \(\d+ bytes\)', from_mark=mark, timeout=180)
 
     def skip_if_no_major_compaction(self):
         if self.cluster.version() < '2.2' and self.strategy == 'LeveledCompactionStrategy':

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -5,7 +5,7 @@ import time
 
 from assertions import assert_almost_equal, assert_none, assert_one
 from dtest import Tester, debug
-from tools import require, since
+from tools import since
 
 
 class TestCompaction(Tester):

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -1060,7 +1060,6 @@ Tracing session:""")
 Warnings :
 Unlogged batch covering 2 partitions detected against table [client_warnings.test]. You should use a logged batch for atomicity, or asynchronous writes for performance.""")
 
-    @require("9601")
     @since('2.2')
     def test_connect_timeout(self):
         """

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -17,7 +17,7 @@ from assertions import assert_all, assert_none
 from ccmlib import common
 from cqlsh_tools import monkeypatch_driver, unmonkeypatch_driver
 from dtest import Tester, debug
-from tools import create_c1c2_table, insert_c1c2, require, rows_to_list, since
+from tools import create_c1c2_table, insert_c1c2, rows_to_list, since
 
 
 class TestCqlsh(Tester):

--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -3,6 +3,7 @@ from cassandra import ConsistencyLevel
 from dtest import DISABLE_VNODES, Tester
 from tools import create_c1c2_table, insert_c1c2, query_c1c2, since
 
+
 @since('3.0')
 class TestHintedHandoff(Tester):
 

--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -1,10 +1,9 @@
 from cassandra import ConsistencyLevel
 
 from dtest import DISABLE_VNODES, Tester
-from tools import create_c1c2_table, insert_c1c2, query_c1c2, require
+from tools import create_c1c2_table, insert_c1c2, query_c1c2, since
 
-
-@require("9035")
+@since('3.0')
 class TestHintedHandoff(Tester):
 
     def _start_two_node_cluster(self, config_options=None):


### PR DESCRIPTION
I also changed the warning message of 9643, which was modified during commit. 

hinted_handoff.py will fail due to an NPE in the logs but this is not related to 9035 at all. This NPE is happening for other dtests too.