### PR TITLE
adds tools for running tests with @require

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -40,7 +40,7 @@ NUM_TOKENS = os.environ.get('NUM_TOKENS', '256')
 RECORD_COVERAGE = os.environ.get('RECORD_COVERAGE', '').lower() in ('yes', 'true')
 REUSE_CLUSTER = os.environ.get('REUSE_CLUSTER', '').lower() in ('yes', 'true')
 SILENCE_DRIVER_ON_SHUTDOWN = os.environ.get('SILENCE_DRIVER_ON_SHUTDOWN', 'true').lower() in ('yes', 'true')
-
+IGNORE_REQUIRE = os.environ.get('IGNORE_REQUIRE', '').lower() in ('yes', 'true')
 
 CURRENT_TEST = ""
 


### PR DESCRIPTION
This adds some new functionality surrounding the `@require` decorator. If you set the environment variable `IGNORE_REQUIRE` to `'yes'` or `'true'`, then `@require`d tests will run as though there were no decorator. It also modifies `@require`d tests with the `attr` decorator, so you can select them with `nosetests -a required`. 

Unfortunately, they'll still be skipped if you don't set `IGNORE_REQUIRE`; to have these play together nicely would require digging into the behavior of plugins, which is out of scope right now.

@aboudreault and/or @shawnkumar to review. Asking for extra-careful review of the docstring changes -- can you think of a better way to document this?