### PR TITLE
2.2 flakes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,6 +74,10 @@ will often need to modify them in some fashion at some later point:
 
         sudo apt-get install python-nose
 
+* flaky
+
+		sudo pip install flaky
+
 * cassandra
 
         cd ~/git/cstar
@@ -104,6 +108,11 @@ will often need to modify them in some fashion at some later point:
 
          cd ~/git/cstar/cassandra-dtest
          nosetests
+
+* Run the full dtest suite, retrying tests decorated with `flaky` (see [the `flaky` plugin](https://github.com/box/flaky) for more documentation):
+
+         cd ~/git/cstar/cassandra-dtest
+         nosetests --with-flaky
 
 * Run a single dtest, printing debug info, stopping at the first error encountered (if any):
 

--- a/jmx_test.py
+++ b/jmx_test.py
@@ -1,12 +1,14 @@
+from flaky import flaky
+
 from dtest import Tester, debug
 from jmxutils import JolokiaAgent, make_mbean, remove_perf_disable_shared_mem
-from tools import require, since
+from tools import since
 
 
 class TestJMX(Tester):
 
     @since('2.1')
-    @require(9741)  # flaps on 2.2
+    @flaky  # flaps on 2.2
     def cfhistograms_test(self):
         """
         Test cfhistograms on large and small datasets

--- a/jmx_test.py
+++ b/jmx_test.py
@@ -1,10 +1,12 @@
 from dtest import Tester, debug
-from jmxutils import make_mbean, JolokiaAgent, remove_perf_disable_shared_mem
-from tools import since
+from jmxutils import JolokiaAgent, make_mbean, remove_perf_disable_shared_mem
+from tools import require, since
+
 
 class TestJMX(Tester):
 
     @since('2.1')
+    @require(9741)  # flaps on 2.2
     def cfhistograms_test(self):
         """
         Test cfhistograms on large and small datasets

--- a/repair_test.py
+++ b/repair_test.py
@@ -5,7 +5,7 @@ from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
 from dtest import Tester, debug
-from tools import insert_c1c2, no_vnodes, query_c1c2, since, require
+from tools import insert_c1c2, no_vnodes, query_c1c2, require, since
 
 
 class TestRepair(Tester):

--- a/repair_test.py
+++ b/repair_test.py
@@ -301,7 +301,7 @@ class TestRepair(Tester):
         node2.flush()
         node2.stop()
         insert_c1c2(cursor, 1000, ConsistencyLevel.THREE)
-        node2.start(wait_other_notice=True)
+        node2.start(wait_for_binary_proto=True, wait_other_notice=True)
         for i in xrange(1001, 2001):
             insert_c1c2(cursor, i, ConsistencyLevel.ALL)
 


### PR DESCRIPTION
This deals with a couple flaky tests on 2.2. See the commit messages for more details.

I'm not confident that the new `wait_on_binary_proto` will make the test stop flaking, as I noted in the commit message for that change -- I don't understand the interaction between `wait_for_binary_proto` and `wait_other_notice` well enough to say. However, adding `wait_for_binary_proto` can't hurt, and it might help. We'll figure it out as we keep an eye on flaky dtests in the coming weeks.