### PR TITLE
Flaky repair test

### DIFF
--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -1,13 +1,15 @@
-from dtest import Tester, debug
-from tools import insert_c1c2, since
+import os
+import time
+from re import findall
+
 from cassandra import ConsistencyLevel
 from ccmlib.node import Node
-from re import findall
-import time
-import os
-from assertions import assert_one, assert_almost_equal
 from nose.plugins.attrib import attr
+
+from assertions import assert_almost_equal, assert_one
+from dtest import Tester, debug
 from flaky import flaky
+from tools import insert_c1c2, since
 
 
 @since('2.1')

--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -7,6 +7,7 @@ import time
 import os
 from assertions import assert_one, assert_almost_equal
 from nose.plugins.attrib import attr
+from flaky import flaky
 
 
 @since('2.1')
@@ -203,6 +204,7 @@ class TestIncRepair(Tester):
 
     @since('2.1')
     @attr('long')
+    @flaky  # see CASSANDRA-9752
     def multiple_subsequent_repair_test(self):
         """
         Covers CASSANDRA-8366


### PR DESCRIPTION
One of the repair tests is flaky on 2.2 (see [this jira ticket](https://issues.apache.org/jira/browse/CASSANDRA-9752)). This decorates it as such.

Unfortunately, it also seems to fail hard on trunk. If we merge this PR, it will be run twice on trunk until it's fixed. Are we ok with that? This is marked with `@attr(long)`, so I take it it's a long-running test. I think @mshuler is the person to answer that question.