### PR TITLE
fixes up assertions for compaction tests

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -185,7 +185,8 @@ class TestCompaction(Tester):
         avgthroughput = re.match(throughput_pattern, stringline).group(1).strip()
         debug(avgthroughput)
 
-        assert_almost_equal(float(threshold), float(avgthroughput), error=0.1)
+        self.assertGreaterEqual(float(threshold), float(avgthroughput))
+        assert_almost_equal(float(threshold), float(avgthroughput), error=0.2)
 
     def compaction_strategy_switching_test(self):
         """Ensure that switching strategies does not result in problems.


### PR DESCRIPTION
This test has been flapping on CI. From what I've seen, it's always below the threshhold and greater than 4, so this should reduce failure.

Example failures here:

http://cassci.datastax.com/view/trunk/job/trunk_dtest/323/testReport/junit/compaction_test/TestCompaction_with_DateTieredCompactionStrategy/compaction_throughput_test/
http://cassci.datastax.com/view/trunk/job/trunk_dtest/318/testReport/junit/compaction_test/TestCompaction_with_DateTieredCompactionStrategy/compaction_throughput_test/
http://cassci.datastax.com/view/trunk/job/trunk_dtest/314/testReport/junit/compaction_test/TestCompaction_with_DateTieredCompactionStrategy/compaction_throughput_test/
http://cassci.datastax.com/view/trunk/job/trunk_dtest/lastCompletedBuild/testReport/junit/compaction_test/TestCompaction_with_DateTieredCompactionStrategy/compaction_throughput_test/

I added the `assertGreaterEqual` assertion so that I could expand the acceptable error for the `assert_almost_equal` without allowing values way over the threshold.

@krummas could you please have a quick look at this to make sure the test is still valid?