### PR TITLE
adds require to failing tests mentioned in 9722

### DIFF
--- a/thrift_tests.py
+++ b/thrift_tests.py
@@ -677,6 +677,7 @@ class TestMutations(ThriftTester):
                     for key in keys:
                         _assert_no_columnpath(key, ColumnPath(column_family, super_column=sc.name, column=c.name))
 
+    @require(9722)
     def test_batch_mutate_remove_super_columns_with_none_given_underneath(self):
         _set_keyspace('Keyspace1')
 
@@ -734,6 +735,7 @@ class TestMutations(ThriftTester):
             for key in keys:
                 _assert_no_columnpath(key, ColumnPath('Super1', super_column=sc.name))
 
+    @require(9722)
     def test_batch_mutate_remove_slice_standard(self):
         _set_keyspace('Keyspace1')
 
@@ -755,6 +757,7 @@ class TestMutations(ThriftTester):
         _assert_no_columnpath('key', ColumnPath('Standard1', column='c4'))
         _assert_columnpath_exists('key', ColumnPath('Standard1', column='c5'))
 
+    @require(9722)
     def test_batch_mutate_remove_slice_of_entire_supercolumns(self):
         _set_keyspace('Keyspace1')
 
@@ -781,6 +784,7 @@ class TestMutations(ThriftTester):
         _assert_no_columnpath('key', ColumnPath('Super1', super_column='sc4', column=_i64(6)))
         _assert_columnpath_exists('key', ColumnPath('Super1', super_column='sc5', column=_i64(7)))
 
+    @require(9722)
     def test_batch_mutate_remove_slice_part_of_supercolumns(self):
         _set_keyspace('Keyspace1')
 
@@ -1392,6 +1396,7 @@ class TestMutations(ThriftTester):
             key = 'key'+str(i)
             assert counts[key] == i
 
+    @require(9722)
     def test_batch_mutate_super_deletion(self):
         _set_keyspace('Keyspace1')
         _insert_super('test')
@@ -2022,6 +2027,7 @@ class TestMutations(ThriftTester):
         _assert_no_columnpath('key2', ColumnPath(column_family='Counter1', column='c1'))
 
     @since('2.0')
+    @require(9722)
     def test_range_deletion(self):
         """ Tests CASSANDRA-7990 """
         _set_keyspace('Keyspace1')


### PR DESCRIPTION
These are failing at the moment on trunk. As discussed previously, let's `@require` it.

This does introduce a problem -- these tests should be run on, e.g. 2.2, but won't be with require. I think it should be pretty easy to add some `@since` machinery to `@require`, so I'll try to add that.