### PR TITLE
Require with version

### DIFF
--- a/thrift_tests.py
+++ b/thrift_tests.py
@@ -20,7 +20,7 @@ from thrift_bindings.v22.Cassandra import (CfDef, Column, ColumnDef,
                                            Mutation, NotFoundException,
                                            SlicePredicate, SliceRange,
                                            SuperColumn)
-from tools import since
+from tools import since, require
 
 
 def get_thrift_client(host='127.0.0.1', port=9160):
@@ -653,6 +653,7 @@ class TestMutations(ThriftTester):
                 for key in keys:
                     _assert_no_columnpath(key, ColumnPath(column_family, column=c.name))
 
+    @require(9722, broken_in='3.0')
     def test_batch_mutate_remove_super_columns_with_standard_under(self):
         _set_keyspace('Keyspace1')
         column_families = ['Super1', 'Super2']
@@ -677,6 +678,7 @@ class TestMutations(ThriftTester):
                     for key in keys:
                         _assert_no_columnpath(key, ColumnPath(column_family, super_column=sc.name, column=c.name))
 
+    @require(9722, broken_in='3.0')
     def test_batch_mutate_remove_super_columns_with_none_given_underneath(self):
         _set_keyspace('Keyspace1')
 
@@ -734,6 +736,7 @@ class TestMutations(ThriftTester):
             for key in keys:
                 _assert_no_columnpath(key, ColumnPath('Super1', super_column=sc.name))
 
+    @require(9722, broken_in='3.0')
     def test_batch_mutate_remove_slice_standard(self):
         _set_keyspace('Keyspace1')
 
@@ -755,6 +758,7 @@ class TestMutations(ThriftTester):
         _assert_no_columnpath('key', ColumnPath('Standard1', column='c4'))
         _assert_columnpath_exists('key', ColumnPath('Standard1', column='c5'))
 
+    @require(9722, broken_in='3.0')
     def test_batch_mutate_remove_slice_of_entire_supercolumns(self):
         _set_keyspace('Keyspace1')
 
@@ -781,6 +785,7 @@ class TestMutations(ThriftTester):
         _assert_no_columnpath('key', ColumnPath('Super1', super_column='sc4', column=_i64(6)))
         _assert_columnpath_exists('key', ColumnPath('Super1', super_column='sc5', column=_i64(7)))
 
+    @require(9722, broken_in='3.0')
     def test_batch_mutate_remove_slice_part_of_supercolumns(self):
         _set_keyspace('Keyspace1')
 
@@ -1392,6 +1397,7 @@ class TestMutations(ThriftTester):
             key = 'key'+str(i)
             assert counts[key] == i
 
+    @require(9722, broken_in='3.0')
     def test_batch_mutate_super_deletion(self):
         _set_keyspace('Keyspace1')
         _insert_super('test')
@@ -2022,6 +2028,7 @@ class TestMutations(ThriftTester):
         _assert_no_columnpath('key2', ColumnPath(column_family='Counter1', column='c1'))
 
     @since('2.0')
+    @require(9722, broken_in='3.0')
     def test_range_deletion(self):
         """ Tests CASSANDRA-7990 """
         _set_keyspace('Keyspace1')

--- a/tools.py
+++ b/tools.py
@@ -176,18 +176,17 @@ class since(object):
             return "%s > %s" % (version, self.max_version)
 
     def _wrap_setUp(self, cls):
-        backup_setUp_name = '_since_setUp'
+        orig_setUp = cls.setUp
 
         @functools.wraps(cls.setUp)
-        def wrapped(obj):
-            getattr(obj, backup_setUp_name)()
+        def wrapped_setUp(obj, *args, **kwargs):
+            orig_setUp(obj, *args, **kwargs)
             version = LooseVersion(obj.cluster.version())
             msg = self._skip_msg(version)
             if msg:
                 obj.skip(msg)
 
-        setattr(cls, backup_setUp_name, cls.setUp)
-        cls.setUp = wrapped
+        cls.setUp = wrapped_setUp
         return cls
 
     def _wrap_function(self, f):

--- a/tools.py
+++ b/tools.py
@@ -210,7 +210,7 @@ def no_vnodes():
     return unittest.skipIf(not DISABLE_VNODES, 'Test disabled for vnodes')
 
 
-def require(require_pattern):
+def require(require_pattern, broken_in=None):
     """Skips the decorated class or method, unless the argument
     'require_pattern' is a case-insensitive regex match for the name of the git
     branch in the directory from which Cassandra is running. For example, the
@@ -249,7 +249,6 @@ def require(require_pattern):
     if IGNORE_REQUIRE:
         return tagging_decorator
     require_pattern = str(require_pattern)
-    skipme = True
     git_branch = ''
     try:
         git_branch = cassandra_git_branch().lower()
@@ -259,13 +258,19 @@ def require(require_pattern):
 
     if git_branch:
         run_on_branch_patterns = (require_pattern, 'cassandra-{b}'.format(b=require_pattern))
+        # always run the test if the git branch name matches
         if any(re.match(p, git_branch, re.IGNORECASE) for p in run_on_branch_patterns):
-            skipme = False
-
-    def tag_and_skip_decorator(test_item):
-        test_item = tagging_decorator(test_item)
-        return unittest.skipIf(skipme, 'require ' + str(require_pattern))(test_item)
-    return tag_and_skip_decorator
+            return tagging_decorator
+        # if skipping a buggy/flapping test, use since
+        elif broken_in:
+            def tag_and_skip_after_version(decorated):
+                return since('0', broken_in)(tagging_decorator(decorated))
+            return tag_and_skip_after_version
+        # otherwise, skip with a message
+        else:
+            def tag_and_skip(decorated):
+                return unittest.skip('require ' + str(require_pattern))(tagging_decorator(decorated))
+            return tag_and_skip
 
 
 def cassandra_git_branch():


### PR DESCRIPTION
This changes the `require` decorator so you can skipping the `require`d test only after a particular version. So, imagine:

- A commit is merged to 2.2 and all greater versions, causing a test to fail or flap.
- File Jira ticket number 42 to request the bug be fixed.
- We want to run the test on versions before 2.2, but skip it on later versions 2.2.

The changes in this PR allow us to use `@require(42, broken_in='2.2')` to tag the test's failure as dependent on `CASSANDRA-42` and skips the test on all versions after 2.2.

This also changes the `since` decorator to use a more standard design. This allows a class to be `since`d multiple times, which is more likely to come up now because the new `require` feature uses `since` internally.

My testing of this basically consisted of playing with it, mostly using the tests in `validation.py` as a testbed. It :tada: :balloon: works on my machine :balloon: :tada:, but I'd appreciate it if whoever reviews this could run it locally and confirm it behaves as they expect.

@aboudreault and/or @shawnkumar, can you review?

This also adds some uses of the new `require` feature, superceding #374 -- see the 3rd commit.