### PR TITLE
looks for correct error on map key search

### DIFF
--- a/secondary_indexes_test.py
+++ b/secondary_indexes_test.py
@@ -482,17 +482,16 @@ class TestSecondaryIndexesOnCollections(Tester):
                "uuids map<uuid, uuid>);")
         cursor.execute(stmt)
 
+        no_index_error = ('No secondary indexes on the restricted columns support the provided operators'
+                          if self.cluster.version() < '3' else
+                          'No supported secondary index found for the non primary key columns restrictions')
         # no index present yet, make sure there's an error trying to query column
         stmt = ("SELECT * from map_index_search.users where uuids contains {some_uuid}").format(some_uuid=uuid.uuid4())
-        if self.cluster.version() < "3":
-            assert_invalid(cursor, stmt, 'No secondary indexes on the restricted columns support the provided operators')
-        else:
-            assert_invalid(cursor, stmt, 'No supported secondary index found for the non primary key columns restrictions')
-
+        assert_invalid(cursor, stmt, no_index_error)
 
         stmt = ("SELECT * from map_index_search.users where uuids contains key {some_uuid}"
             ).format(some_uuid=uuid.uuid4())
-        assert_invalid(cursor, stmt, 'No secondary indexes on the restricted columns support the provided operators')
+        assert_invalid(cursor, stmt, no_index_error)
 
         # add index on keys and query again (even though there are no rows in the table yet)
         stmt = "CREATE INDEX user_uuids on map_index_search.users (KEYS(uuids));"


### PR DESCRIPTION
This has been [failing consistently on cassci](http://cassci.datastax.com/view/trunk/job/trunk_dtest/lastCompletedBuild/testReport/secondary_indexes_test/TestSecondaryIndexesOnCollections/test_map_indexes/history/). This is because one of the asserts was expecting an old error message. This updates the error message for that assert and consolidates some logic with a similar assert nearby.