### PR TITLE
Skip paxos test

### DIFF
--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -21,7 +21,7 @@ class TestPaxos(Tester):
             cluster.set_partitioner("org.apache.cassandra.dht.ByteOrderedPartitioner")
 
         if (use_cache):
-            cluster.set_configuration_options(values={ 'row_cache_size_in_mb' : 100 })
+            cluster.set_configuration_options(values={'row_cache_size_in_mb': 100})
 
         cluster.populate(nodes).start()
         node1 = cluster.nodelist()[0]
@@ -33,7 +33,7 @@ class TestPaxos(Tester):
         return cursor
 
     def replica_availability_test(self):
-        #See CASSANDRA-8640
+        # See CASSANDRA-8640
         session = self.prepare(nodes=3, rf=3)
         session.execute("CREATE TABLE test (k int PRIMARY KEY, v int)")
         session.execute("INSERT INTO test (k, v) VALUES (0, 0) IF NOT EXISTS")
@@ -52,9 +52,9 @@ class TestPaxos(Tester):
 
     @no_vnodes()
     def cluster_availability_test(self):
-        #Warning, a change in partitioner or a change in CCM token allocation
-        #may require the partition keys of these inserts to be changed.
-        #This must not use vnodes as it relies on assumed token values.
+        # Warning, a change in partitioner or a change in CCM token allocation
+        # may require the partition keys of these inserts to be changed.
+        # This must not use vnodes as it relies on assumed token values.
 
         session = self.prepare(nodes=3)
         session.execute("CREATE TABLE test (k int PRIMARY KEY, v int)")
@@ -76,8 +76,8 @@ class TestPaxos(Tester):
     def contention_test_multi_iterations(self):
         self._contention_test(8, 100)
 
-    ##Warning, this test will require you to raise the open
-    ##file limit on OSX. Use 'ulimit -n 1000'
+    # Warning, this test will require you to raise the open
+    # file limit on OSX. Use 'ulimit -n 1000'
     def contention_test_many_threds(self):
         self._contention_test(300, 1)
 
@@ -88,7 +88,7 @@ class TestPaxos(Tester):
 
         cursor = self.prepare(nodes=3)
         cursor.execute("CREATE TABLE test (k int, v int static, id int, PRIMARY KEY (k, id))")
-        cursor.execute("INSERT INTO test(k, v) VALUES (0, 0)");
+        cursor.execute("INSERT INTO test(k, v) VALUES (0, 0)")
 
         class Worker(Thread):
             def __init__(self, wid, cursor, iterations, query):
@@ -108,7 +108,7 @@ class TestPaxos(Tester):
                     done = False
                     while not done:
                         try:
-                            res = self.cursor.execute(self.query, (prev+1, prev, self.wid ))
+                            res = self.cursor.execute(self.query, (prev+1, prev, self.wid))
                             if verbose:
                                 print "[%3d] CAS %3d -> %3d (res: %s)" % (self.wid, prev, prev+1, str(res))
                             if res[0][0] is True:
@@ -140,7 +140,7 @@ class TestPaxos(Tester):
                     while True:
                         try:
                             self.cursor.execute("DELETE FROM test WHERE k = 0 AND id = %d IF EXISTS" % self.wid)
-                            break;
+                            break
                         except WriteTimeout as e:
                             pass
 
@@ -181,4 +181,3 @@ class TestPaxos(Tester):
             retries = retries + w.retries
 
         assert (value == threads * iterations) and (errors == 0), "value=%d, errors=%d, retries=%d" % (value, errors, retries)
-

--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -33,7 +33,9 @@ class TestPaxos(Tester):
         return cursor
 
     def replica_availability_test(self):
-        # See CASSANDRA-8640
+        """
+        @jira_ticket CASSANDRA-8640
+        """
         session = self.prepare(nodes=3, rf=3)
         session.execute("CREATE TABLE test (k int PRIMARY KEY, v int)")
         session.execute("INSERT INTO test (k, v) VALUES (0, 0) IF NOT EXISTS")
@@ -82,7 +84,9 @@ class TestPaxos(Tester):
         self._contention_test(300, 1)
 
     def _contention_test(self, threads, iterations):
-        """ Test threads repeatedly contending on the same row """
+        """
+        Test threads repeatedly contending on the same row.
+        """
 
         verbose = False
 

--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -78,7 +78,7 @@ class TestPaxos(Tester):
 
     # Warning, this test will require you to raise the open
     # file limit on OSX. Use 'ulimit -n 1000'
-    def contention_test_many_threds(self):
+    def contention_test_many_threads(self):
         self._contention_test(300, 1)
 
     def _contention_test(self, threads, iterations):

--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -1,13 +1,15 @@
 # coding: utf-8
 
-from dtest import Tester
-from tools import since, no_vnodes
-from assertions import assert_unavailable
+import time
+from threading import Thread
+
 from cassandra import ConsistencyLevel, WriteTimeout
 from cassandra.query import SimpleStatement
 
-import time
-from threading import Thread
+from assertions import assert_unavailable
+from dtest import Tester
+from tools import no_vnodes, since
+
 
 @since('2.0.6')
 class TestPaxos(Tester):

--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -8,7 +8,7 @@ from cassandra.query import SimpleStatement
 
 from assertions import assert_unavailable
 from dtest import Tester
-from tools import no_vnodes, since
+from tools import no_vnodes, require, since
 
 
 @since('2.0.6')
@@ -72,6 +72,7 @@ class TestPaxos(Tester):
         self.cluster.nodelist()[2].start(wait_for_binary_proto=True)
         session.execute("INSERT INTO test (k, v) VALUES (6, 6) IF NOT EXISTS")
 
+    @require(9764, broken_in='3.0')
     def contention_test_multi_iterations(self):
         self._contention_test(8, 100)
 


### PR DESCRIPTION
This skips a known failing test and cleans up `paxos_tests.py` along the way. Not a big review job. @aboudreault or @shawnkumar could you have a loog?