### PR TITLE
switch decorating order so attr works

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -269,7 +269,7 @@ def require(require_pattern, broken_in=None):
         # otherwise, skip with a message
         else:
             def tag_and_skip(decorated):
-                return unittest.skip('require ' + str(require_pattern))(tagging_decorator(decorated))
+                return tagging_decorator(unittest.skip('require ' + str(require_pattern))(decorated))
             return tag_and_skip
 
 


### PR DESCRIPTION
With the existing implementation, plain `@require`d tests (with no
`broken_in`) don't get tagged with the `required` attribute. This
switches the order of the application of `skip` and `attr` to fix that.