### PR TITLE
import require correctly

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -3,8 +3,8 @@ import re
 import subprocess
 
 from ccmlib import common
-from dtest import Tester, debug, require
-from tools import since
+from dtest import Tester, debug
+from tools import require, since
 
 
 class TestOfflineTools(Tester):


### PR DESCRIPTION
`require` doesn't live in `dtest`. This makes `offline_tools_test` import it correctly.