### PR TITLE
Fix TestCommitLog.ignore_failure_policy_test on Windows

### DIFF
--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import platform
 import stat
 import subprocess
 import time
@@ -245,12 +246,22 @@ class TestCommitLog(Tester):
         self.assertTrue(failure, "Cannot find the commitlog failure message in logs")
         self.assertTrue(self.node1.is_running(), "Node1 should still be running")
 
-        with self.assertRaises((OperationTimedOut, WriteTimeout)):
-            self.session1.execute("""
-              INSERT INTO test (key, col1) VALUES (2, 2);
-            """)
-        # Should not exists
-        assert_none(self.session1, "SELECT * FROM test where key=2;")
+        # on Windows, we can't delete the segments if they're chmod to 0 so they'll still be available for use by CLSM,
+        # and we can still create new segments since os.chmod is limited to stat.S_IWRITE and stat.S_IREAD to set files
+        # as read-only. New mutations will still be allocated and WriteTimeouts will not be raised. It's sufficient that
+        # we confirm that a) the node isn't dead (stop) and b) the node doesn't terminate the thread (stop_commit)
+        query = "INSERT INTO test (key, col1) VALUES (2, 2);"
+        if platform.system() == 'Windows':
+            # We expect this to succeed
+            self.session1.execute(query)
+            self.assertFalse(self.node1.grep_log("terminating thread"), "thread was terminated but CL error should have been ignored.")
+            self.assertTrue(self.node1.is_running(), "Node1 should still be running after an ignore error on CL")
+        else:
+            with self.assertRaises((OperationTimedOut, WriteTimeout)):
+                self.session1.execute(query)
+
+            # Should not exist
+            assert_none(self.session1, "SELECT * FROM test where key=2;")
 
         # bring back the node commitlogs
         self._change_commitlog_perms(stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)


### PR DESCRIPTION
os.chmod can't be trusted on Windows. Comments on the PR should be pretty explanatory.