### PR TITLE
Unskip paxos contention test

### DIFF
--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -8,7 +8,7 @@ from cassandra.query import SimpleStatement
 
 from assertions import assert_unavailable
 from dtest import Tester
-from tools import no_vnodes, require, since
+from tools import no_vnodes, since
 
 
 @since('2.0.6')
@@ -78,7 +78,6 @@ class TestPaxos(Tester):
         self.cluster.nodelist()[2].start(wait_for_binary_proto=True)
         session.execute("INSERT INTO test (k, v) VALUES (6, 6) IF NOT EXISTS")
 
-    @require(9764, broken_in='3.0')
     def contention_test_multi_iterations(self):
         self.skipTest("Hanging the build")
         self._contention_test(8, 100)

--- a/paxos_tests.py
+++ b/paxos_tests.py
@@ -3,10 +3,9 @@
 import time
 from threading import Thread
 
+from assertions import assert_unavailable
 from cassandra import ConsistencyLevel, WriteTimeout
 from cassandra.query import SimpleStatement
-
-from assertions import assert_unavailable
 from dtest import Tester
 from tools import no_vnodes, since
 


### PR DESCRIPTION
This un-`@require`s the contention test in `paxos_tests.py` -- it passes locally, and it looks like the underlying bug is fixed (see the discussion [in CASSANDRA-9764](https://issues.apache.org/jira/browse/CASSANDRA-9764).

Unfortunately, the test has hung periodically on CassCI; I've filed #421 to track progress on fixing that. Until then, it's skipped.

This PR includes the usual isort cleanup as well.