### PR TITLE
Unrequire paging ttl test

### DIFF
--- a/paging_test.py
+++ b/paging_test.py
@@ -1467,7 +1467,6 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
         self.check_all_paging_results(expected_data, 8,
                                       [25, 25, 25, 25, 25, 25, 25, 25])
 
-    @require(9831, broken_in='2.2')
     def test_ttl_deletions(self):
         """Test ttl deletions. Paging over a query that has only tombstones """
         self.session = self.prepare()

--- a/paging_test.py
+++ b/paging_test.py
@@ -1482,6 +1482,8 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             self.session.execute(
                 SimpleStatement(s, consistency_level=CL.ALL)
             )
+        self.check_all_paging_results(data, 8,
+                                      [25, 25, 25, 25, 25, 25, 25, 25])
         time.sleep(5)
         self.check_all_paging_results([], 0, [])
 


### PR DESCRIPTION
This test has been passing for a while: http://cassci.datastax.com/job/trunk_dtest-skipped-with-require/22/testReport/paging_test/TestPagingWithDeletions/test_ttl_deletions/history/ so, gonna un-require it.

So, this test works by:

1. inserting data with a 3-second TTL in a loop
- checking that the data is there (new with this PR)
- waiting 5 seconds
- checking that no data is there

I'm concerned that, if there's a long delay between steps 1 and 2, or if the test is running on a slow machine, TTL'd data may have already expired before its presence is checked for. Is this a realistic concern, or is 3 seconds plenty of time?