### PR TITLE
Unrequire scrub test

### DIFF
--- a/scrub_test.py
+++ b/scrub_test.py
@@ -6,7 +6,7 @@ import uuid
 
 from ccmlib import common
 from dtest import Tester, debug
-from tools import since, require
+from tools import since
 import time
 
 KEYSPACE = 'ks'
@@ -254,7 +254,6 @@ class TestScrubIndexes(TestHelper):
         users = self.query_users(session)
         self.assertEqual(initial_users, users)
 
-    @require('9814', broken_in='3.0')
     def test_scrub_collections_table(self):
         cluster = self.cluster
         cluster.populate(1).start()

--- a/scrub_test.py
+++ b/scrub_test.py
@@ -152,6 +152,7 @@ class TestHelper(Tester):
 
         debug('sstables after increment %s' % (str(sstables)))
 
+
 @since('2.2')
 class TestScrubIndexes(TestHelper):
     """
@@ -292,6 +293,7 @@ class TestScrubIndexes(TestHelper):
         users = session.execute(("SELECT * from users where uuids contains {some_uuid}").format(some_uuid=_id))
 
         self.assertListEqual(initial_users, users)
+
 
 class TestScrub(TestHelper):
     """


### PR DESCRIPTION
This does the mechanical work of un`@requiring` `test_scrub_collections_table`. I've run the dtests over the C* versions where it was fixed, and it looks like these stopped failing [at b70f7ea](https://github.com/apache/cassandra/commit/b70f7ea0ce27b5defa0a7773d448732364e7aee0). I can't figure out why; anyone have ideas?