### PR TITLE
CASSANDRA-9902 Fix configurations dtest on windows

### DIFF
--- a/configuration_test.py
+++ b/configuration_test.py
@@ -87,6 +87,7 @@ class TestConfiguration(Tester):
                         "AND DURABLE_WRITES = false")
         session.execute('CREATE TABLE ks.tab (key int PRIMARY KEY, a int, b int, c int)')
         session.execute('ALTER KEYSPACE ks WITH DURABLE_WRITES=true')
+        write_to_trigger_fsync(session, 'ks', 'tab')
         self.assertGreater(commitlog_size(node), init_size,
                            msg='ALTER KEYSPACE was not respected')
 

--- a/dtest.py
+++ b/dtest.py
@@ -60,6 +60,12 @@ def reset_environment_vars():
     os.environ.clear()
     os.environ.update(initial_environment)
 
+
+def warning(msg):
+    LOG.warning(msg, extra={"current_test": CURRENT_TEST})
+    if PRINT_DEBUG:
+        print "WARN: " + msg
+
 def debug(msg):
     LOG.debug(msg, extra={"current_test":CURRENT_TEST})
     if PRINT_DEBUG:

--- a/jmxutils.py
+++ b/jmxutils.py
@@ -6,6 +6,11 @@ import subprocess
 
 JOLOKIA_JAR = os.path.join('lib', 'jolokia-jvm-1.2.3-agent.jar')
 
+def java_bin():
+    if os.environ.has_key('JAVA_HOME'):
+        return os.path.join(os.environ['JAVA_HOME'],'bin','java')
+    else:
+        return 'java'
 
 def make_mbean(package, type, **kwargs):
     '''
@@ -72,7 +77,7 @@ class JolokiaAgent(object):
         Starts the Jolokia agent.  The process will fork from the parent
         and continue running until stop() is called.
         """
-        args = ('java',
+        args = (java_bin(),
                 '-jar', JOLOKIA_JAR,
                 '--host', self.node.network_interfaces['binary'][0],
                 'start', str(self.node.pid))
@@ -88,7 +93,7 @@ class JolokiaAgent(object):
         """
         Stops the Jolokia agent.
         """
-        args = ('java',
+        args = (java_bin(),
                 '-jar', JOLOKIA_JAR,
                 'stop', str(self.node.pid))
         try:


### PR DESCRIPTION
* Fix is platform independent, should work on Linux but I didn't have the chance to test.
* Also fixed configuration_test.change_durable_writes_test
More information: https://issues.apache.org/jira/browse/CASSANDRA-9902