### PR TITLE
Add test for internode_compression: 'none'

### DIFF
--- a/internode_ssl_test.py
+++ b/internode_ssl_test.py
@@ -10,13 +10,26 @@ class TestInternodeSSL(Tester):
     def putget_with_internode_ssl_test(self):
         """
         Simple putget test with internode ssl enabled
+        with default 'all' internode compression
         @jira_ticket CASSANDRA-9884
         """
+        self.__putget_with_internode_ssl_test('all')
+
+    def putget_with_internode_ssl_without_compression_test(self):
+        """
+        Simple putget test with internode ssl enabled
+        without internode compression
+        @jira_ticket CASSANDRA-9884
+        """
+        self.__putget_with_internode_ssl_test('none')
+
+    def __putget_with_internode_ssl_test(self, internode_compression):
         cluster = self.cluster
 
         debug("***using internode ssl***")
         generate_ssl_stores(self.test_path)
-        self.cluster.enable_internode_ssl(self.test_path)
+        cluster.set_configuration_options({'internode_compression': internode_compression})
+        cluster.enable_internode_ssl(self.test_path)
 
         cluster.populate(3).start()
 


### PR DESCRIPTION
CASSANDRA-9884 still needs fix NPE when internode compresssion is off.
Patch to add this scenario.