### PR TITLE
changed cqlsh_tests.TestCqlsh.test_eat_glass to specify utf-8 encoding (CASSANDRA-9418)

### DIFF
--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -297,7 +297,7 @@ UPDATE varcharmaptable SET varcharvarintmap['Vitrum edere possum, mihi non nocet
             'I can eat glass and it does not hurt me': 1400
         })
 
-        output, err = self.run_cqlsh(node1, 'use testks; SELECT * FROM varcharmaptable')
+        output, err = self.run_cqlsh(node1, 'use testks; SELECT * FROM varcharmaptable', ['--encoding=utf-8'])
 
         self.assertEquals(output.count('Можам да јадам стакло, а не ме штета.'), 16)
         self.assertEquals(output.count(' ⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑'), 16)


### PR DESCRIPTION
This fix depends on the resolution of the following tickets:
https://issues.apache.org/jira/browse/CASSANDRA-10000
https://issues.apache.org/jira/browse/CASSANDRA-10004