### PR TITLE
Trying to fix decommissioned_wiped_node_can_join_test on Jenkins

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -369,8 +369,8 @@ class TestBootstrap(Tester):
         self.assertEquals(original_rows, list(session.execute("SELECT * FROM {}".format(stress_table,))))
 
         # Decommision the new node and wipe its data
-        node2.nodetool('decommission')
-        node2.stop(gently=True)
+        node2.decommission()
+        node2.stop(gently=False)
         data_dir = os.path.join(node2.get_path(), 'data')
         debug("Deleting {}".format(data_dir))
         shutil.rmtree(data_dir)


### PR DESCRIPTION
decommissioned_wiped_node_can_join_test : replace SIGTERM with SIGKILL after decommision to make sure process does not linger