### PR TITLE
Fix for replace_address and concurrent_schema_changes failing tests.

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -367,6 +367,7 @@ class TestBootstrap(Tester):
 
         session = self.patient_cql_connection(node2)
         self.assertEquals(original_rows, list(session.execute("SELECT * FROM {}".format(stress_table,))))
+        session.shutdown()  # Ensure all sockets to node2 are released
 
         # Decommision the new node and wipe its data
         node2.decommission()

--- a/concurrent_schema_changes_test.py
+++ b/concurrent_schema_changes_test.py
@@ -221,13 +221,14 @@ class TestConcurrentSchemaChanges(Tester):
         # create and add a new node, I must not be a seed, otherwise
         # we get schema disagreement issues for awhile after decommissioning it.
         node2 = Node('node2',
-                    cluster,
-                    True,
-                    ('127.0.0.2', 9160),
-                    ('127.0.0.2', 7000),
-                    '7200',
+                     cluster,
+                     True,
+                     ('127.0.0.2', 9160),
+                     ('127.0.0.2', 7000),
+                     '7200',
                      '0',
-                    None)
+                     None,
+                     binary_interface=('127.0.0.2', 9042))
         cluster.add(node2, False)
 
         node1, node2 = cluster.nodelist()
@@ -246,13 +247,14 @@ class TestConcurrentSchemaChanges(Tester):
 
         # create and add a new node
         node3 = Node('node3',
-                    cluster,
-                    True,
-                    ('127.0.0.3', 9160),
-                    ('127.0.0.3', 7000),
-                    '7300',
+                     cluster,
+                     True,
+                     ('127.0.0.3', 9160),
+                     ('127.0.0.3', 7000),
+                     '7300',
                      '0',
-                    None)
+                     None,
+                     binary_interface=('127.0.0.3', 9042))
 
         cluster.add(node3, True)
         node3.start(wait_for_binary_proto=True)


### PR DESCRIPTION
I noticed that the test I've added for CASSANDRA-9871 is not running on Jenkins whilst it did run on my box. The reason is that the version of ccm I had installed was not up-to-date. After updating it I got the same failure and fixed it along with a few more tests in replace_address and one test in concurrent_schema_changes that were failing with the same reason. I also sped up a couple of tests in replace_address, no need to wait for 5 minutes for a binary notification that will never be there.

Finally, I attempted one more time to fix decommissioned_wiped_node_can_join_test() although this is just a guess as this test was fine on my box even after updating ccm.