### PR TITLE
added compression disable/enable test - CASSANDRA-8384

### DIFF
--- a/compression_test.py
+++ b/compression_test.py
@@ -7,13 +7,13 @@ class TestCompression(TestHelper):
 
     def _get_compression_type(self, file):
         types = {
-            '00 10': 'NONE',
-            '78 9c': 'DEFLATE'
+            '0010': 'NONE',
+            '789c': 'DEFLATE'
         }
 
         with open(file, 'rb') as fh:
-            file_start = fh.read(4)
-            return types.get(''.join(["%02x " % ord(x) for x in file_start[:2]]).strip(), 'UNKNOWN')
+            file_start = fh.read(2)
+            return types.get(file_start.encode('hex'), 'UNKNOWN')
 
     @since("3.0")
     def disable_compression_cql_test(self):

--- a/compression_test.py
+++ b/compression_test.py
@@ -1,0 +1,102 @@
+from dtest import Tester
+from tools import since
+
+
+class TestCompression(Tester):
+
+    @since("3.0")
+    def disable_compression_cql_test(self):
+        """
+        @jira_ticket CASSANDRA-8384
+        using new cql create table syntax to disable compression
+        """
+        cluster = self.cluster
+        cluster.populate(1).start(wait_for_binary_proto=True)
+        [node] = cluster.nodelist()
+
+        session = self.patient_cql_connection(node)
+        self.create_ks(session, 'ks', 1)
+        session.execute("create table disabled_compression_table (id uuid PRIMARY KEY ) WITH compression = {'enabled': false};")
+        meta = session.cluster.metadata.keyspaces['ks'].tables['disabled_compression_table']
+        self.assertEqual('false', meta.options['compression']['enabled'])
+
+    @since("3.0")
+    def compression_cql_options_test(self):
+        """
+        @jira_ticket CASSANDRA-8384
+        using new cql create table syntax to configure compression
+        """
+        cluster = self.cluster
+        cluster.populate(1).start(wait_for_binary_proto=True)
+        [node] = cluster.nodelist()
+
+        session = self.patient_cql_connection(node)
+        self.create_ks(session, 'ks', 1)
+        session.execute("""
+            create table compression_opts_table
+                (id uuid PRIMARY KEY )
+                WITH compression = {
+                    'class': 'SnappyCompressor',
+                    'chunk_length_in_kb': 256,
+                    'crc_check_chance': 0.25
+                };
+            """)
+        meta = session.cluster.metadata.keyspaces['ks'].tables['compression_opts_table']
+        self.assertEqual('org.apache.cassandra.io.compress.SnappyCompressor', meta.options['compression']['class'])
+        self.assertEqual('256', meta.options['compression']['chunk_length_in_kb'])
+        self.assertEqual('0.25', meta.options['compression']['crc_check_chance'])
+
+    @since("3.0")
+    def compression_cql_disabled_with_alter_test(self):
+        """
+        @jira_ticket CASSANDRA-8384
+        starting with compression enabled then disabling it
+        """
+        cluster = self.cluster
+        cluster.populate(1).start(wait_for_binary_proto=True)
+        [node] = cluster.nodelist()
+
+        session = self.patient_cql_connection(node)
+        self.create_ks(session, 'ks', 1)
+        session.execute("""
+            create table start_enabled_compression_table
+                (id uuid PRIMARY KEY )
+                WITH compression = {
+                    'class': 'SnappyCompressor',
+                    'chunk_length_in_kb': 256,
+                    'crc_check_chance': 0.25
+                };
+            """)
+        meta = session.cluster.metadata.keyspaces['ks'].tables['start_enabled_compression_table']
+        self.assertEqual('org.apache.cassandra.io.compress.SnappyCompressor', meta.options['compression']['class'])
+        self.assertEqual('256', meta.options['compression']['chunk_length_in_kb'])
+        self.assertEqual('0.25', meta.options['compression']['crc_check_chance'])
+        session.execute("alter table start_enabled_compression_table with compression = {'enabled': false};")
+        meta = session.cluster.metadata.keyspaces['ks'].tables['start_enabled_compression_table']
+        self.assertEqual('false', meta.options['compression']['enabled'])
+
+    @since("3.0")
+    def compression_cql_enabled_with_alter_test(self):
+        """
+        @jira_ticket CASSANDRA-8384
+        starting with compression disabled and enabling it
+        """
+        cluster = self.cluster
+        cluster.populate(1).start(wait_for_binary_proto=True)
+        [node] = cluster.nodelist()
+
+        session = self.patient_cql_connection(node)
+        self.create_ks(session, 'ks', 1)
+        session.execute("create table start_disabled_compression_table (id uuid PRIMARY KEY ) WITH compression = {'enabled': false};")
+        meta = session.cluster.metadata.keyspaces['ks'].tables['start_disabled_compression_table']
+        self.assertEqual('false', meta.options['compression']['enabled'])
+        session.execute("""alter table start_disabled_compression_table
+                                WITH compression = {
+                                        'class': 'SnappyCompressor',
+                                        'chunk_length_in_kb': 256,
+                                        'crc_check_chance': 0.25
+                                    };""")
+        meta = session.cluster.metadata.keyspaces['ks'].tables['start_disabled_compression_table']
+        self.assertEqual('org.apache.cassandra.io.compress.SnappyCompressor', meta.options['compression']['class'])
+        self.assertEqual('256', meta.options['compression']['chunk_length_in_kb'])
+        self.assertEqual('0.25', meta.options['compression']['crc_check_chance'])

--- a/compression_test.py
+++ b/compression_test.py
@@ -1,6 +1,7 @@
+import os
+
 from scrub_test import TestHelper
 from tools import since
-import os
 
 
 class TestCompression(TestHelper):
@@ -28,6 +29,7 @@ class TestCompression(TestHelper):
         session = self.patient_cql_connection(node)
         self.create_ks(session, 'ks', 1)
         session.execute("create table disabled_compression_table (id uuid PRIMARY KEY ) WITH compression = {'enabled': false};")
+        session.cluster.refresh_schema_metadata()
         meta = session.cluster.metadata.keyspaces['ks'].tables['disabled_compression_table']
         self.assertEqual('false', meta.options['compression']['enabled'])
 
@@ -60,6 +62,7 @@ class TestCompression(TestHelper):
                     'crc_check_chance': 0.25
                 };
             """)
+        session.cluster.refresh_schema_metadata()
         meta = session.cluster.metadata.keyspaces['ks'].tables['compression_opts_table']
         self.assertEqual('org.apache.cassandra.io.compress.DeflateCompressor', meta.options['compression']['class'])
         self.assertEqual('256', meta.options['compression']['chunk_length_in_kb'])
@@ -98,6 +101,8 @@ class TestCompression(TestHelper):
         self.assertEqual('256', meta.options['compression']['chunk_length_in_kb'])
         self.assertEqual('0.25', meta.options['compression']['crc_check_chance'])
         session.execute("alter table start_enabled_compression_table with compression = {'enabled': false};")
+
+        session.cluster.refresh_schema_metadata()
         meta = session.cluster.metadata.keyspaces['ks'].tables['start_enabled_compression_table']
         self.assertEqual('false', meta.options['compression']['enabled'])
 
@@ -122,6 +127,8 @@ class TestCompression(TestHelper):
                                         'chunk_length_in_kb': 256,
                                         'crc_check_chance': 0.25
                                     };""")
+
+        session.cluster.refresh_schema_metadata()
         meta = session.cluster.metadata.keyspaces['ks'].tables['start_disabled_compression_table']
         self.assertEqual('org.apache.cassandra.io.compress.SnappyCompressor', meta.options['compression']['class'])
         self.assertEqual('256', meta.options['compression']['chunk_length_in_kb'])


### PR DESCRIPTION
2 questions with this pull request:
- should it verify that the actual sstables on disk are compressed?
- I had a small usability nit -- the enabled key only comes back from the compression metadata call if it's disabled -- so a client that was checking status has an odd check -- should this be brought up on the jira ticket?