### PR TITLE
fix for CASSANDRA-10051

### DIFF
--- a/json_tools_test.py
+++ b/json_tools_test.py
@@ -12,6 +12,7 @@ class TestJson(Tester):
 
         debug("Starting cluster...")
         cluster = self.cluster
+        cluster.set_configuration_options(batch_commitlog=True)
         cluster.populate(1).start()
 
         debug("Version: " + cluster.version())


### PR DESCRIPTION
this test assumes the commit log will be recovered on next startup, which was not happening on windows because the node was being shutdown before the next sync period, so I basically changed it to use the batch-sync commit log, which fixed the test
(this test is also dependent on https://github.com/pcmanus/ccm/pull/351 to work on windows)