### PR TITLE
Skip hanging tests

### DIFF
--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -1,14 +1,12 @@
 import os
 import time
 from re import findall
-from unittest import skipIf
+from unittest import skip
 
 from cassandra import ConsistencyLevel
-from flaky import flaky
 from nose.plugins.attrib import attr
 
 from assertions import assert_almost_equal, assert_one
-from ccmlib.common import is_win
 from ccmlib.node import Node
 from dtest import Tester, debug
 from tools import insert_c1c2, since
@@ -208,8 +206,7 @@ class TestIncRepair(Tester):
 
     @since('2.1')
     @attr('long')
-    @skipIf(is_win(), 'Times out on Windows during write')
-    @flaky  # see CASSANDRA-9752
+    @skip('hangs CI')
     def multiple_subsequent_repair_test(self):
         """
         Covers CASSANDRA-8366

--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -1,16 +1,16 @@
 import os
 import time
-from unittest import skipIf
 from re import findall
+from unittest import skipIf
 
 from cassandra import ConsistencyLevel
-from ccmlib.node import Node
-from ccmlib.common import is_win
+from flaky import flaky
 from nose.plugins.attrib import attr
 
 from assertions import assert_almost_equal, assert_one
+from ccmlib.common import is_win
+from ccmlib.node import Node
 from dtest import Tester, debug
-from flaky import flaky
 from tools import insert_c1c2, since
 
 

--- a/repair_test.py
+++ b/repair_test.py
@@ -1,5 +1,6 @@
 import time
 from collections import namedtuple
+from unittest import skip
 
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
@@ -372,6 +373,7 @@ class TestRepairDataSystemTable(Tester):
         return RepairTableContents(parent_repair_history=parent_repair_history,
                                    repair_history=repair_history)
 
+    @skip('hangs CI')
     def initial_empty_repair_tables_test(self):
         debug('repair tables:')
         debug(self.repair_table_contents(node=self.node1, include_system_keyspaces=False))


### PR DESCRIPTION
These tests hung on a recent CassCI run (I believe [this one](http://cassci.datastax.com/view/trunk/job/trunk_dtest/lastCompletedBuild/testReport/)). Here are the relevant tests in the test nodes' stdout; note no more tests are run after these tests:

https://gist.github.com/mambocab/2ae8539003bee6b4eb7d#file-test_stdout-005-txt-L204

https://gist.github.com/mambocab/2ae8539003bee6b4eb7d#file-test_stdout-008-txt-L2

So, this PR skips them hard.

There's also a bit of import reorganization in this PR :+1: