### PR TITLE
fetch riptano/master and diff against that

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ script:
   # we use flake8 because it allows us to ignore other warnings
   # exclude the thrift directories - they contain auto-generated code
   - flake8 --ignore=E,W,F811,F812,F821,F822,F823,F831,F841,N8,C9 --exclude=thrift_bindings,cassandra-thrift .
+  - git remote add riptano git://github.com/riptano/cassandra-dtest.git
+  - git fetch riptano # fetch master for the next diff
   # feed changed lines with no context around them to pep8
   # I know we don't enforce line length but if you introduce
   # 200-char lines you are doing something terribly wrong
-  - git diff master -U0 | pep8 --diff --max-line-length=200
+  - git diff riptano/master -U0 | pep8 --diff --max-line-length=200
 sudo: false


### PR DESCRIPTION
Dunno why I didn't make a PR for this this a week or two ago when I did it, but:

We've been having some weird problems with Travis, where the diffing fails to find the right master branch. It's hard to tell when it's a problem, but this should fix it.

It also has the nice side effect of letting people run Travis on their forks and check this stuff via CI before making a PR. For example, here is a build of a branch on my fork that I deliberately inserted whitespace errors into:

https://travis-ci.org/mambocab/cassandra-dtest/builds/75453490