### PR TITLE
Import sleep in replace_address_test

### DIFF
--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -1,9 +1,9 @@
-from dtest import Tester, debug, DISABLE_VNODES
-from tools import since, InterruptBootstrap
+from cassandra import ConsistencyLevel, ReadTimeout, Unavailable
+from cassandra.query import SimpleStatement
 
 from ccmlib.node import Node, NodeError
-from cassandra import ConsistencyLevel, Unavailable, ReadTimeout
-from cassandra.query import SimpleStatement
+from dtest import DISABLE_VNODES, Tester, debug
+from tools import InterruptBootstrap, since
 
 
 class NodeUnavailable(Exception):

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from cassandra import ConsistencyLevel, ReadTimeout, Unavailable
 from cassandra.query import SimpleStatement
 


### PR DESCRIPTION
This has been failing on CassCI because it used sleep without importing it. But when I ran it locally, it passed? Spooky. Anyway, this should fix it, and contains the obligatory isort changes.