### PR TITLE
fix for CASSANDRA-10097

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -156,6 +156,7 @@ class TestBootstrap(Tester):
         """Test bootstrap with resetting bootstrap progress"""
 
         cluster = self.cluster
+        cluster.set_configuration_options(values={'stream_throughput_outbound_megabits_per_sec': 1})
         cluster.populate(2).start(wait_other_notice=True)
 
         node1 = cluster.nodes['node1']
@@ -168,7 +169,6 @@ class TestBootstrap(Tester):
 
         # start bootstrapping node3 and wait for streaming
         node3 = new_node(cluster)
-        node3.set_configuration_options(values={'stream_throughput_outbound_megabits_per_sec': 1})
         try:
             node3.start()
         except NodeError:


### PR DESCRIPTION
Limiting cluster stream_throughput_outbound_megabits_per_sec on bootstrap_test.py:TestBootstrap.bootstrap_with_reset_bootstrap_state_test
fails (more details here: https://issues.apache.org/jira/browse/CASSANDRA-10097)