### PR TITLE
Setting memtable_heap_space_in_mb only on commit log segment size tests

### DIFF
--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -242,7 +242,7 @@ class TestCommitLog(Tester):
                                      if self.cluster.version() >= '3.0'
                                      else (10, 42))
         self._commitlog_test(5, expected_commitlog_size, expected_commitlog_files,
-                             compressed=True, files_error=0.12)
+                             compressed=True, files_error=0.3)
 
     def stop_failure_policy_test(self):
         """ Test the stop commitlog failure policy (default one) """

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -33,8 +33,7 @@ class TestCommitLog(Tester):
 
     def prepare(self, configuration={}, create_test_keyspace=True, **kwargs):
         conf = {'commitlog_sync_period_in_ms': 1000}
-        if self.cluster.version() >= "2.1":
-            conf['memtable_heap_space_in_mb'] = 512
+
         conf.update(configuration)
         self.cluster.set_configuration_options(values=conf, **kwargs)
         self.cluster.start()
@@ -87,6 +86,13 @@ class TestCommitLog(Tester):
                         num_commitlog_files, compressed=False,
                         files_error=0):
         """ Execute a basic commitlog test and validate the commitlog files """
+
+        conf = {'commitlog_segment_size_in_mb': segment_size_in_mb}
+        if compressed:
+            conf['commitlog_compression'] = [{'class_name': 'LZ4Compressor'}]
+        if self.cluster.version() >= "2.1":
+            conf['memtable_heap_space_in_mb'] = 512
+        self.prepare(configuration=conf, create_test_keyspace=False)
 
         if compressed:
             segment_size_in_mb *= 0.7
@@ -213,40 +219,30 @@ class TestCommitLog(Tester):
     def default_segment_size_test(self):
         """ Test default commitlog_segment_size_in_mb (32MB) """
 
-        self.prepare(create_test_keyspace=False)
         self._commitlog_test(32, 64, 2, files_error=0.5)
 
     @since('2.1')
     def small_segment_size_test(self):
         """ Test a small commitlog_segment_size_in_mb (5MB) """
-        segment_size_in_mb = 5
-        self.prepare(configuration={
-            'commitlog_segment_size_in_mb': segment_size_in_mb
-        }, create_test_keyspace=False)
-        self._commitlog_test(segment_size_in_mb, 62.5, 13, files_error=0.25)
+
+        self._commitlog_test(5, 62.5, 13, files_error=0.25)
 
     @since('2.2')
     def default_compressed_segment_size_test(self):
         """ Test default compressed commitlog_segment_size_in_mb (32MB) """
 
-        self.prepare(configuration={
-            'commitlog_compression': [{'class_name': 'LZ4Compressor'}]
-        }, create_test_keyspace=False)
         self._commitlog_test(32, 42, 2, compressed=True, files_error=0.5)
 
     @since('2.2')
     def small_compressed_segment_size_test(self):
         """ Test a small compressed commitlog_segment_size_in_mb (5MB) """
-        segment_size_in_mb = 5
-        self.prepare(configuration={
-            'commitlog_segment_size_in_mb': segment_size_in_mb,
-            'commitlog_compression': [{'class_name': 'LZ4Compressor'}]
-        }, create_test_keyspace=False)
+
         (expected_commitlog_files,
          expected_commitlog_size) = ((12, 33)
                                      if self.cluster.version() >= '3.0'
                                      else (10, 42))
-        self._commitlog_test(segment_size_in_mb, expected_commitlog_size, expected_commitlog_files, compressed=True, files_error=0.12)
+        self._commitlog_test(5, expected_commitlog_size, expected_commitlog_files,
+                             compressed=True, files_error=0.12)
 
     def stop_failure_policy_test(self):
         """ Test the stop commitlog failure policy (default one) """


### PR DESCRIPTION
The `commitlog_test.py:TestCommitLog.stop_failure_policy_test` was failing on Windows due to java.lang.OutOfMemoryError: Java heap space (https://issues.apache.org/jira/browse/CASSANDRA-10100)

I noticed that `prepare()` method (used by all tests) was setting the configuration `memtable_heap_space_in_mb` to 512MB. This property by default is 1/4 of the heap size, and the heap of ccm nodes is only 500MB. Do you remember why is it necessary to set this property for these tests?

Not setting this property made the failure policy tests (including `stop_failure_policy_test`) pass on Windows, probably due to reduced heap/gc pressure. However, the commit log segment size tests (`_commitlog_test` variants) were affected by the removal of this property, so I assume this property is only necessary for these tests.

In the fix, I do not set `memtable_heap_space_in_mb` in the `prepare()` method, which is shared by all testing methods, but only in the `_commitlog_test()`, what fixes the failure policy tests on windows without affecting the other tests that depend on this property.

Could you please review @aboudreault? Thanks!