### PR TITLE
printing debug output on sstablesplit failure (sstablesplit_test.py)

### DIFF
--- a/sstablesplit_test.py
+++ b/sstablesplit_test.py
@@ -72,7 +72,13 @@ class TestSSTableSplit(Tester):
         expected_num_sstables = floor(origsstable_size / expected_sstable_size) 
 
         # split the sstables
-        node.run_sstablesplit(keyspace=keyspace, size=splitmaxsize, no_snapshot=True)
+        result = node.run_sstablesplit(keyspace=keyspace, size=splitmaxsize,
+                                       no_snapshot=True, debug=True)
+
+        for (out, error, rc) in result:
+            debug("stdout: {}".format(out))
+            debug("stderr: {}".format(error))
+            debug("rc: {}".format(rc))
 
         # get the sstables post-split and their total size
         sstables = node.get_sstables(keyspace, '')


### PR DESCRIPTION
I cannot reproduce locally the error described on [CASSANDRA-10108](https://issues.apache.org/jira/browse/CASSANDRA-10108). The error is only happening on [windows cassci](http://cassci.datastax.com/view/win32/job/cassandra-3.0_dtest_win32/21/testReport/sstablesplit_test/TestSSTableSplit/split_test/).

In order to have more elements to find out what's happening, this PR modifies `sstablesplit_test.py` to debug_print stdout, stderr, and rc of the sstablesplit tool. This shouldn't affect passing tests, will only print when the test fails.

This PR depends on this [ccm PR](https://github.com/pcmanus/ccm/pull/363).