### PR TITLE
Unrequire passing tests

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -371,16 +371,17 @@ class TestCompaction(Tester):
         time.sleep(2)
         self.assertTrue(len(node.grep_log('Compacting.+to_disable')) > 0, 'Found no log items for {0}'.format(self.strategy))
 
-
     def skip_if_no_major_compaction(self):
         if self.cluster.version() < '2.2' and self.strategy == 'LeveledCompactionStrategy':
             self.skipTest('major compaction not implemented for LCS in this version of Cassandra')
+
 
 def get_random_word(wordLen):
     word = ''
     for i in range(wordLen):
         word += random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789')
     return word
+
 
 def block_on_compaction_log(node, ks=None, table=None):
     """

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -6,7 +6,8 @@ import random
 
 from assertions import assert_almost_equal, assert_none, assert_one
 from dtest import Tester, debug
-from tools import require, since
+from tools import since
+
 
 class TestCompaction(Tester):
 
@@ -165,7 +166,6 @@ class TestCompaction(Tester):
         time.sleep(5)
         assert expired_sstable not in node1.get_sstables('ks', 'cf')
 
-    @require('dtest PR #373', broken_in='3.0')
     def compaction_throughput_test(self):
         """
         Test setting compaction throughput.

--- a/scrub_test.py
+++ b/scrub_test.py
@@ -152,6 +152,7 @@ class TestHelper(Tester):
 
         debug('sstables after increment %s' % (str(sstables)))
 
+
 @since('2.2')
 class TestScrubIndexes(TestHelper):
     """
@@ -293,6 +294,7 @@ class TestScrubIndexes(TestHelper):
         users = session.execute(("SELECT * from users where uuids contains {some_uuid}").format(some_uuid=_id))
 
         self.assertListEqual(initial_users, users)
+
 
 class TestScrub(TestHelper):
     """

--- a/scrub_test.py
+++ b/scrub_test.py
@@ -6,7 +6,7 @@ import uuid
 
 from ccmlib import common
 from dtest import Tester, debug
-from tools import since, require
+from tools import since
 import time
 
 KEYSPACE = 'ks'
@@ -255,7 +255,6 @@ class TestScrubIndexes(TestHelper):
         users = self.query_users(session)
         self.assertEqual(initial_users, users)
 
-    @require('9814', broken_in='3.0')
     def test_scrub_collections_table(self):
         cluster = self.cluster
         cluster.populate(1).start()

--- a/sstablesplit_test.py
+++ b/sstablesplit_test.py
@@ -57,8 +57,8 @@ class TestSSTableSplit(Tester):
         node.stop()
 
         # default split size is 50MB
-        splitmaxsize = 10 
-        expected_sstable_size = (10 * 1024 * 1024) 
+        splitmaxsize = 10
+        expected_sstable_size = (10 * 1024 * 1024)
         keyspace = 'keyspace1' if self.cluster.version() >= '2.1' else 'Keyspace1'
 
         # get the initial sstables and their total size
@@ -67,7 +67,7 @@ class TestSSTableSplit(Tester):
         debug("Original sstable and sizes before split: {}".format([(name, getsize(name)) for name in origsstables]))
 
         # calculate the expected number of sstables post-split
-        expected_num_sstables = floor(origsstable_size / expected_sstable_size) 
+        expected_num_sstables = floor(origsstable_size / expected_sstable_size)
 
         # split the sstables
         result = node.run_sstablesplit(keyspace=keyspace, size=splitmaxsize,


### PR DESCRIPTION
This does some whitespace cleanup, but more importantly, removes `@require`s from tests that pass now.