### PR TITLE
removed watch_log_for timeout on test_commitlog_replay_on_startup

### DIFF
--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -204,7 +204,7 @@ class TestCommitLog(Tester):
 
         debug("Verify commit log was replayed on startup")
         node1.start()
-        node1.watch_log_for("Log replay complete", timeout=5)
+        node1.watch_log_for("Log replay complete")
         # Here we verify there was more than 0 replayed mutations
         zero_replays = node1.grep_log(" 0 replayed mutations")
         self.assertEqual(0, len(zero_replays))


### PR DESCRIPTION
small timeout was making test fail on [win32 cassci](http://cassci.datastax.com/view/cassandra-3.0/job/cassandra-3.0_dtest_win32/lastCompletedBuild/testReport/commitlog_test/TestCommitLog/test_commitlog_replay_on_startup/history/)