### PR TITLE
lint against most recent common ancestor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
   # feed changed lines with no context around them to pep8
   # I know we don't enforce line length but if you introduce
   # 200-char lines you are doing something terribly wrong
-  - git diff riptano/master -U0 | pep8 --diff --max-line-length=200
+  - git diff riptano/master...HEAD -U0 | pep8 --diff --max-line-length=200
 sudo: false

--- a/linter_check.sh
+++ b/linter_check.sh
@@ -6,7 +6,7 @@
 flake8 --ignore=E,W,F811,F812,F821,F822,F823,F831,F841,N8,C9 --exclude=thrift_bindings,cassandra-thrift .
 flake8_result=$?
 
-git diff master -U0 | pep8 --diff --max-line-length=200
+git diff master...HEAD -U0 | pep8 --diff --max-line-length=200
 pep8_result=$?
 
 echo -e "\nflake8 exited with ${flake8_result}."


### PR DESCRIPTION
The linter should only check lines that have changed on the branch being linted. The previous script checked against HEAD of master, which meant that Travis would catch linter errors in PRs when unrelated changes had been merged into master since they were branched off.

Asking for review from @ptnapoleon, since he stepped through git stuff with me, and from @aboudreault, since he is the keeper of the linter script.