### PR TITLE
Ignoring errors before upgrade to 1.2 on Windows (CASSANDRA-10037)

### DIFF
--- a/upgrade_internal_auth_test.py
+++ b/upgrade_internal_auth_test.py
@@ -26,12 +26,6 @@ class TestAuthUpgrade(Tester):
         Tester.__init__(self, *args, **kwargs)
 
     def upgrade_to_22_test(self):
-        if is_win():
-            # These three occur on older versions of C* on Windows
-            self.ignore_log_patterns.append(r'Failed deleting temp components for')
-            self.ignore_log_patterns.append(r'Missing component')
-            self.ignore_log_patterns.append(r'Exception in thread Thread\[CompactionExecutor')
-            self.ignore_log_patterns.append(r'Unable to delete')
         self.do_upgrade_with_internal_auth("git:cassandra-2.2")
 
     # todo: when we branch for 3.0 switch this from trunk to cassandra-3.0
@@ -137,6 +131,11 @@ class TestAuthUpgrade(Tester):
         node.watch_log_for("DRAINED")
         node.stop(wait_other_notice=False)
         debug('{node} stopped'.format(**format_args))
+
+        # Ignore errors before upgrade on Windows
+        if is_win():
+            node.mark_log_for_errors()
+
         # Update Cassandra Directory
         debug('Updating version to tag {tag}'.format(**format_args))
         node.set_install_dir(version=tag, verbose=True)


### PR DESCRIPTION
Instead of using the error whitelist approach, the idea is to mark the log for errors just before upgrading to 2.2 on Windows, effectivelly ignoring all errors happening on 2.1 (since we're not interested in those errors for the purpose of this test).

This test depends on this [ccm PR](https://github.com/pcmanus/ccm/pull/370) and approval on [this ticket](https://issues.apache.org/jira/browse/CASSANDRA-10037) before being merged.