### PR TITLE
Improve git in require

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -328,8 +328,8 @@ def cassandra_git_branch():
     p = subprocess.Popen(['git', 'branch'], cwd=CASSANDRA_DIR,
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()
-    # fail if err was printed and isn't empty OR if git failed
-    if err.split() or (p.returncode != 0):
+    # fail if git failed
+    if p.returncode != 0:
         raise RuntimeError('Git printed error: {err}'.format(err=err))
     [current_branch_line] = [line for line in out.splitlines() if line.startswith('*')]
     return current_branch_line[1:].strip()

--- a/tools.py
+++ b/tools.py
@@ -303,11 +303,7 @@ def require(require_pattern, broken_in=None):
         return tagging_decorator
     require_pattern = str(require_pattern)
     git_branch = ''
-    try:
-        git_branch = cassandra_git_branch().lower()
-    except OSError as e:
-        debug('git branch check failed with error {e}'.format(e=e))
-        return unittest.skip('failed git branch name check in {f}()'.format(f=require.__name__))
+    git_branch = cassandra_git_branch().lower()
 
     if git_branch:
         run_on_branch_patterns = (require_pattern, 'cassandra-{b}'.format(b=require_pattern))

--- a/tools.py
+++ b/tools.py
@@ -332,7 +332,8 @@ def cassandra_git_branch():
     p = subprocess.Popen(['git', 'branch'], cwd=CASSANDRA_DIR,
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()
-    if err:
+    # fail if err was printed and isn't empty OR if git failed
+    if err.split() or (p.returncode != 0):
         raise RuntimeError('Git printed error: {err}'.format(err=err))
     [current_branch_line] = [line for line in out.splitlines() if line.startswith('*')]
     return current_branch_line[1:].strip()


### PR DESCRIPTION
When `git`, called through `@require` printed whitespace to stderr, the decorator would fail. Because of the way it was called when loading through nose (and because of poor error reporting design on my part), the failure was silent.

I'm not sure I understand what I was going for when I originally wrote this branch-handling code, but my thoughts on it now are in my commit messages; don't let this pass review if you don't agree with them.