### PR TITLE
Skip failing tests for CASSANDRA-10086 due to TERM variable not set

### DIFF
--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from distutils.version import LooseVersion
 from tempfile import NamedTemporaryFile
 from uuid import UUID, uuid4
+from unittest import skip
 
 from cassandra import InvalidRequest
 from cassandra.concurrent import execute_concurrent_with_args
@@ -1208,6 +1209,7 @@ Unlogged batch covering 2 partitions detected against table [client_warnings.tes
         # the table created before and after should be the same
         self.assertEqual(reloaded_describe_out, describe_out)
 
+    @skip('no terminal in CI')
     @since('3.0')
     def test_clear(self):
         """
@@ -1216,6 +1218,7 @@ Unlogged batch covering 2 partitions detected against table [client_warnings.tes
         """
         self._test_clear_screen('CLEAR')
 
+    @skip('no terminal in CI')
     @since('3.0')
     def test_cls(self):
         """


### PR DESCRIPTION
Sample failure [here] (http://cassci.datastax.com/job/stef1927-8630-3.0-dtest/lastBuild/testReport/cqlsh_tests/TestCqlsh/test_clear/).

It seems the TERM environment variable is not set, i.e. we don't have a terminal on Jenkins. Unless someone knows how to address this, I propose to skip them.