### PR TITLE
only run upgrade tests on 2.2 and later

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -23,6 +23,7 @@ from cassandra.util import sortedset
 from upgrade_base import UpgradeTester
 
 
+@since('2.2')
 class TestCQL(UpgradeTester):
 
     def static_cf_test(self):

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -181,7 +181,7 @@ class BasePagingTester(UpgradeTester):
         return cursor
 
 
-@since('2.0')
+@since('2.2')
 class TestPagingSize(BasePagingTester, PageAssertionMixin):
     """
     Basic tests relating to page size (relative to results set)
@@ -337,7 +337,7 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
 
-@since('2.0')
+@since('2.2')
 class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when CQL modifiers (such as order, limit, allow filtering) are used.
@@ -594,7 +594,7 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
             )
 
 
-@since('2.0')
+@since('2.2')
 class TestPagingData(BasePagingTester, PageAssertionMixin):
 
     def basic_paging_test(self):
@@ -1063,7 +1063,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(expected_data, pf.all_data())
 
 
-@since('2.0')
+@since('2.2')
 class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when the queried dataset changes while pages are being retrieved.
@@ -1258,7 +1258,7 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(page3, page3expected)
 
 
-@since('2.0')
+@since('2.2')
 class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with isolation of paged queries (queries can't affect each other).
@@ -1348,7 +1348,7 @@ class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(flatten_into_set(page_fetchers[10].all_data()), flatten_into_set(expected_data[:50000]))
 
 
-@since('2.0')
+@since('2.2')
 class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when deletions occur.


### PR DESCRIPTION
Pursuant to some discussion on IRC, these tests need to be run over a few upgrade paths (see [CASSANDRA-10269](https://issues.apache.org/jira/browse/CASSANDRA-10269). Until then, they are hard-coded to upgrade from 2.1, so let's only run them on 2.2 and greater for now.