### PR TITLE
CASSANDRA-7392: added MV test and adapted existing tests

### DIFF
--- a/assertions.py
+++ b/assertions.py
@@ -1,5 +1,5 @@
 import re
-from cassandra import InvalidRequest, Unavailable, ConsistencyLevel, WriteTimeout, ReadTimeout
+from cassandra import InvalidRequest, Unavailable, ConsistencyLevel, WriteFailure, WriteTimeout, ReadFailure, ReadTimeout
 from cassandra.query import SimpleStatement
 from tools import rows_to_list
 
@@ -10,7 +10,7 @@ def assert_unavailable(fun, *args):
             fun(None)
         else:
             fun(*args)
-    except (Unavailable, WriteTimeout, ReadTimeout) as e:
+    except (Unavailable, WriteTimeout, WriteFailure, ReadTimeout, ReadFailure) as e:
         pass
     except Exception as e:
         assert False, "Expecting unavailable exception, got: " + str(e)


### PR DESCRIPTION
I've added a test for materialized views and I've updated the existing tests for CASSANDRA-7392 since they were no longer passing (increased timeout, added failure exceptions, removed retry policy and changed log file format slightly).