### PR TITLE
Specify upgrade paths

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -23,7 +23,6 @@ from cassandra.util import sortedset
 from upgrade_base import UpgradeTester
 
 
-@since('2.2')
 class TestCQL(UpgradeTester):
 
     def static_cf_test(self):

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -181,7 +181,6 @@ class BasePagingTester(UpgradeTester):
         return cursor
 
 
-@since('2.2')
 class TestPagingSize(BasePagingTester, PageAssertionMixin):
     """
     Basic tests relating to page size (relative to results set)
@@ -337,7 +336,6 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
 
-@since('2.2')
 class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when CQL modifiers (such as order, limit, allow filtering) are used.
@@ -594,7 +592,6 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
             )
 
 
-@since('2.2')
 class TestPagingData(BasePagingTester, PageAssertionMixin):
 
     def basic_paging_test(self):
@@ -1063,7 +1060,6 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(expected_data, pf.all_data())
 
 
-@since('2.2')
 class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when the queried dataset changes while pages are being retrieved.
@@ -1258,7 +1254,6 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(page3, page3expected)
 
 
-@since('2.2')
 class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with isolation of paged queries (queries can't affect each other).
@@ -1348,7 +1343,6 @@ class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(flatten_into_set(page_fetchers[10].all_data()), flatten_into_set(expected_data[:50000]))
 
 
-@since('2.2')
 class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when deletions occur.

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -21,6 +21,9 @@ OLD_CASSANDRA_DIR = os.environ.get('OLD_CASSANDRA_DIR', None)
 # a 3.0 cluster will use.
 UPGRADE_MODE = os.environ.get('UPGRADE_MODE', 'normal').lower()
 
+# Specify a branch to upgrade to
+UPGRADE_TO = os.environ.get('UPGRADE_TO', None)
+
 
 @since('2.1')
 class UpgradeTester(Tester):
@@ -109,7 +112,9 @@ class UpgradeTester(Tester):
                 node2.mark_log_for_errors()
 
         # choose version to upgrade to
-        if self.original_git_branch == 'trunk' or self.original_version >= '3.0':
+        if UPGRADE_TO:
+            new_branch = UPGRADE_TO
+        elif self.original_git_branch == 'trunk' or self.original_version >= '3.0':
             new_branch = 'git:trunk'
         else:
             new_branch = 'git:cassandra-3.0'

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -22,6 +22,7 @@ OLD_CASSANDRA_DIR = os.environ.get('OLD_CASSANDRA_DIR', None)
 UPGRADE_MODE = os.environ.get('UPGRADE_MODE', 'normal').lower()
 
 
+@since('2.1')
 class UpgradeTester(Tester):
     """
     When run in 'normal' upgrade mode without specifying any version to run,


### PR DESCRIPTION
This makes the upgrade tests run different paths depending on the version you're running the tests on. In particular,

| C* Version | upgrade path |
| :--- | :--- |
| 2.1 | 2.1->3.0 | 
| 2.2 | 2.2->3.0 | 
| 3.0 | 3.0->trunk | 
| trunk | 2.2->trunk |

as discussed [in CASSANDRA-10269](https://issues.apache.org/jira/browse/CASSANDRA-10269).

This also adds an environment variable that lets users configure what version to upgrade to.