### PR TITLE
Remove requires

### DIFF
--- a/nodetool_test.py
+++ b/nodetool_test.py
@@ -1,11 +1,9 @@
 from ccmlib.node import NodetoolError
 from dtest import Tester
-from tools import require
 
 
 class TestNodetool(Tester):
 
-    @require("8741")
     def test_decommission_after_drain_is_invalid(self):
         """
         @jira_ticket CASSANDRA-8741

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -1631,7 +1631,6 @@ class TestCQL(UpgradeTester):
             res = cursor.execute("SELECT * FROM test")
             assert rows_to_list(res) == [[2, 2, None, None]], res
 
-    @require("CASSANDRA-6717")
     @freshCluster()
     def only_pk_test(self):
         """ Check table with only a PK (#4361) """
@@ -1644,9 +1643,6 @@ class TestCQL(UpgradeTester):
                 PRIMARY KEY (k, c)
             )
         """)
-
-        # The migration for this table is not quite correct right now.
-        # Until CASSANDRA-6717 fixes this, this test will fail.
 
         # Check for dense tables too
         cursor.execute("""


### PR DESCRIPTION
These two tests have started succeeding:

http://cassci.datastax.com/job/trunk_dtest-skipped-with-require/61/testReport/upgrade_tests.cql_tests/TestCQL/only_pk_test/

http://cassci.datastax.com/job/trunk_dtest-skipped-with-require/61/testReport/nodetool_test/TestNodetool/test_decommission_after_drain_is_invalid/

So I've un-required them. CASSANDRA-8741 has been closed, so that test definitely is ready to be unskipped, and CASSANDRA-6717 is in progress, so it makes sense to me that the other test would start succeeding now.