### PR TITLE
improve and consolidate upgrade path decision logic

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -4076,9 +4076,11 @@ class TestCQL(UpgradeTester):
 
             assert_invalid(cursor, "SELECT v1, v2, v3 FROM test WHERE k = 0 AND (v1, v3) > (1, 0)")
 
-    @since('2.1.1')
+    @since('2.1.1', max_version='2.2.X')
     def test_v2_protocol_IN_with_tuples(self):
-        """ Test for CASSANDRA-8062 """
+        """
+        @jira_ticket CASSANDRA-8062
+        """
         cursor = self.prepare(protocol_version=2)
         cursor.execute("CREATE TABLE test (k int, c1 int, c2 text, PRIMARY KEY (k, c1, c2))")
 

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -55,7 +55,8 @@ def get_default_upgrade_path(job_version):
         # but 3.0->3.X is.
         start_version = 'git:cassandra-3.0'
 
-    assert [start_version, upgrade_version].count(None) >= 1
+    err = 'Expected one or two upgrade path endpoints to be None; found {}'.format((start_version, upgrade_version))
+    assert [start_version, upgrade_version].count(None) >= 1, err
     return UpgradePath(start_version, upgrade_version)
 
 

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -48,10 +48,10 @@ def get_default_upgrade_path(job_version):
     if '2.1' <= job_version < '2.2':
         # If this is 2.1.X, we can upgrade to 2.2.
         # Skip 2.2.X->3.X because of JDK compatibility.
-        upgrade_version = 'git:cassandra-2.2'
+        upgrade_version = 'binary:2.2.0'
     elif '3.0' <= job_version < '3.1':
         # We can choose 2.2 because it will run on JDK 1.8
-        start_version = 'git:cassandra-2.2'
+        start_version = 'binary:2.2.0'
     elif '3.1' <= job_version:
         # 2.2->3.X, where X > 0, isn't a supported upgrade path,
         # but 3.0->3.X is.


### PR DESCRIPTION
This rewrites the logic for determining the upgrade path in the storage engine upgrade tests. Rather than working off the branch name, it works off the version of the It works locally for me, both for running as-is, and for specifying paths with `UPGRADE_TO`. Demonstration of the latter is here:

http://cassci.datastax.com/job/scratch_mambocab-storage_engine_upgrades-2.1/17

This should deal with problems like [the problem tjake had](https://issues.apache.org/jira/browse/CASSANDRA-10261?focusedCommentId=14740734&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14740734) where the test ran the upgrade from cassandra-3.0 to the pre-3.0 dev branch, which isn't a supported path.