### PR TITLE
Disable hinted handoff to prevent unintended SSTable

### DIFF
--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -25,6 +25,8 @@ class TestIncRepair(Tester):
 
     def sstable_marking_test(self):
         cluster = self.cluster
+        # hinted handoff can create SSTable that we don't need after node3 restarted
+        cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 


### PR DESCRIPTION
This is for [CASSANDRA-10345](https://issues.apache.org/jira/browse/CASSANDRA-10345).
In cassandra-3.0, hinted handoff can generate SSTable during incremental repair that is not be marked as repaired.
We need to disable hinted handoff for reliable test.