### PR TITLE
fixing test_failure_threshold_deletions

### DIFF
--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -1,11 +1,12 @@
+import itertools
 import time
 import uuid
 
-from cassandra import ConsistencyLevel as CL
+from cassandra import ConsistencyLevel as CL, OperationTimedOut
 from cassandra import InvalidRequest, ReadTimeout
 from cassandra.query import SimpleStatement, dict_factory, named_tuple_factory
 from dtest import run_scenarios, debug
-from tools import since, require, rows_to_list
+from tools import since, require, rows_to_list, no_vnodes
 
 from datahelp import create_rows, parse_data_into_dicts, flatten_into_set
 from assertions import assert_invalid
@@ -1663,11 +1664,11 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
         """Test that paging throws a failure in case of tombstone threshold """
         self.allow_log_errors = True
         self.cluster.set_configuration_options(
-            values={'tombstone_failure_threshold': 500}
+            values={'tombstone_failure_threshold': 500,
+                    'read_request_timeout_in_ms': 1000}
         )
         cursor = self.prepare()
-        node1, node2 = self.cluster.nodelist()
-
+        nodes = self.cluster.nodelist()
         self.setup_schema(cursor)
 
         for is_upgraded, cursor in self.do_upgrade(cursor):
@@ -1686,11 +1687,13 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
                     consistency_level=CL.ALL
                 ))
 
-            assert_invalid(cursor, SimpleStatement("select * from paging_test", fetch_size=1000, consistency_level=CL.ALL), expected=ReadTimeout)
+            stmt = SimpleStatement("select * from paging_test", fetch_size=1000, consistency_level=CL.ALL)
+            assert_invalid(cursor, stmt, expected=ReadTimeout)
 
-            failure_msg = ("Scanned over.* tombstones in ks."
-                           "paging_test.* query aborted")
-            failure = (node1.grep_log(failure_msg) or
-                       node2.grep_log(failure_msg))
+            patterns = [r"Scanned over.* tombstones during query 'SELECT \* FROM ks.paging_test.* query aborted",  # new pattern
+                        "Scanned over.* tombstones in ks.paging_test.* query aborted"]  # old pattern
 
-            self.assertTrue(failure, "Cannot find tombstone failure threshold error in log")
+            grep = lambda n, m: bool(n.grep_log(m))
+            failed = any([grep(*a) for a in itertools.product(nodes, patterns)])
+
+            self.assertTrue(failed, "Cannot find tombstone failure threshold error in log for {} node".format(("upgraded" if is_upgraded else "old")))

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -2,11 +2,11 @@ import itertools
 import time
 import uuid
 
-from cassandra import ConsistencyLevel as CL, OperationTimedOut
+from cassandra import ConsistencyLevel as CL
 from cassandra import InvalidRequest, ReadTimeout
 from cassandra.query import SimpleStatement, dict_factory, named_tuple_factory
 from dtest import run_scenarios, debug
-from tools import since, require, rows_to_list, no_vnodes
+from tools import since, require, rows_to_list
 
 from datahelp import create_rows, parse_data_into_dicts, flatten_into_set
 from assertions import assert_invalid
@@ -1693,7 +1693,6 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             patterns = [r"Scanned over.* tombstones during query 'SELECT \* FROM ks.paging_test.* query aborted",  # new pattern
                         "Scanned over.* tombstones in ks.paging_test.* query aborted"]  # old pattern
 
-            grep = lambda n, m: bool(n.grep_log(m))
-            failed = any([grep(*a) for a in itertools.product(nodes, patterns)])
+            failed = any([n.grep_log(m) for n, m in itertools.product(nodes, patterns)])
 
             self.assertTrue(failed, "Cannot find tombstone failure threshold error in log for {} node".format(("upgraded" if is_upgraded else "old")))


### PR DESCRIPTION
This fixes one of the failing tests in CASSANDRA-10267. The log pattern we grep for has changed in 3.0, and the read_request_timeout was reduced to prevent sporadic OperationTimedOut exceptions, instead of ReadTimeout