### PR TITLE
remove @require from CASSANDRA-9775 tests

### DIFF
--- a/paging_test.py
+++ b/paging_test.py
@@ -272,7 +272,6 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
 
     @require(9775, broken_in='3.0')
     def test_with_equal_results_to_page_size(self):
-        self.skipTest("Hangs the build")
         session = self.prepare()
         self.create_ks(session, 'test_paging_size', 2)
         session.execute("CREATE TABLE paging_test ( id int PRIMARY KEY, value text )")

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -6,7 +6,7 @@ from cassandra import ConsistencyLevel as CL
 from cassandra import InvalidRequest, ReadTimeout
 from cassandra.query import SimpleStatement, dict_factory, named_tuple_factory
 from dtest import run_scenarios, debug
-from tools import since, require, rows_to_list
+from tools import since, rows_to_list
 
 from datahelp import create_rows, parse_data_into_dicts, flatten_into_set
 from assertions import assert_invalid
@@ -795,7 +795,6 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(expected_data, pf.all_data())
 
     @since('2.0.6')
-    @require(9775, broken_in='3.0')
     def static_columns_paging_test(self):
         """
         Exercises paging with static columns to detect bugs


### PR DESCRIPTION
CASSANDRA-9775 has been resolved. Since `test_with_equal_results_to_page_size` was hanging the build, I've removed the hard skip, but not the `@require`, so it will run on [the branch for `@require`d tests](http://cassci.datastax.com/job/trunk_dtest-skipped-with-require/). If it's stable there for a few days, I'll make another PR to remove the `@require` there too.