### PR TITLE
Emolsson un autopep8

### DIFF
--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -1,7 +1,6 @@
 import os
 import time
 from re import findall
-from re import search
 from unittest import skip
 
 from cassandra import ConsistencyLevel

--- a/incremental_repair_test.py
+++ b/incremental_repair_test.py
@@ -264,9 +264,10 @@ class TestIncRepair(Tester):
         expected_load_size = 4.5  # In GB
         assert_almost_equal(load_size, expected_load_size, error=0.25)
 
+    @since('2.1')
     def sstable_marking_test_not_intersecting_all_ranges(self):
         """
-        For CASSANDRA-10299
+        @jira_ticket CASSANDRA-10299
         """
         cluster = self.cluster
         cluster.populate(4, use_vnodes=True).start()
@@ -298,12 +299,11 @@ class TestIncRepair(Tester):
             debug("Repairing node 4")
             node4.nodetool("repair -inc -par")
 
-
         with open("final.txt", "w") as h:
-            node1.run_sstablemetadata(output_file=h,keyspace='keyspace1')
-            node2.run_sstablemetadata(output_file=h,keyspace='keyspace1')
-            node3.run_sstablemetadata(output_file=h,keyspace='keyspace1')
-            node4.run_sstablemetadata(output_file=h,keyspace='keyspace1')
+            node1.run_sstablemetadata(output_file=h, keyspace='keyspace1')
+            node2.run_sstablemetadata(output_file=h, keyspace='keyspace1')
+            node3.run_sstablemetadata(output_file=h, keyspace='keyspace1')
+            node4.run_sstablemetadata(output_file=h, keyspace='keyspace1')
 
         with open("final.txt", "r") as r:
             output = r.read()


### PR DESCRIPTION
@emolsson can you review? This is a rebasing of #544 to remove a few changes made with `autopep8`. Sorry, we weren't very clear about how to configure `autopep8` for this. It should be the same as your work, but with the `autopep8` commit replaced by https://github.com/riptano/cassandra-dtest/commit/e1bd34d7ddbda31de146dc0dd3cf0f8eb68ceb6a.