### PR TITLE
unrequire passing, non-hanging paging test

### DIFF
--- a/paging_test.py
+++ b/paging_test.py
@@ -270,7 +270,6 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
         # make sure expected and actual have same data elements (ignoring order)
         self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
-    @require(9775, broken_in='3.0')
     def test_with_equal_results_to_page_size(self):
         session = self.prepare()
         self.create_ks(session, 'test_paging_size', 2)


### PR DESCRIPTION
Follow-up to #566 -- this has been run on cassci for a while and it doesn't look like it fails or hangs:

http://cassci.datastax.com/job/trunk_dtest-skipped-with-require/82/testReport/paging_test/TestPagingSize/test_with_equal_results_to_page_size/history/

This test should be ready to run with normal jobs now.