### PR TITLE
Check if Windows on assert for existence of NotSslRecordException

### DIFF
--- a/native_transport_ssl_test.py
+++ b/native_transport_ssl_test.py
@@ -3,6 +3,7 @@ from dtest import Tester
 from cassandra import ConsistencyLevel
 from cassandra.cluster import NoHostAvailable
 from tools import generate_ssl_stores, putget
+from ccmlib.common import is_win
 
 
 class NativeTransportSSL(Tester):
@@ -28,8 +29,9 @@ class NativeTransportSSL(Tester):
         except NoHostAvailable:
             pass
 
-        assert len(node1.grep_log("^io.netty.handler.ssl.NotSslRecordException.*")) > 0, \
-            "Missing SSL handshake exception while connecting with non-SSL enabled client"
+        if not is_win():
+            assert len(node1.grep_log("^io.netty.handler.ssl.NotSslRecordException.*")) > 0, \
+                "Missing SSL handshake exception while connecting with non-SSL enabled client"
 
         # enabled ssl on the client and try again (this should work)
         session = self.patient_cql_connection(node1, ssl_opts={'ca_certs': os.path.join(self.test_path, 'ccm_node.cer')})


### PR DESCRIPTION
This PR adds an OS check around an assert checking for the existence of a log entry, as this log entry does not appear on Windows.

I've tested on Windows and Linux, as well as applied PEP 8 fixes from autopep8.

This issue is tracked in [CASSANDRA-10388](https://issues.apache.org/jira/browse/CASSANDRA-10388).