### PR TITLE
Clean up ssl tests, possibly begin using `nose.tools` assertions

### DIFF
--- a/native_transport_ssl_test.py
+++ b/native_transport_ssl_test.py
@@ -19,11 +19,12 @@ class NativeTransportSSL(Tester):
         cluster = self._populateCluster(enableSSL=True)
         node1 = cluster.nodelist()[0]
 
-        # try to connect without ssl options
-        try:
-            cluster.start()
-            session = self.patient_cql_connection(node1)
-            assert False, "Should not be able to connect to SSL socket without SSL enabled client"
+        cluster.start()
+
+        try:  # hack around assertRaise's lack of msg parameter
+            # try to connect without ssl options
+            self.patient_cql_connection(node1)
+            self.fail('Should not be able to connect to SSL socket without SSL enabled client')
         except NoHostAvailable:
             pass
 
@@ -42,10 +43,10 @@ class NativeTransportSSL(Tester):
         cluster = self._populateCluster(nativePort=9567)
         node1 = cluster.nodelist()[0]
 
-        try:
-            cluster.start()
-            session = self.patient_cql_connection(node1)
-            assert False, "Should not be able to connect to non-default port"
+        cluster.start()
+        try:  # hack around assertRaise's lack of msg parameter
+            self.patient_cql_connection(node1)
+            self.fail('Should not be able to connect to non-default port')
         except NoHostAvailable:
             pass
 

--- a/native_transport_ssl_test.py
+++ b/native_transport_ssl_test.py
@@ -10,9 +10,6 @@ class NativeTransportSSL(Tester):
     Native transport integration tests, specifically for ssl and port configurations.
     """
 
-    def __init__(self, *args, **kwargs):
-        Tester.__init__(self, *args, **kwargs)
-
     def connect_to_ssl_test(self):
         """
         Connecting to SSL enabled native transport port should only be possible using SSL enabled client

--- a/native_transport_ssl_test.py
+++ b/native_transport_ssl_test.py
@@ -1,7 +1,9 @@
 import os
-from dtest import Tester
+
 from cassandra import ConsistencyLevel
 from cassandra.cluster import NoHostAvailable
+
+from dtest import Tester
 from tools import generate_ssl_stores, putget, since
 
 


### PR DESCRIPTION
Depends on #580, @ptnapoleon to review.

Since this is a straight-up refactor (so, not urgent, style discussions are appropriate and worth blocking merge), I thought it might be a good place to start the `self.assertThing` vs `nose.tools.assert_thing` discussion. Philip and I had talked about how it would be nice to use the `nose.tools` after Andrew ran into problems writing custom assert functions that weren't methods. Example in action [on this line](https://github.com/riptano/cassandra-dtest/compare/master...mambocab:clean-up-ssl-tests?expand=1#diff-256d3a62cfb3c3d440953958032f15f1R35). 

I propose we start using them for new code and changed tests, and mark it as such in CONTRIBUTING. I like them better because they allow us to more easily write custom asserts. They also take up less horizontal space, which is good for readability in deeply nested code. More generally, I find them more attractive and readable, which adds up when working in the dtests all day.

The downside that I can think of is that they do introduce a dependency on `nose` in the test code itself, while the `self.assertX` methods just depend on `unittest`. That said, if we ever move off `nose`, we could roll our own replacement for this part of `nose.tools` easily; it's just a few lines of metaprogramming.