### PR TITLE
short circuit self.data access

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -179,7 +179,7 @@ class CqlshCopyTest(Tester):
         encoding_name = 'utf-8'  # codecs.lookup(locale.getpreferredencoding()).name
 
         # this seems gross but if the blob isn't set to type:bytearray is won't compare correctly
-        if isinstance(val, str) and self.data[2] == val:
+        if isinstance(val, str) and hasattr(self, 'data') and self.data[2] == val:
             var_type = bytearray
             val = bytearray(val)
         else:


### PR DESCRIPTION
self.data only exists after calling all_datatypes_prepare, so when looking it up on self, check for it before doing so.

This should deal with the recent failures in the copy tests on CassCI:

http://cassci.datastax.com/view/trunk/job/cassandra-3.0_dtest/lastCompletedBuild/testReport/cqlsh_tests.cqlsh_copy_tests/CqlshCopyTest/test_null_as_null_indicator/

http://cassci.datastax.com/view/trunk/job/cassandra-3.0_dtest/lastCompletedBuild/testReport/cqlsh_tests.cqlsh_copy_tests/CqlshCopyTest/test_undefined_as_null_indicator/

I wasn't able to reproduce the original failures locally, but this change should be safe. @nutbunnies You touched this last, right? Could you review?