### PR TITLE
Use correct delete statement to delete whole partition in MV dtest

### DIFF
--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -1067,7 +1067,7 @@ class TestMaterializedViews(Tester):
             )
 
             # delete a partition that matches the filter
-            session.execute(delete_stmt1, (1,))
+            session.execute(delete_stmt2, (1,))
             assert_all(session, "SELECT a, b, c, d FROM mv", [], cl=ConsistencyLevel.QUORUM)
 
             # Cleanup


### PR DESCRIPTION
This fixes [CASSANDRA-10460](https://issues.apache.org/jira/browse/CASSANDRA-10460).

The failures were due to the fixed bug in the dtest.