### PR TITLE
Fix default upgrade logic

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -323,10 +323,11 @@ def require(require_pattern, broken_in=None):
             return tag_and_skip
 
 
-def cassandra_git_branch():
+def cassandra_git_branch(cdir=None):
     '''Get the name of the git branch at CASSANDRA_DIR.
     '''
-    p = subprocess.Popen(['git', 'branch'], cwd=CASSANDRA_DIR,
+    cdir = CASSANDRA_DIR if cdir is None else cdir
+    p = subprocess.Popen(['git', 'branch'], cwd=cdir,
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()
     # fail if git failed

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -46,16 +46,18 @@ def get_default_upgrade_path(job_version, cdir=None):
     start_version, upgrade_version = None, None
     debug('getting default job version for {}'.format(job_version))
 
+    start_2_2_X_release = 'binary:2.2.1'
+
     if '2.1' <= job_version < '2.2':
         # If this is 2.1.X, we can upgrade to 2.2.
         # Skip 2.2.X->3.X because of JDK compatibility.
-        upgrade_version = 'binary:2.2.0'
+        upgrade_version = start_2_2_X_release
     elif '3.0' <= job_version < '3.1':
         # We can choose 2.2 because it will run on JDK 1.8
         if cassandra_git_branch(cdir=cdir) == 'trunk':
             start_version = 'binary:3.0.0-rc1'
         else:
-            start_version = 'binary:2.2.0'
+            start_version = start_2_2_X_release
     elif '3.1' <= job_version:
         # 2.2->3.X, where X > 0, isn't a supported upgrade path,
         # but 3.0->3.X is.

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -44,6 +44,7 @@ def get_default_upgrade_path(job_version):
     will be running on JDK 1.7. This means we can't run 3.0+ on this version.
     """
     start_version, upgrade_version = None, None
+    debug('getting default job version for {}'.format(job_version))
 
     if '2.1' <= job_version < '2.2':
         # If this is 2.1.X, we can upgrade to 2.2.
@@ -59,7 +60,9 @@ def get_default_upgrade_path(job_version):
 
     err = 'Expected one or two upgrade path endpoints to be None; found {}'.format((start_version, upgrade_version))
     assert [start_version, upgrade_version].count(None) >= 1, err
-    return UpgradePath(start_version, upgrade_version)
+    upgrade_path = UpgradePath(start_version, upgrade_version)
+    debug(upgrade_path)
+    return upgrade_path
 
 
 @since('3.0')
@@ -101,7 +104,7 @@ class UpgradeTester(Tester):
             self.upgrade_path = get_default_upgrade_path(self.original_version)
             if OLD_CASSANDRA_DIR:
                 cluster.set_install_dir(install_dir=OLD_CASSANDRA_DIR)
-            elif UPGRADE_TO is not None and self.upgrade_path.starting_version:
+            elif self.upgrade_path.starting_version:
                 cluster.set_install_dir(version=self.upgrade_path.starting_version)
             # in other cases, just use the existing install directory
             cluster.start(wait_for_binary_proto=True)


### PR DESCRIPTION
This fixes the logic that determines the default upgrade path for the tests in `./upgrade_tests/`. Previously, choosing the sensible default required that the `UPGRADE_TO` env variable be set, which is the opposite of what we want.

It also adds a parameter to the function that detects the Cassandra git branch so that you can pass in an argument. This parameter has a default value, and the function behaves identically with no argument specified, so it shouldn't affect other callers.