### PR TITLE
manually skip upgrade test with protocol v2

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -4087,7 +4087,7 @@ class TestCQL(UpgradeTester):
 
             assert_invalid(cursor, "SELECT v1, v2, v3 FROM test WHERE k = 0 AND (v1, v3) > (1, 0)")
 
-    @since('2.1.1', max_version='2.2.X')
+    @since('2.0', max_version='2.2.X')
     def test_v2_protocol_IN_with_tuples(self):
         """
         @jira_ticket CASSANDRA-8062
@@ -4096,7 +4096,7 @@ class TestCQL(UpgradeTester):
         cursor.execute("CREATE TABLE test (k int, c1 int, c2 text, PRIMARY KEY (k, c1, c2))")
 
         for version in (UPGRADE_TO, self.upgrade_path.upgrade_version):
-            if not '2.1.1' <= version <= '2.2.X':
+            if version >= '3.0':
                 raise SkipTest('version {} not compatible with protocol version 2'.format(version))
 
         for is_upgraded, cursor in self.do_upgrade(cursor):


### PR DESCRIPTION
This also `isort`s `cql_tests.py`.

Basically, in order to run these tests reasonably on normal branches, we need to skip all these upgrade tests on certain versions because of, e.g. Java compatibility. Then, in order to run them manually on paths that involve those versions (so, the user specifies the correct Java version and wants to override the automatic skip), we set `SKIP=false` to disable those skips. However, we _actually_ want to skip this test, because it uses protocol version 2. So, in the test itself, we check the version of the node we're querying and manually raise `nose`'s exception that skips a test.