### PR TITLE
Fix for CASSANDRA-10205

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -364,15 +364,14 @@ class TestBootstrap(Tester):
 
         # Add a new node, bootstrap=True ensures that it is not a seed
         node2 = new_node(cluster, bootstrap=True)
-        node2.start(wait_for_binary_proto=True)
+        node2.start(wait_for_binary_proto=True, wait_other_notice=True)
 
         session = self.patient_cql_connection(node2)
         self.assertEquals(original_rows, list(session.execute("SELECT * FROM {}".format(stress_table,))))
-        session.shutdown()  # Ensure all sockets to node2 are released
 
         # Decommision the new node and wipe its data
         node2.decommission()
-        node2.stop(gently=False)
+        node2.stop(wait_other_notice=True)
         data_dir = os.path.join(node2.get_path(), 'data')
         commitlog_dir = os.path.join(node2.get_path(), 'commitlogs')
         debug("Deleting {}".format(data_dir))

--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -345,7 +345,6 @@ class TestBootstrap(Tester):
         Test that if we decommission a node and then wipe its data, it can join the cluster.
         """
         cluster = self.cluster
-        cluster.set_log_level('TRACE')
         cluster.populate(3)
         cluster.start(wait_for_binary_proto=True)
 


### PR DESCRIPTION
This should fix `decommissioned_wiped_node_can_join_test` on Jenkins but it should only be merged after CASSANDRA-10205 is committed since otherwise the test will hang on `node2.stop`