### PR TITLE
Fix jmxmetrics_test usage of jmx port

### DIFF
--- a/jmxmetrics_test.py
+++ b/jmxmetrics_test.py
@@ -146,7 +146,7 @@ class TestJMXMetrics(Tester):
             if cluster.version() < "2.1":
                 node.stress(['-o', 'insert', '-n', '100000', '-p', '7100'])
             else:
-                node.stress(['write', 'n=100K', '-port jmx=7100'])
+                node.stress(['write', 'n=100K'])
 
             errors = []
             after = []


### PR DESCRIPTION
ccm lib will already add the port, so we don't need to specify it here.