### PR TITLE
do node version check in limit_multiget_test

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -366,7 +366,7 @@ class TestCQL(UpgradeTester):
             # order of keys (even though 48 is after 2)
             res = cursor.execute("SELECT * FROM clicks WHERE userid IN (48, 2) LIMIT 1")
 
-            if self.get_node_version(is_upgraded):
+            if self.get_node_version(is_upgraded) >= '2.2':
                 # the coordinator is the upgraded 2.2+ node
                 assert rows_to_list(res) == [[2, 'http://foo.com', 42]], res
             else:


### PR DESCRIPTION
This doesn't compare the node version, so it always executes the code meant for 2.2 nodes. I believe this causes a failure here:

http://cassci.datastax.com/view/Upgrades/job/storage_engine_upgrade_dtest-21_HEAD-22_tarball/20/testReport/upgrade_tests.cql_tests/TestCQL/limit_multiget_test/

On the 2.1 -> 2.2 upgrade path. @nutbunnies, can you please review?