### PR TITLE
Add note on installing latest pyhon-driver for Cassandra 3.x

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,7 +63,10 @@ will often need to modify them in some fashion at some later point:
 * python-driver
 
         cd ~/git/cstar
+        Cassandra 2.x:
         sudo pip install cassandra-driver
+        Cassandra 3.x (requires latest python-driver):
+        sudo pip install --pre cassandra-driver
         For more instructions on how to install the python-driver,
         see http://datastax.github.io/python-driver/installation.html
 


### PR DESCRIPTION
Had to spend some time to figure out why tests failed with an `NoHostAvailable: "unconfigured table schema_keyspaces"` with Cassandra 3. Looks like you need to use the latest python driver alpha release to make the tests work. Would be nice to have that actually documented somewhere.

