### PR TITLE
Test to reproduce CASSANDRA-10231 that crashes nodes during decommission

### DIFF
--- a/topology_test.py
+++ b/topology_test.py
@@ -202,10 +202,10 @@ class TestTopology(Tester):
         t = DecommissionInParallel(node1)
         t.start()
 
-        p = re.compile(".N(?:\s*)127\.0\.0\.1(?:.*)null(?:\s*)rack1")
+        null_status_pattern = re.compile(".N(?:\s*)127\.0\.0\.1(?:.*)null(?:\s*)rack1")
         while t.is_alive():
             out = self.show_status(node2)
-            if p.search(out):
+            if null_status_pattern.search(out):
                 debug("Matched null status entry")
                 break
             debug("Restarting node2")
@@ -219,7 +219,7 @@ class TestTopology(Tester):
         debug("Sleeping for 30 seconds to allow gossip updates")
         time.sleep(30)
         out = self.show_status(node2)
-        self.assertFalse(p.search(out))
+        self.assertFalse(null_status_pattern.search(out))
 
     def show_status(self, node):
         out, err = node.nodetool('status')


### PR DESCRIPTION
This PR includes tests added to topology_test that check for a null status entry on nodes that crash during the decommission of the other node. This test is necessary to reproduce [CASSANDRA-10231](https://issues.apache.org/jira/browse/CASSANDRA-10231), which is not covered by any preexisting tests.

Since topology_test was flagged as @no_vnodes at a class level, I moved this down to the scope of the preexisting methods and added the test as a new method that is not decorated.

The commit shows up as Stefania since she did the hard work of first writing this test; that said, I've rebased with nits and fixes, so I'll be responsible for any feedback.

I've run through autopep8 for low-hanging fruit.

Thanks!