### PR TITLE
Catch windowserror git

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -330,7 +330,8 @@ def cassandra_git_branch(cdir=None):
     try:
         p = subprocess.Popen(['git', 'branch'], cwd=cdir,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    except OSError:  # e.g. if git isn't available, just give up and return None
+    except OSError as e:  # e.g. if git isn't available, just give up and return None
+        debug('shelling out to git failed: {}'.format(e))
         return
 
     out, err = p.communicate()

--- a/tools.py
+++ b/tools.py
@@ -327,8 +327,12 @@ def cassandra_git_branch(cdir=None):
     '''Get the name of the git branch at CASSANDRA_DIR.
     '''
     cdir = CASSANDRA_DIR if cdir is None else cdir
-    p = subprocess.Popen(['git', 'branch'], cwd=cdir,
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        p = subprocess.Popen(['git', 'branch'], cwd=cdir,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError:  # e.g. if git isn't available, just give up and return None
+        return
+
     out, err = p.communicate()
     # fail if git failed
     if p.returncode != 0:


### PR DESCRIPTION
Previously this code assumed that `git` would be available in the environment running `nosetests`. This is not always true; this was brought to my attention by a user in a desktop Windows environment who uses a `git` shell for some work but `cmd.exe` for `nosetests`. This PR changes the function that shells out to `git` so it returns `None` if you can't shell out.