### PR TITLE
Fixes for CASSANDRA-10461

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -39,7 +39,7 @@ class TestOfflineTools(Tester):
         cluster.stop(gently=False)
 
         (output, error, rc) = node1.run_sstablelevelreset("keyspace1", "standard1", output=True)
-        debug(error)
+        self.assertEqual(len(error), 0, error)
         self.assertIn("Found no sstables, did you give the correct keyspace", output)
         self.assertEqual(rc, 0, msg=str(rc))
 
@@ -52,6 +52,7 @@ class TestOfflineTools(Tester):
         cluster.stop(gently=False)
 
         (output, error, rc) = node1.run_sstablelevelreset("keyspace1", "standard1", output=True)
+        self.assertEqual(len(error), 0, error)
         self.assertIn("since it is already on level 0", output)
         self.assertEqual(rc, 0, msg=str(rc))
 
@@ -65,6 +66,9 @@ class TestOfflineTools(Tester):
         initial_levels = self.get_levels(node1.run_sstablemetadata(keyspace="keyspace1", column_families=["standard1"]))
         (output, error, rc) = node1.run_sstablelevelreset("keyspace1", "standard1", output=True)
         final_levels = self.get_levels(node1.run_sstablemetadata(keyspace="keyspace1", column_families=["standard1"]))
+
+        self.assertEqual(len(error), 0, error)
+        self.assertEqual(rc, 0, msg=str(rc))
 
         debug(initial_levels)
         debug(final_levels)
@@ -268,7 +272,7 @@ class TestOfflineTools(Tester):
             env = common.make_cassandra_env(node.get_install_cassandra_root(), node.get_node_cassandra_root())
             p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (stdin, stderr) = p.communicate()
-            tmpsstables = stdin.split('\n')
+            tmpsstables = stdin.splitlines()
             ret = list(set(allsstables) - set(tmpsstables))
         else:
             ret = [sstable for sstable in allsstables if "tmp" not in sstable[50:]]

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -150,8 +150,8 @@ class SSTableUtilTest(Tester):
             debug(stderr)
             assert False, "Error invoking sstableutil"
 
-        ret = stdin.split('\n')
-        ret.pop(0)  # The first line is either "Listing files..." or "Cleaning up..."
+        ret = stdin.splitlines()
+        del ret[0]  # The first line is either "Listing files..." or "Cleaning up..."
         debug("Got %d files" % (len(ret),))
         return sorted(filter(None, ret))
 


### PR DESCRIPTION
As discussed on CASSANDRA-10461, to better debug disk space issues such as [this] (http://cassci.datastax.com/job/cassandra-3.0_dtest/248/testReport/offline_tools_test/TestOfflineTools/sstablelevelreset_test/), I've changed `sstablelevelreset_test` to first look at the exit code and `stderr`, and only afterwards validate `stdout`.

I've also improved splitting of `stdout` into lines for `SSTableUtilTest` since it passes locally but fails on Jenkins due to an extra line; so my best guess is a line ending problem.