### PR TITLE
add streaming_timeout_in_ms to resumable_bootstrap_test

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -128,6 +128,8 @@ class TestBootstrap(Tester):
         # start bootstrapping node3 and wait for streaming
         node3 = new_node(cluster)
         node3.set_configuration_options(values={'stream_throughput_outbound_megabits_per_sec': 1})
+        # keep timeout low so that test won't hang
+        node3.set_configuration_options(values={'streaming_socket_timeout_in_ms': 1000})
         try:
             node3.start()
         except NodeError:


### PR DESCRIPTION
Potential fix to [CASSANDRA-10167](https://issues.apache.org/jira/browse/CASSANDRA-10167).

I couldn't reproduce flapping in my laptop, but potential hang may be caused by streaming waiting to be timed out for 1 hour (default value).
This patch sets `streaming_socket_timeuout_in_ms` so that test won't hang and time out.

Can you try running this in CI env to see this will fix the problem?