### PR TITLE
Ignore output lines that are not table file names in sstableutil_test

### DIFF
--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -144,17 +144,17 @@ class SSTableUtilTest(Tester):
 
         p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        (stdin, stderr) = p.communicate()
+        (stdout, stderr) = p.communicate()
 
         if len(stderr) > 0:
             debug(stderr)
             assert False, "Error invoking sstableutil"
 
-        ret = stdin.splitlines()
-        debug(ret)
-        del ret[0]  # The first line is either "Listing files..." or "Cleaning up..."
+        debug(stdout)
+        match = ks + os.sep + table + '-'
+        ret = sorted(filter(lambda s: match in s, stdout.splitlines()))
         debug("Got %d files" % (len(ret),))
-        return sorted(filter(None, ret))
+        return ret
 
     def _get_sstable_files(self, node, ks, table):
         """


### PR DESCRIPTION
This fixes sstableutil_test.py so that it works regardless of extra output lines such as `WARN  14:58:01 Only 37512 MB free across all data volumes. Consider adding more capacity to your cluster or removing obsolete snapshots`, see CASSANDRA-10461 for more details.