### PR TITLE
run upgrade suite 2x with different cluster topos

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -5187,7 +5187,7 @@ class TestCQL(UpgradeTester):
 
 
 class TestCQLNodes3RF3(TestCQL):
-    NODES, RF, __test__ = 3, 3, True
+    NODES, RF, __test__, CL = 3, 3, True, ConsistencyLevel.ALL
 
 
 class TestCQLNodes2RF1(TestCQL):

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -5184,3 +5184,11 @@ class TestCQL(UpgradeTester):
         for is_upgraded, cursor in self.do_upgrade(cursor):
             debug("Querying %s node" % ("upgraded" if is_upgraded else "old",))
             assert_all(cursor, "SELECT k FROM ks.test WHERE v = 0", [[0]])
+
+
+class TestCQLNodes3RF3(TestCQL):
+    NODES, RF, __test__ = 3, 3, True
+
+
+class TestCQLNodes2RF1(TestCQL):
+    NODES, RF, __test__ = 2, 1, True

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -348,6 +348,14 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(pf.all_data(), expected_data)
 
 
+class TestPagingSizeNodes3RF3(TestPagingSize):
+    NODES, RF, __test__ = 3, 3, True
+
+
+class TestPagingSizeNodes2RF1(TestPagingSize):
+    NODES, RF, __test__ = 2, 1, True
+
+
 class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when CQL modifiers (such as order, limit, allow filtering) are used.
@@ -602,6 +610,14 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
                     """, format_funcs={'id': int, 'value': unicode}
                 )
             )
+
+
+class TestPagingWithModifiersNodes3RF3(TestPagingWithModifiers):
+    NODES, RF, __test__ = 3, 3, True
+
+
+class TestPagingWithModifiersNodes2RF1(TestPagingWithModifiers):
+    NODES, RF, __test__ = 2, 1, True
 
 
 class TestPagingData(BasePagingTester, PageAssertionMixin):
@@ -1071,6 +1087,14 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(expected_data, pf.all_data())
 
 
+class TestPagingDataNodes3RF3(TestPagingData):
+    NODES, RF, __test__ = 3, 3, True
+
+
+class TestPagingDataNodes2RF1(TestPagingData):
+    NODES, RF, __test__ = 2, 1, True
+
+
 class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when the queried dataset changes while pages are being retrieved.
@@ -1265,6 +1289,14 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(page3, page3expected)
 
 
+class TestPagingDatasetChangesNodes3RF3(TestPagingDatasetChanges):
+    NODES, RF, __test__ = 3, 3, True
+
+
+class TestPagingDatasetChangesNodes2RF1(TestPagingDatasetChanges):
+    NODES, RF, __test__ = 2, 1, True
+
+
 class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with isolation of paged queries (queries can't affect each other).
@@ -1352,6 +1384,14 @@ class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(flatten_into_set(page_fetchers[8].all_data()), flatten_into_set(expected_data[15000:20000]))
             self.assertEqualIgnoreOrder(flatten_into_set(page_fetchers[9].all_data()), flatten_into_set(expected_data[20000:25000]))
             self.assertEqualIgnoreOrder(flatten_into_set(page_fetchers[10].all_data()), flatten_into_set(expected_data[:50000]))
+
+
+class TestPagingQueryIsolationNodes3RF3(TestPagingQueryIsolation):
+    NODES, RF, __test__ = 3, 3, True
+
+
+class TestPagingQueryIsolationNodes2RF1(TestPagingQueryIsolation):
+    NODES, RF, __test__ = 2, 1, True
 
 
 class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
@@ -1679,3 +1719,11 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             failed = any([n.grep_log(m) for n, m in itertools.product(nodes, patterns)])
 
             self.assertTrue(failed, "Cannot find tombstone failure threshold error in log for {} node".format(("upgraded" if is_upgraded else "old")))
+
+
+class TestPagingWithDeletionsNodes3RF3(TestPagingWithDeletions):
+    NODES, RF, __test__ = 3, 3, True
+
+
+class TestPagingWithDeletionsNodes2RF1(TestPagingWithDeletions):
+    NODES, RF, __test__ = 2, 1, True

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -349,7 +349,7 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
 
 
 class TestPagingSizeNodes3RF3(TestPagingSize):
-    NODES, RF, __test__ = 3, 3, True
+    NODES, RF, __test__, CL = 3, 3, True, CL.ALL
 
 
 class TestPagingSizeNodes2RF1(TestPagingSize):
@@ -613,7 +613,7 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
 
 
 class TestPagingWithModifiersNodes3RF3(TestPagingWithModifiers):
-    NODES, RF, __test__ = 3, 3, True
+    NODES, RF, __test__, CL = 3, 3, True, CL.ALL
 
 
 class TestPagingWithModifiersNodes2RF1(TestPagingWithModifiers):
@@ -1088,7 +1088,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
 
 class TestPagingDataNodes3RF3(TestPagingData):
-    NODES, RF, __test__ = 3, 3, True
+    NODES, RF, __test__, CL = 3, 3, True, CL.ALL
 
 
 class TestPagingDataNodes2RF1(TestPagingData):
@@ -1290,7 +1290,7 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
 
 
 class TestPagingDatasetChangesNodes3RF3(TestPagingDatasetChanges):
-    NODES, RF, __test__ = 3, 3, True
+    NODES, RF, __test__, CL = 3, 3, True, CL.ALL
 
 
 class TestPagingDatasetChangesNodes2RF1(TestPagingDatasetChanges):
@@ -1387,7 +1387,7 @@ class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
 
 
 class TestPagingQueryIsolationNodes3RF3(TestPagingQueryIsolation):
-    NODES, RF, __test__ = 3, 3, True
+    NODES, RF, __test__, CL = 3, 3, True, CL.ALL
 
 
 class TestPagingQueryIsolationNodes2RF1(TestPagingQueryIsolation):
@@ -1722,7 +1722,7 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
 
 
 class TestPagingWithDeletionsNodes3RF3(TestPagingWithDeletions):
-    NODES, RF, __test__ = 3, 3, True
+    NODES, RF, __test__, CL = 3, 3, True, CL.ALL
 
 
 class TestPagingWithDeletionsNodes2RF1(TestPagingWithDeletions):

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -82,8 +82,12 @@ class UpgradeTester(Tester):
     When run on 3.0, this will test the upgrade path to trunk. When run on
     versions above 3.0, this will test the upgrade path from 3.0 to HEAD.
     """
+    NODES, RF, __test__ = 2, 1, False
 
-    def prepare(self, ordered=False, create_keyspace=True, use_cache=False, nodes=2, rf=1, protocol_version=None, **kwargs):
+    def prepare(self, ordered=False, create_keyspace=True, use_cache=False, nodes=None, rf=None, protocol_version=None, **kwargs):
+        nodes = self.NODES if nodes is None else nodes
+        rf = self.RF if rf is None else rf
+
         assert nodes >= 2, "backwards compatibility tests require at least two nodes"
         assert not self._preserve_cluster, "preserve_cluster cannot be True for upgrade tests"
 


### PR DESCRIPTION
This makes each upgrade test run twice, each with a different topology. It does this basically by treating the test methods as methods from mixins and adding a bunch of extra classes that are actually run as the tests.

Requesting review from @thobbs and from @ptnapoleon. @ptnapoleon, sorry to ask this of you, but could you double-check that I've made 2 subclasses of each test class in `upgrade_test`? I don't think I missed any, but I want to make sure none of them fell through the cracks. (There may also be a better solution here, open to suggestions.)