### PR TITLE
Use 2.2.3 upgrades

### DIFF
--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -111,7 +111,17 @@ class UpgradeTester(Tester):
             if OLD_CASSANDRA_DIR:
                 cluster.set_install_dir(install_dir=OLD_CASSANDRA_DIR)
             elif self.upgrade_path.starting_version:
-                cluster.set_install_dir(version=self.upgrade_path.starting_version)
+                try:
+                    cluster.set_install_dir(version=self.upgrade_path.starting_version)
+                except:
+                    if self.upgrade_path.starting_version.startswith('binary'):
+                        debug('Exception while downloading {}; falling back to source'.format(
+                            self.upgrade_path.starting_version))
+                        version_number = self.upgrade_path.starting_version.split(':')[-1]
+                        source_ccm_id = 'git:cassandra-' + version_number
+                        debug('Source identifier: {}'.format(source_ccm_id))
+                        cluster.set_install_dir(version=source_ccm_id)
+
             # in other cases, just use the existing install directory
             cluster.start(wait_for_binary_proto=True)
             debug('starting from {}'.format(get_version_from_build(node1.get_install_dir())))

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -46,7 +46,7 @@ def get_default_upgrade_path(job_version, cdir=None):
     start_version, upgrade_version = None, None
     debug('getting default job version for {}'.format(job_version))
 
-    start_2_2_X_release = 'binary:2.2.2'
+    start_2_2_X_release = 'binary:2.2.3'
 
     if '2.1' <= job_version < '2.2':
         # If this is 2.1.X, we can upgrade to 2.2.


### PR DESCRIPTION
This does 2 things:

- bumps up 2.2.latest for the upgrade test defaults
- adds some (really quite gross) logic for falling back to downloading from git rather than the archive.