### PR TITLE
Wait before checking the node is running

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -467,6 +467,7 @@ class TestBootstrap(Tester):
         process = node3.start()
         stdout, stderr = process.communicate()
         self.assertIn(bootstrap_error, stderr, msg=stderr)
+        time.sleep(.5)
         self.assertFalse(node3.is_running(), msg="Two nodes bootstrapped simultaneously")
 
         node2.watch_log_for("Starting listening for CQL clients")


### PR DESCRIPTION
This is for [CASSANDRA-10578](https://issues.apache.org/jira/browse/CASSANDRA-10578).
Added sleep before checking cassandra process is not running.

Hope this helps running test reliably.