### PR TITLE
Print error with new lines

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -542,7 +542,7 @@ class Tester(TestCase):
         failed = sys.exc_info() != (None, None, None)
         try:
             for node in self.cluster.nodelist():
-                if self.allow_log_errors == False:
+                if not self.allow_log_errors:
                     errors = list(self.__filter_errors(
                         ['\n'.join(msg) for msg in node.grep_log_for_errors()]))
                     if len(errors) is not 0:
@@ -621,7 +621,7 @@ class Tester(TestCase):
         """
         try:
             return node.network_interfaces['binary'][1]
-        except Exception as e:
+        except Exception:
             raise RuntimeError("No network interface defined on this node object. {}".format(node.network_interfaces))
 
     def get_auth_provider(self, user, password):

--- a/dtest.py
+++ b/dtest.py
@@ -544,7 +544,7 @@ class Tester(TestCase):
             for node in self.cluster.nodelist():
                 if self.allow_log_errors == False:
                     errors = list(self.__filter_errors(
-                        [' '.join(msg) for msg in node.grep_log_for_errors()]))
+                        ['\n'.join(msg) for msg in node.grep_log_for_errors()]))
                     if len(errors) is not 0:
                         failed = True
                         raise AssertionError('Unexpected error in %s node log: %s' % (node.name, errors))


### PR DESCRIPTION
@ptnapoleon can you review? We disucssed this privately.

This change prints the log errors split by newlines rather than spaces. Doesn't actually make a huge difference unless you want to do some post-processing. Before (results truncated):

```
AssertionError: Unexpected error in node1 node log: ['ERROR [main] 2015-10-29 10:53:49,321 LogTransaction.java:436 - Failed to remove unfinished transaction leftovers for txn [/tmp/dtest-_iDCHG/test/node1/data/system/local-7ad54392bcdd35a684174e047860b377/ma_txn_compaction_dac891a0-7e4c-11e5-9df1-6d10b7106813.log]  java.lang.NullPointerException: null \tat org.apache.cassandra.db.lifecycle.LogRecord.getExistingFiles(LogRecord.java:243) ~[main/:na] \tat org.apache.cassandra.db.lifecycle.LogRecord.getExistingFiles(LogRecord.java:237) ~[main/:na] \tat org.apache.cassandra.db.lifecycle.LogFile.deleteRecordFiles(LogFile.java:308) ~[main/:na] \tat java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184) ~[na:1.8.0_60] \tat java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175) ~[na:1.8.0_60] \tat java.util.Iterator.forEachRemaining(Iterator.java:116) ~[na:1.8.0_60] \tat java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[na:1.8.0_60] \tat java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[na:1.8.0_60] \tat java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[na:1.8.0_60] \tat java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151) ~[na:1.8.0_60] \tat java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174) ~[na:1.8.0_60] \tat java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:1.8.0_60] \tat java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418) ~[na:1.8.0_60] \tat org.apache.cassandra.db.lifecycle.LogFile.deleteFilesForRecordsOfType(LogFile.java:302) ~[main/:na] \tat org.apache.cassandra.db.lifecycle.LogFile.removeUnfinishedLeftovers(LogFile.java:95) ~[main/:na] \tat org.apache.cassandra.db.lifecycle.LogTransaction$LogFilesByName.removeUnfinishedLeftovers(LogTransaction.java:434) ~[main/:na] \tat java.util.HashMap.forEach(HashMap.java:1280) ~[na:1.8.0_60] \tat org.apache.cassandra.db.lifecycle.LogTransaction$LogFilesByName.removeUnfinishedLeftovers(LogTransaction.java:424) ~[main/:na] \tat org.apache.cassandra.db.lifecycle.LogTransaction.removeUnfinishedLeftovers(LogTransaction.java:398) ~[main/:na] \tat org.apache.cassandra.db.
```

And after:

```
AssertionError: Unexpected error in node1 node log: ['ERROR [main] 2015-10-29 10:42:13,596 LogTransaction.java:436 - Failed to remove unfinished transaction leftovers for txn [/tmp/dtest-3prmik/test/node1/data/system/local-7ad54392bcdd35a684174e047860b377/ma_txn_compaction_3c1a6d40-7e4b-11e5-98ea-6d10b7106813.log] \njava.lang.NullPointerException: null\n\tat org.apache.cassandra.db.lifecycle.LogRecord.getExistingFiles(LogRecord.java:243) ~[main/:na]\n\tat org.apache.cassandra.db.lifecycle.LogRecord.getExistingFiles(LogRecord.java:237) ~[main/:na]\n\tat org.apache.cassandra.db.lifecycle.LogFile.deleteRecordFiles(LogFile.java:308) ~[main/:na]\n\tat java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184) ~[na:1.8.0_60]\n\tat java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175) ~[na:1.8.0_60]\n\tat java.util.Iterator.forEachRemaining(Iterator.java:116) ~[na:1.8.0_60]\n\tat java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[na:1.8.0_60]\n\tat java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[na:1.8.0_60]\n\tat java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[na:1.8.0_60]\n\tat java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151) ~[na:1.8.0_60]\n\tat 
```

You get the idea -- basically you see a lot of '\n\t' instead of ' \t'. It's a little better.

I've also included a couple little style changes for linter errors I got locally. Changing `if self.allow_log_errors == False:` to `if not self.allow_log_errors:` is a semantic change, but I don't see anywhere in the codebase that would be affected:

```
$ ag allow_log_errors
sstable_generation_loading_test.py
15:        self.allow_log_errors = True

paging_test.py
1523:        self.allow_log_errors = True

bootstrap_test.py
33:        self.allow_log_errors = True

commitlog_test.py
25:        self.allow_log_errors = True

dtest.py
174:        self.allow_log_errors = False
545:                if not self.allow_log_errors:

concurrent_schema_changes_test.py
28:        self.allow_log_errors = True

pushed_notifications_test.py
273:        self.allow_log_errors = True

replace_address_test.py
34:        self.allow_log_errors = True

upgrade_tests/paging_test.py
1688:        self.allow_log_errors = True
```

In the other style change (`except Exception as e:` -> `except Exception:`) the variable created was never used, so this shouldn't affect behavior.