### PR TITLE
thrift_hsha: Allow a few seconds to go by while testing for closed sockets

### DIFF
--- a/thrift_hsha_test.py
+++ b/thrift_hsha_test.py
@@ -68,8 +68,12 @@ class ThriftHSHATest(Tester):
             debug("Closing connections from the client side..")
             for pool in pools:
                 pool.dispose()
-            stdout = subprocess.Popen(["lsof -a -p %s -iTCP -sTCP:CLOSE_WAIT" % node1.pid], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True).communicate()[0]
-            lines = stdout.splitlines()
+            for i in range(0, 3):
+                stdout = subprocess.Popen(["lsof -a -p %s -iTCP -sTCP:CLOSE_WAIT" % node1.pid], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True).communicate()[0]
+                lines = stdout.splitlines()
+                if len(lines) == 0:
+                    break
+                time.sleep(1)
             self.assertEqual(len(lines), 0, "There are non-closed connections: %s" % stdout)
 
     @unittest.skipIf(not os.path.exists(ATTACK_JAR), "No attack jar found")


### PR DESCRIPTION
When running this in a tight loop locally, I can reproduce it very infrequently; if I add the pause here, I haven't seen this ever happen (been running for a few hours).