### PR TITLE
workaround for CASSANDRA-10632

### DIFF
--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -177,9 +177,9 @@ class SSTableUtilTest(Tester):
 
         (stdout, stderr) = p.communicate()
 
-        if len(stderr) > 0:
+        if p.returncode != 0:
             debug(stderr)
-            assert False, "Error invoking sstableutil"
+            assert False, "Error invoking sstableutil; returned {code}".format(code=p.returncode)
 
         debug(stdout)
         match = ks + os.sep + table + '-'


### PR DESCRIPTION
The `sstableutil` tests fail on Windows because they compared the output from `sstableutil` and `glob.glob`, which were outputting filenames in different (but still correct, because of Windows tooling's case-insensitivity) casings. In my OpenStack Windows test environment, I'd also get different strings for filenames for the same files because filenames would get abbreviated to their short forms with `~1` when returned by (IIRC) `glob.glob`.

Once we port to Py3, we should be able to can switch to using `os.path.samefile`. For the moment, we'll have to work around it. The solution here is to trim the common prefix from each filename when we get them back from a given tool. The remainder will uniquely identify the file and allow us to make sure the same files are reported by `sstableutil` and `glob.glob`.

This PR also checks if `sstableutil` fails by checking the return code, not checking the `stderr`, because sometimes there are warnings that we don't care about.

In my OpenStack Windows environment, this makes `sstableutil_test.py:SSTableUtilTest.compaction_test` pass, but `sstableutil_test.py:SSTableUtilTest.abortedcompaction_test` still fails when the calculated value of `expected_tempfiles` is an empty list here:

https://github.com/mambocab/cassandra-dtest/blob/10632/sstableutil_test.py#L149

Still, it's an improvement. @josh-mckenzie and @ptnapoleon, can you please review?