### PR TITLE
Improve/add MV tests around bootstrapping/adding datacenters

### DIFF
--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -324,15 +324,15 @@ class TestMaterializedViews(Tester):
 
         debug("Writing 1k to base")
         for i in xrange(1000):
-            session.execute("INSERT INTO t (id, v) VALUES ({v}, {v})".format(v=i))
+            session.execute("INSERT INTO t (id, v) VALUES ({id}, {v})".format(id=i, v=-i))
 
         debug("Reading 1k from view")
         for i in xrange(1000):
-            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(i), [i, i])
+            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
 
         debug("Reading 1k from base")
         for i in xrange(1000):
-            assert_one(session, "SELECT * FROM t WHERE id = {}".format(i), [i, i])
+            assert_one(session, "SELECT * FROM t WHERE id = {}".format(i), [i, -i])
 
         debug("Bootstrapping new node in another dc")
         node4 = new_node(self.cluster, data_center='dc2')
@@ -346,15 +346,15 @@ class TestMaterializedViews(Tester):
 
         debug("Verifying data from new node in view")
         for i in xrange(1000):
-            assert_one(session2, "SELECT * FROM ks.t_by_v WHERE v = {}".format(i), [i, i])
+            assert_one(session2, "SELECT * FROM ks.t_by_v WHERE v = {}".format(-i), [-i, i])
 
         debug("Inserting 100 into base")
         for i in xrange(1000, 1100):
-            session.execute("INSERT INTO t (id, v) VALUES ({v}, {v})".format(v=i))
+            session.execute("INSERT INTO t (id, v) VALUES ({id}, {v})".format(id=i, v=-i))
 
         debug("Verify 100 in view")
         for i in xrange(1000, 1100):
-            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(i), [i, i])
+            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
 
     def add_node_after_mv_test(self):
         """Test that materialized views work as expected when adding a node."""
@@ -366,10 +366,10 @@ class TestMaterializedViews(Tester):
                          "WHERE v IS NOT NULL AND id IS NOT NULL PRIMARY KEY (v, id)"))
 
         for i in xrange(1000):
-            session.execute("INSERT INTO t (id, v) VALUES ({v}, {v})".format(v=i))
+            session.execute("INSERT INTO t (id, v) VALUES ({id}, {v})".format(id=i, v=-i))
 
         for i in xrange(1000):
-            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(i), [i, i])
+            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
 
         node4 = new_node(self.cluster)
         node4.start(wait_for_binary_proto=True)
@@ -377,13 +377,37 @@ class TestMaterializedViews(Tester):
         session2 = self.patient_exclusive_cql_connection(node4)
 
         for i in xrange(1000):
-            assert_one(session2, "SELECT * FROM ks.t_by_v WHERE v = {}".format(i), [i, i])
+            assert_one(session2, "SELECT * FROM ks.t_by_v WHERE v = {}".format(-i), [-i, i])
 
         for i in xrange(1000, 1100):
-            session.execute("INSERT INTO t (id, v) VALUES ({v}, {v})".format(v=i))
+            session.execute("INSERT INTO t (id, v) VALUES ({id}, {v})".format(id=i, v=-i))
 
         for i in xrange(1000, 1100):
-            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(i), [i, i])
+            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
+
+    def add_survey_node_after_mv_test(self):
+        """Test that materialized views work as expected when adding a node."""
+
+        session = self.prepare()
+
+        session.execute("CREATE TABLE t (id int PRIMARY KEY, v int)")
+        session.execute(("CREATE MATERIALIZED VIEW t_by_v AS SELECT * FROM t "
+                         "WHERE v IS NOT NULL AND id IS NOT NULL PRIMARY KEY (v, id)"))
+
+        for i in xrange(1000):
+            session.execute("INSERT INTO t (id, v) VALUES ({id}, {v})".format(id=i, v=-i))
+
+        for i in xrange(1000):
+            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
+
+        node4 = new_node(self.cluster)
+        node4.start(wait_for_binary_proto=True, jvm_args=["-Dcassandra.write_survey=true"])
+
+        for i in xrange(1000, 1100):
+            session.execute("INSERT INTO t (id, v) VALUES ({id}, {v})".format(id=i, v=-i))
+
+        for i in xrange(1100):
+            assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
 
     def allow_filtering_test(self):
         """Test that allow filtering works as usual for a materialized view"""

--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -312,9 +312,7 @@ class TestMaterializedViews(Tester):
         result = list(session.execute("SELECT * FROM ks.users_by_state_birth_year WHERE state='TX' AND birth_year=1968"))
         self.assertEqual(len(result), 1, "Expecting {} users, got {}".format(1, len(result)))
 
-    def __add_dc_after_mv_test(self, rf):
-        """Test that materialized views work as expected when adding a datacenter."""
-
+    def _add_dc_after_mv_test(self, rf):
         session = self.prepare(rf=rf)
 
         debug("Creating schema")
@@ -357,10 +355,22 @@ class TestMaterializedViews(Tester):
             assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
 
     def add_dc_after_mv_simple_replication_test(self):
-        self.__add_dc_after_mv_test(1)
+        """
+        @jira_ticket CASSANDRA-10634
+
+        Test that materialized views work as expected when adding a datacenter with SimpleStrategy.
+        """
+
+        self._add_dc_after_mv_test(1)
 
     def add_dc_after_mv_network_replication_test(self):
-        self.__add_dc_after_mv_test({'dc1': 1, 'dc2': 1})
+        """
+        @jira_ticket CASSANDRA-10634
+
+        Test that materialized views work as expected when adding a datacenter with NetworkTopologyStrategy.
+        """
+
+        self._add_dc_after_mv_test({'dc1': 1, 'dc2': 1})
 
 
     def add_node_after_mv_test(self):
@@ -392,8 +402,12 @@ class TestMaterializedViews(Tester):
         for i in xrange(1000, 1100):
             assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
 
-    def add_survey_node_after_mv_test(self):
-        """Test that materialized views work as expected when adding a node."""
+    def add_write_survey_node_after_mv_test(self):
+        """
+        @jira_ticket CASSANDRA-10621
+
+        Test that materialized views work as expected when adding a node in write survey mode.
+        """
 
         session = self.prepare()
 

--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -312,10 +312,10 @@ class TestMaterializedViews(Tester):
         result = list(session.execute("SELECT * FROM ks.users_by_state_birth_year WHERE state='TX' AND birth_year=1968"))
         self.assertEqual(len(result), 1, "Expecting {} users, got {}".format(1, len(result)))
 
-    def add_dc_after_mv_test(self):
+    def __add_dc_after_mv_test(self, rf):
         """Test that materialized views work as expected when adding a datacenter."""
 
-        session = self.prepare()
+        session = self.prepare(rf=rf)
 
         debug("Creating schema")
         session.execute("CREATE TABLE t (id int PRIMARY KEY, v int)")
@@ -355,6 +355,13 @@ class TestMaterializedViews(Tester):
         debug("Verify 100 in view")
         for i in xrange(1000, 1100):
             assert_one(session, "SELECT * FROM t_by_v WHERE v = {}".format(-i), [-i, i])
+
+    def add_dc_after_mv_simple_replication_test(self):
+        self.__add_dc_after_mv_test(1)
+
+    def add_dc_after_mv_network_replication_test(self):
+        self.__add_dc_after_mv_test({'dc1': 1, 'dc2': 1})
+
 
     def add_node_after_mv_test(self):
         """Test that materialized views work as expected when adding a node."""


### PR DESCRIPTION
This adds/fixes tests for [CASSANDRA-10621](https://issues.apache.org/jira/browse/CASSANDRA-10621) and [CASSANDRA-10634](https://issues.apache.org/jira/browse/CASSANDRA-10634).

A few changes are made:
* in the tests for bootstrapping nodes and adding datacenters, we modify the test so that the values for the partition key are different between the base table and the view table. This prevents nodes from always being paired to themselves in view replica calculation
* we add a test for Cassandra write survey mode
* we make sure to test adding datacenters under NetworkTopologyStrategy and SimpleStrategy