### PR TITLE
Skip static columns paging test 10476

### DIFF
--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -1,6 +1,7 @@
 import itertools
 import time
 import uuid
+from unittest import SkipTest
 
 from cassandra import ConsistencyLevel as CL
 from cassandra import InvalidRequest, ReadFailure, ReadTimeout
@@ -834,6 +835,12 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
         cursor.execute("CREATE TABLE test (a int, b int, c int, s1 int static, s2 int static, PRIMARY KEY (a, b))")
 
         for is_upgraded, cursor in self.do_upgrade(cursor):
+            min_version = min(self.get_node_versions())
+            latest_version_with_bug = '2.2.3'
+            if min_version <= latest_version_with_bug:
+                raise SkipTest('known bug released in {latest_ver} and earlier (current min version {min_ver}); '
+                               'skipping'.format(latest_ver=latest_version_with_bug, min_ver=min_version))
+
             cursor.row_factory = dict_factory
             debug("Querying %s node" % ("upgraded" if is_upgraded else "old",))
             cursor.execute("TRUNCATE test")

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -3,13 +3,12 @@ import time
 import uuid
 
 from cassandra import ConsistencyLevel as CL
-from cassandra import InvalidRequest, ReadTimeout, ReadFailure
+from cassandra import InvalidRequest, ReadFailure, ReadTimeout
 from cassandra.query import SimpleStatement, dict_factory, named_tuple_factory
-from dtest import run_scenarios, debug
-from tools import since, rows_to_list
 
-from datahelp import create_rows, parse_data_into_dicts, flatten_into_set
-
+from datahelp import create_rows, flatten_into_set, parse_data_into_dicts
+from dtest import debug, run_scenarios
+from tools import rows_to_list, since
 from upgrade_base import UpgradeTester
 
 


### PR DESCRIPTION
As per a comment from Sylvain on CASSANDRA-10476:

> We do expect 2.2.3 -> 3.0 upgrade to succeed. We don't expect
> static_columns_paging_test to pass however since that test don't even
> pass for non-upgrade test on 2.2.3, it's a bug of 2.2.3 that has been
> fixed in 2.2.4 (CASSANDRA-10381). If we can make so that the test
> doesn't run on 2.2.3 (but does run once we'll update to 2.2.4), that
> would be perfect.

@pcmanus is this what you had in mind? This will skip the entire test if any node is version 2.2.3 or lower. Another option is to still run the test, but only query nodes running higher versions. I'm not sure what configurations we expect errors in.