### PR TITLE
jmx_test exception handling

### DIFF
--- a/jmx_test.py
+++ b/jmx_test.py
@@ -69,21 +69,21 @@ class TestJMX(Tester):
         node1.flush()
         node1.stop(gently=False)
         try:
-            node1.nodetool("netstats")
+            node1.nodetool('netstats')
         except Exception as e:
-            if "ConcurrentModificationException" in str(e):
-                self.fail("Netstats failed due to CASSANDRA-6577")
+            if 'ConcurrentModificationException' in str(e):
+                self.fail('Netstats failed due to CASSANDRA-6577')
             else:
                 debug(str(e))
 
         node1.start(wait_for_binary_proto=True)
 
         try:
-            node1.nodetool("netstats")
+            node1.nodetool('netstats')
         except Exception as e:
             if 'java.lang.reflect.UndeclaredThrowableException' in str(e):
                 debug(str(e))
-                self.fail("Netstats failed with UndeclaredThrowableException (CASSANDRA-8122)")
+                self.fail('Netstats failed with UndeclaredThrowableException (CASSANDRA-8122)')
             else:
                 self.fail(str(e))
 


### PR DESCRIPTION
2 commits here:

- one that does `s/"/'/` for Python nerd purposes, and
- one that cleans up the exception-handling logic in `jmx_test.py`.

The main reason for this PR is because I have a question about the existing logic here:

https://github.com/riptano/cassandra-dtest/compare/master...mambocab:jmx_test-exception-handling?expand=1#diff-a5036552850755a7ef3b1b262c2f2727L77

This catches the exception, checks to see if its message meets some criteron, then happily continues running the test. In the other call to `nodetool netstats`, it fails the test regardless of whether the exception meets our criterion or not:

https://github.com/riptano/cassandra-dtest/compare/master...mambocab:jmx_test-exception-handling?expand=1#diff-a5036552850755a7ef3b1b262c2f2727L88

Is both of these correct? The first seems wrong to me.

EDIT: Is both of these correct? Oh good.