### PR TITLE
Skip concurrent schema changes

### DIFF
--- a/concurrent_schema_changes_test.py
+++ b/concurrent_schema_changes_test.py
@@ -6,9 +6,9 @@ import time
 from random import randrange
 from threading import Thread
 
+from cassandra.concurrent import execute_concurrent
 from ccmlib.node import Node
 
-from cassandra.concurrent import execute_concurrent
 from dtest import Tester, debug
 from tools import since
 

--- a/concurrent_schema_changes_test.py
+++ b/concurrent_schema_changes_test.py
@@ -20,6 +20,7 @@ def wait(delay=2):
     time.sleep(delay)
 
 
+@require(10699)
 class TestConcurrentSchemaChanges(Tester):
 
     def __init__(self, *argv, **kwargs):


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CASSANDRA-10665. @nutbunnies, are any of these supposed to pass reliably, or should we `require` away the whole suite until we have our improved view onto failing tests?