### PR TITLE
don't use bare except trying to strip timeszones

### DIFF
--- a/cqlsh_tests/cqlsh_tools.py
+++ b/cqlsh_tests/cqlsh_tools.py
@@ -31,7 +31,7 @@ def strip_timezone_if_time_string(s):
         time_struct = time.strptime(time_string_no_tz, '%Y-%m-%d %H:%M:%S')
         dt_no_timezone = datetime.datetime(*time_struct[:6])
         return dt_no_timezone.strftime('%Y-%m-%d %H:%M:%S')
-    except:
+    except (TypeError, ValueError):
         return s
 
 


### PR DESCRIPTION
I believe `ValueError`s and `TypeError`s are the only ones thrown when the functions called here are provided incorrect arguments. I ran the cqlsh_copy_tests and nothing blew up, which is promising. (In any event, we need to not use a bare `except:` here, so if this is an incomplete list of exceptions to check for, it'll still be a starting point for doing this correctly.)