### PR TITLE
increase # of records for abortedcompaction_test

### DIFF
--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -60,7 +60,7 @@ class SSTableUtilTest(Tester):
         cluster.populate(1).start(wait_for_binary_proto=True)
         node = cluster.nodelist()[0]
 
-        numrecords = 200000
+        numrecords = 400000
 
         self._create_data(node, KeyspaceName, TableName, numrecords)
         finalfiles, tmpfiles = self._check_files(node, KeyspaceName, TableName)


### PR DESCRIPTION
On Linux, abortedcompaction_test is flapping when it fails to find any
temporary files. The comment indicates that we should try increasing the
number of records so that temporary files are still around by the time
we check for them. This commit does that.

This is part of CASSANDRA-10664, and will hopefully make this test stop flapping:

http://cassci.datastax.com/job/cassandra-3.0_dtest/355/testReport/junit/sstableutil_test/SSTableUtilTest/abortedcompaction_test/

I don't know if it's necessary to double the number of records; maybe bumping them 50% would be sufficient. I just picked a number, really. Before this change, this test can take between 2.5 and 3 minutes sometimes, FWIW.