### PR TITLE
Fix  strip common prefix

### DIFF
--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -12,18 +12,19 @@ KeyspaceName = 'keyspace1'
 TableName = 'standard1'
 
 
+def _remove_prefix(string, prefix):
+    assert string.startswith(prefix), '{p} not a prefix of {s}'.format(p=prefix, s=string)
+    suffix = string[len(prefix):]
+    assert string.endswith(suffix), '{u} not a prefix of {t}'.format(u=suffix, t=string)
+    assert len(suffix) + len(prefix) == len(string)
+    return suffix
+
+
 def _strip_common_prefix(strings):
     strings = list(map(os.path.normcase, strings))
     common_prefix = os.path.commonprefix(strings)
 
-    rvs = []
-    for s in strings:
-        stripped = s[len(common_prefix):]
-        assert len(stripped) + len(common_prefix) == len(s)
-        assert s.endswith(stripped)
-        rvs.append(stripped)
-
-    return rvs
+    return [_remove_prefix(string, common_prefix) for string in strings]
 
 
 @since('3.0')

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -145,6 +145,8 @@ class SSTableUtilTest(Tester):
 
         if len(expected_tmpfiles) == 0:
             expected_tmpfiles = sorted(list(set(allfiles) - set(finalfiles)))
+        if common.is_win():
+            expected_tmpfiles = _strip_common_prefix(expected_tmpfiles)
 
         debug("Comparing tmp files...")
         tmpfiles = self._invoke_sstableutil(ks, table, type='tmp')

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -143,14 +143,13 @@ class SSTableUtilTest(Tester):
 
         self.assertEqual(expected_finalfiles, finalfiles)
 
-        if len(expected_tmpfiles) == 0:
-            expected_tmpfiles = sorted(list(set(allfiles) - set(finalfiles)))
-        if common.is_win():
-            expected_tmpfiles = _strip_common_prefix(expected_tmpfiles)
-
         debug("Comparing tmp files...")
         tmpfiles = self._invoke_sstableutil(ks, table, type='tmp')
-        self.assertEqual(expected_tmpfiles, tmpfiles)
+
+        common_prefix = os.path.commonprefix(list(tmpfiles) + list(expected_tmpfiles))
+
+        self.assertEqual([_remove_prefix(s, common_prefix) for s in tmpfiles],
+                         [_remove_prefix(s, common_prefix) for s in expected_tmpfiles])
 
         debug("Comparing op logs...")
         expectedoplogs = sorted(self._get_sstable_transaction_logs(node, ks, table))

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -15,11 +15,12 @@ TableName = 'standard1'
 def _strip_common_prefix(strings):
     strings = list(map(os.path.normcase, strings))
     common_prefix = os.path.commonprefix(strings)
+
     rvs = []
     for s in strings:
-        stripped = s.lstrip(common_prefix)
-        if s:
-            assert stripped
+        stripped = s[len(common_prefix):]
+        assert len(stripped) + len(common_prefix) == len(s)
+        assert s.endswith(stripped)
         rvs.append(stripped)
 
     return rvs


### PR DESCRIPTION
Fixes the problem described [in this Jira comment from Joel](https://issues.apache.org/jira/browse/CASSANDRA-10632?focusedCommentId=15007942&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15007942) and adds some assertions that the prefix-stripping works correctly.

I used the file in [this Gist](https://gist.github.com/865f97bde4534bd3f89c) to smoke test the changed function:

```python
In [1]: from sstableutil_test import _strip_common_prefix ; from filenames import filenames                                                                                   

In [2]: _strip_common_prefix(filenames)
Out[2]: 
['1-big-CRC.db',
 '1-big-Data.db',
 '1-big-Digest.crc32',
 '1-big-Filter.db',
 '1-big-Index.db',
 '1-big-Statistics.db',
 '1-big-Summary.db',
 '1-big-TOC.txt',
 '2-big-CRC.db',
 '2-big-Data.db',
 '2-big-Digest.crc32',
 '2-big-Filter.db',
 '2-big-Index.db',
 '2-big-Statistics.db',
 '2-big-Summary.db',
 '2-big-TOC.txt',
 '3-big-CRC.db',
 '3-big-Data.db',
 '3-big-Digest.crc32',
 '3-big-Filter.db',
 '3-big-Index.db',
 '3-big-Statistics.db',
 '3-big-Summary.db',
 '3-big-TOC.txt',
 '4-big-CRC.db',
 '4-big-Data.db',
 '4-big-Digest.crc32',
 '4-big-Filter.db',
 '4-big-Index.db',
 '4-big-Statistics.db',
 '4-big-Summary.db',
 '4-big-TOC.txt',
 '5-big-CRC.db',
 '5-big-Data.db',
 '5-big-Digest.crc32',
 '5-big-Filter.db',
 '5-big-Index.db',
 '5-big-Statistics.db',
 '5-big-Summary.db',
 '5-big-TOC.txt']

In [3]: len(filenames), len(_strip_common_prefix(filenames))
Out[3]: (40, 40)
```

This looks correct to me. @jkni can you please review?