### PR TITLE
upgrade test special case comparing tag versions

### DIFF
--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -92,11 +92,18 @@ class GitSemVer(object):
             self.semver = LooseVersion(make_ver_str(TRUNK_VER))
 
     def __cmp__(self, other):
-        # if we find a tag of x.y.z we need to special case that to compare higher than x.y.z-foo
-        # to accomplish this, compare on length and then invert so shorter version wins
-        if (len(self.semver.version) == 3) or (len(other.semver.version) == 3):
-            if self.semver.version[0:3] == other.semver.version[0:3]:
-                return cmp(len(self.semver.version), len(other.semver.version)) * -1
+        # when comparing x.y.z and x.y.z-foo, we need to value x.y.z higher than the "nicknamed" tag x.y.z-foo
+        # likewise for shorter versions of the form X.Y and X.Y-foo
+        # to accomplish this, check if "x.y.z-" (note the dash there) is contained within "x.y.z-foo", and if so declare x.y.z the higher version
+        # e.g. when comparing 3.0.0 and 3.0.0-rc1, consider 3.0.0 higher
+        # e.g. when comparing 3.3 and 3.3-beta1, consider 3.3 higher
+        if (len(self.semver.version) <= 3) or (len(other.semver.version) <= 3):
+            if self.semver.vstring + "-" in other.semver.vstring:
+                return 1
+            elif other.semver.vstring + "-" in self.semver.vstring:
+                return -1
+            elif other.semver.vstring == self.semver.vstring:
+                return 0
 
         return cmp(self.semver, other.semver)
 

--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -92,6 +92,12 @@ class GitSemVer(object):
             self.semver = LooseVersion(make_ver_str(TRUNK_VER))
 
     def __cmp__(self, other):
+        # if we find a tag of x.y.z we need to special case that to compare higher than x.y.z-foo
+        # to accomplish this, compare on length and then invert so shorter version wins
+        if (len(self.semver.version) == 3) or (len(other.semver.version) == 3):
+            if self.semver.version[0:3] == other.semver.version[0:3]:
+                return cmp(len(self.semver.version), len(other.semver.version)) * -1
+
         return cmp(self.semver, other.semver)
 
 


### PR DESCRIPTION
When x.y.z has been tagged it should always win over x.y.z-foo