### PR TITLE
Fix  strip common prefix

### DIFF
--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -12,18 +12,19 @@ KeyspaceName = 'keyspace1'
 TableName = 'standard1'
 
 
+def _remove_prefix(string, prefix):
+    assert string.startswith(prefix), '{p} not a prefix of {s}'.format(p=prefix, s=string)
+    suffix = string[len(prefix):]
+    assert string.endswith(suffix), '{u} not a prefix of {t}'.format(u=suffix, t=string)
+    assert len(suffix) + len(prefix) == len(string)
+    return suffix
+
+
 def _strip_common_prefix(strings):
     strings = list(map(os.path.normcase, strings))
     common_prefix = os.path.commonprefix(strings)
 
-    rvs = []
-    for s in strings:
-        stripped = s[len(common_prefix):]
-        assert len(stripped) + len(common_prefix) == len(s)
-        assert s.endswith(stripped)
-        rvs.append(stripped)
-
-    return rvs
+    return [_remove_prefix(string, common_prefix) for string in strings]
 
 
 @since('3.0')

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -145,6 +145,8 @@ class SSTableUtilTest(Tester):
 
         if len(expected_tmpfiles) == 0:
             expected_tmpfiles = sorted(list(set(allfiles) - set(finalfiles)))
+        if common.is_win():
+            expected_tmpfiles = _strip_common_prefix(expected_tmpfiles)
 
         debug("Comparing tmp files...")
         tmpfiles = self._invoke_sstableutil(ks, table, type='tmp')

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -143,14 +143,13 @@ class SSTableUtilTest(Tester):
 
         self.assertEqual(expected_finalfiles, finalfiles)
 
-        if len(expected_tmpfiles) == 0:
-            expected_tmpfiles = sorted(list(set(allfiles) - set(finalfiles)))
-        if common.is_win():
-            expected_tmpfiles = _strip_common_prefix(expected_tmpfiles)
-
         debug("Comparing tmp files...")
         tmpfiles = self._invoke_sstableutil(ks, table, type='tmp')
-        self.assertEqual(expected_tmpfiles, tmpfiles)
+
+        common_prefix = os.path.commonprefix(list(tmpfiles) + list(expected_tmpfiles))
+
+        self.assertEqual([_remove_prefix(s, common_prefix) for s in tmpfiles],
+                         [_remove_prefix(s, common_prefix) for s in expected_tmpfiles])
 
         debug("Comparing op logs...")
         expectedoplogs = sorted(self._get_sstable_transaction_logs(node, ks, table))

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -15,11 +15,12 @@ TableName = 'standard1'
 def _strip_common_prefix(strings):
     strings = list(map(os.path.normcase, strings))
     common_prefix = os.path.commonprefix(strings)
+
     rvs = []
     for s in strings:
-        stripped = s.lstrip(common_prefix)
-        if s:
-            assert stripped
+        stripped = s[len(common_prefix):]
+        assert len(stripped) + len(common_prefix) == len(s)
+        assert s.endswith(stripped)
         rvs.append(stripped)
 
     return rvs

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -11,6 +11,15 @@ import os
 KeyspaceName = 'keyspace1'
 TableName = 'standard1'
 
+
+def _normcase_all(xs):
+    """
+    Return a list of the elements in xs, each with its casing normalized for
+    use as a filename.
+    """
+    return [os.path.normcase(x) for x in xs]
+
+
 @since('3.0')
 class SSTableUtilTest(Tester):
 
@@ -96,30 +105,30 @@ class SSTableUtilTest(Tester):
         node.stress(['read', 'n=%d' % (numrecords,), '-rate', 'threads=25'])
 
     def _check_files(self, node, ks, table, expected_finalfiles=None, expected_tmpfiles=None):
-        sstablefiles = map(os.path.normcase, self._get_sstable_files(node, ks, table))
-        allfiles = map(os.path.normcase, self._invoke_sstableutil(ks, table, type='all'))
-        finalfiles = map(os.path.normcase, self._invoke_sstableutil(ks, table, type='final'))
-        tmpfiles = map(os.path.normcase, self._invoke_sstableutil(ks, table, type='tmp'))
-        expected_oplogs = map(os.path.normcase, self._get_sstable_transaction_logs(node, ks, table))
-        tmpfiles_with_oplogs = map(os.path.normcase, self._invoke_sstableutil(ks, table, type='tmp', oplogs=True))
+        sstablefiles = _normcase_all(self._get_sstable_files(node, ks, table))
+        allfiles = _normcase_all(self._invoke_sstableutil(ks, table, type='all'))
+        finalfiles = _normcase_all(self._invoke_sstableutil(ks, table, type='final'))
+        tmpfiles = _normcase_all(self._invoke_sstableutil(ks, table, type='tmp'))
+        expected_oplogs = _normcase_all(self._get_sstable_transaction_logs(node, ks, table))
+        tmpfiles_with_oplogs = _normcase_all(self._invoke_sstableutil(ks, table, type='tmp', oplogs=True))
         oplogs = list(set(tmpfiles_with_oplogs) - set(tmpfiles))
-        
+
         if expected_finalfiles is None:
             expected_finalfiles = allfiles
         else:
-            map(os.path.normcase, expected_finalfiles)
-            
+            expected_finalfiles = _normcase_all(expected_finalfiles)
+
         if expected_tmpfiles is None:
-            expected_tmpfiles = sorted(list(set(allfiles) - set(finalfiles)))
+            expected_tmpfiles = sorted(set(allfiles) - set(finalfiles))
         else:
-            map(os.path.normcase, expected_tmpfiles)
+            expected_tmpfiles = _normcase_all(expected_tmpfiles)
 
         debug("Comparing all files...")
         self.assertEqual(sstablefiles, allfiles)
 
         debug("Comparing final files...")
         self.assertEqual(expected_finalfiles, finalfiles)
-            
+
         debug("Comparing tmp files...")
         self.assertEqual(expected_tmpfiles, tmpfiles)
 


### PR DESCRIPTION
Consider this a reopened version of #665.

I've applied @jkni's (excellent) changes and made some changes, mostly for Python 3 compatibility (`map` returns a list in py2, but a generator in py3, so we have to flatten it to a list. I pulled out a method to do just that.).

@jkni can you please review and smoke test on Windows when you get a chance? and @ptnapoleon can you review for readability? I think Joel's changes make this much more readable but I already know the test, so.