### PR TITLE
Unify corrupt sstable output analysis in sstableverify test

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -244,10 +244,7 @@ class TestOfflineTools(Tester):
         # Process sstableverify output to normalize paths in string to Python casing as above
         error = re.sub("(?<=Corrupted: ).*", lambda match: os.path.normcase(match.group(0)), error)
 
-        if self.cluster.version() < '3.0':
-            self.assertIn("java.lang.Exception: Invalid SSTable", error)
-        else:
-            self.assertIn("Corrupted: " + sstable1, error)
+        self.assertIn("Corrupted: " + sstable1, error)
         self.assertEqual(rc, 1, msg=str(rc))
 
     def sstableexpiredblockers_test(self):


### PR DESCRIPTION
In [CASSANDRA-10582](https://issues.apache.org/jira/browse/CASSANDRA-10582), the exception thrown on corrupt sstables was unified with that of 3.0.

The test wasn't updated, so it was failing on 2.2 when it looked for the old exception output.

I've removed the 2.2 branch in an if condition; we no longer need to handle it separately.