### PR TITLE
Replication cleanup

### DIFF
--- a/replication_test.py
+++ b/replication_test.py
@@ -68,11 +68,8 @@ class ReplicationTest(Tester):
                 continue
 
         for trace_event in trace.events:
-            session = trace._session
             activity = trace_event.description
             source = trace_event.source
-            source_elapsed = trace_event.source_elapsed
-            thread = trace_event.thread_name
 
             # Step 2, find all the nodes that each node talked to:
             send_match = TRACE_SEND_MESSAGE.search(activity)

--- a/replication_test.py
+++ b/replication_test.py
@@ -263,11 +263,9 @@ class SnitchConfigurationUpdateTest(Tester):
     which nodes should be shutdown in order to have the rack changed.
     """
 
-    def __init__(self, *args, **kwargs):
-        Tester.__init__(self, *args, **kwargs)
-        self.ignore_log_patterns = ["Fatal exception during initialization",
-                                    "Cannot start node if snitch's rack(.*) differs from previous rack(.*)",
-                                    "Cannot update data center or rack"]
+    ignore_log_patterns = ["Fatal exception during initialization",
+                           "Cannot start node if snitch's rack(.*) differs from previous rack(.*)",
+                           "Cannot update data center or rack"]
 
     def check_endpoint_count(self, ks, table, nodes, rf):
         """

--- a/replication_test.py
+++ b/replication_test.py
@@ -259,8 +259,19 @@ class ReplicationTest(Tester):
 
 class SnitchConfigurationUpdateTest(Tester):
     """
-    Test to repro CASSANDRA-10238, wherein changing snitch properties to change racks without a restart could violate RF contract.
+    Test to reproduce CASSANDRA-10238, wherein changing snitch properties to change racks without a restart
+    could violate RF contract.
+
+    Since CASSANDRA-10243 it is no longer possible to change rack or dc for live nodes so we must specify
+    which nodes should be shutdown in order to have the rack changed.
     """
+
+    def __init__(self, *args, **kwargs):
+        Tester.__init__(self, *args, **kwargs)
+        self.ignore_log_patterns = ["Fatal exception during initialization",
+                                    "Cannot start node if snitch's rack(.*) differs from previous rack(.*)",
+                                    "Cannot update data center or rack"]
+
     def check_endpoint_count(self, ks, table, nodes, rf):
         """
         Check a dummy key expecting it to have replication factor as the sum of rf on all dcs.
@@ -313,6 +324,8 @@ class SnitchConfigurationUpdateTest(Tester):
     def test_rf_collapse_gossiping_property_file_snitch(self):
         """
         @jira_ticket CASSANDRA-10238
+        @jira_ticket CASSANDRA-10242
+        @jira_ticket CASSANDRA-10243
 
         Confirm that when racks are collapsed using a gossiping property file snitch the RF is not impacted.
         """
@@ -321,11 +334,14 @@ class SnitchConfigurationUpdateTest(Tester):
                                        snitch_config_file='cassandra-rackdc.properties',
                                        snitch_lines_before=lambda i, node: ["dc=dc1", "rack=rack{}".format(i)],
                                        snitch_lines_after=lambda i, node: ["dc=dc1", "rack=rack1"],
-                                       final_racks=["rack1", "rack1", "rack1"])
+                                       final_racks=["rack1", "rack1", "rack1"],
+                                       nodes_to_shutdown=[0, 2])
 
     def test_rf_expand_gossiping_property_file_snitch(self):
         """
         @jira_ticket CASSANDRA-10238
+        @jira_ticket CASSANDRA-10242
+        @jira_ticket CASSANDRA-10243
 
         Confirm that when racks are expanded using a gossiping property file snitch the RF is not impacted.
         """
@@ -334,11 +350,14 @@ class SnitchConfigurationUpdateTest(Tester):
                                        snitch_config_file='cassandra-rackdc.properties',
                                        snitch_lines_before=lambda i, node: ["dc=dc1", "rack=rack1"],
                                        snitch_lines_after=lambda i, node: ["dc=dc1", "rack=rack{}".format(i)],
-                                       final_racks=["rack0", "rack1", "rack2"])
+                                       final_racks=["rack0", "rack1", "rack2"],
+                                       nodes_to_shutdown=[0, 2])
 
     def test_rf_collapse_gossiping_property_file_snitch_multi_dc(self):
         """
         @jira_ticket CASSANDRA-10238
+        @jira_ticket CASSANDRA-10242
+        @jira_ticket CASSANDRA-10243
 
         Confirm that when racks are collapsed using a gossiping property file snitch the RF is not impacted, in a multi-dc environment.
         """
@@ -347,11 +366,14 @@ class SnitchConfigurationUpdateTest(Tester):
                                        snitch_config_file='cassandra-rackdc.properties',
                                        snitch_lines_before=lambda i, node: ["dc={}".format(node.data_center), "rack=rack{}".format(i % 3)],
                                        snitch_lines_after=lambda i, node: ["dc={}".format(node.data_center), "rack=rack1"],
-                                       final_racks=["rack1", "rack1", "rack1", "rack1", "rack1", "rack1"])
+                                       final_racks=["rack1", "rack1", "rack1", "rack1", "rack1", "rack1"],
+                                       nodes_to_shutdown=[0, 2, 3, 5])
 
     def test_rf_expand_gossiping_property_file_snitch_multi_dc(self):
         """
         @jira_ticket CASSANDRA-10238
+        @jira_ticket CASSANDRA-10242
+        @jira_ticket CASSANDRA-10243
 
         Confirm that when racks are expanded using a gossiping property file snitch the RF is not impacted, in a multi-dc environment.
         """
@@ -360,11 +382,14 @@ class SnitchConfigurationUpdateTest(Tester):
                                        snitch_config_file='cassandra-rackdc.properties',
                                        snitch_lines_before=lambda i, node: ["dc={}".format(node.data_center), "rack=rack1"],
                                        snitch_lines_after=lambda i, node: ["dc={}".format(node.data_center), "rack=rack{}".format(i % 3)],
-                                       final_racks=["rack0", "rack1", "rack2", "rack0", "rack1", "rack2"])
+                                       final_racks=["rack0", "rack1", "rack2", "rack0", "rack1", "rack2"],
+                                       nodes_to_shutdown=[0, 2, 3, 5])
 
     def test_rf_collapse_property_file_snitch(self):
         """
         @jira_ticket CASSANDRA-10238
+        @jira_ticket CASSANDRA-10242
+        @jira_ticket CASSANDRA-10243
 
         Confirm that when racks are collapsed using a property file snitch the RF is not impacted.
         """
@@ -373,11 +398,14 @@ class SnitchConfigurationUpdateTest(Tester):
                                        snitch_config_file='cassandra-topology.properties',
                                        snitch_lines_before=lambda i, node: ["127.0.0.1=dc1:rack0", "127.0.0.2=dc1:rack1", "127.0.0.3=dc1:rack2"],
                                        snitch_lines_after=lambda i, node: ["default=dc1:rack0"],
-                                       final_racks=["rack0", "rack0", "rack0"])
+                                       final_racks=["rack0", "rack0", "rack0"],
+                                       nodes_to_shutdown=[1, 2])
 
     def test_rf_expand_property_file_snitch(self):
         """
         @jira_ticket CASSANDRA-10238
+        @jira_ticket CASSANDRA-10242
+        @jira_ticket CASSANDRA-10243
 
         Confirm that when racks are expanded using a property file snitch the RF is not impacted.
         """
@@ -386,12 +414,15 @@ class SnitchConfigurationUpdateTest(Tester):
                                        snitch_config_file='cassandra-topology.properties',
                                        snitch_lines_before=lambda i, node: ["default=dc1:rack0"],
                                        snitch_lines_after=lambda i, node: ["127.0.0.1=dc1:rack0", "127.0.0.2=dc1:rack1", "127.0.0.3=dc1:rack2"],
-                                       final_racks=["rack0", "rack1", "rack2"])
+                                       final_racks=["rack0", "rack1", "rack2"],
+                                       nodes_to_shutdown=[1, 2])
 
     @since('2.0', max_version='2.1.x')
     def test_rf_collapse_yaml_file_snitch(self):
         """
         @jira_ticket CASSANDRA-10238
+        @jira_ticket CASSANDRA-10242
+        @jira_ticket CASSANDRA-10243
 
         Confirm that when racks are collapsed using a yaml file snitch the RF is not impacted.
         """
@@ -418,12 +449,15 @@ class SnitchConfigurationUpdateTest(Tester):
                                                                            "      - broadcast_address: 127.0.0.1",
                                                                            "      - broadcast_address: 127.0.0.2",
                                                                            "      - broadcast_address: 127.0.0.3"],
-                                       final_racks=["rack0", "rack0", "rack0"])
+                                       final_racks=["rack0", "rack0", "rack0"],
+                                       nodes_to_shutdown=[1, 2])
 
     @since('2.0', max_version='2.1.x')
     def test_rf_expand_yaml_file_snitch(self):
         """
         @jira_ticket CASSANDRA-10238
+        @jira_ticket CASSANDRA-10242
+        @jira_ticket CASSANDRA-10243
 
         Confirm that when racks are expanded using a yaml file snitch the RF is not impacted.
         """
@@ -450,9 +484,11 @@ class SnitchConfigurationUpdateTest(Tester):
                                                                            "    - rack_name: rack2",
                                                                            "      nodes:",
                                                                            "      - broadcast_address: 127.0.0.3"],
-                                       final_racks=["rack0", "rack1", "rack2"])
+                                       final_racks=["rack0", "rack1", "rack2"],
+                                       nodes_to_shutdown=[1, 2])
 
-    def _test_rf_on_snitch_update(self, nodes, rf, snitch_class_name, snitch_config_file, snitch_lines_before, snitch_lines_after, final_racks):
+    def _test_rf_on_snitch_update(self, nodes, rf, snitch_class_name, snitch_config_file,
+                                  snitch_lines_before, snitch_lines_after, final_racks, nodes_to_shutdown):
         cluster = self.cluster
         cluster.populate(nodes)
         cluster.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.{}'.format(snitch_class_name)})
@@ -474,13 +510,171 @@ class SnitchConfigurationUpdateTest(Tester):
         # make sure endpoint count is correct before continuing with the rest of the test
         self.check_endpoint_count('testing', 'rf_test', cluster.nodelist(), rf)
 
-        # update snitch file on all nodes
+        for i in nodes_to_shutdown:
+            node = cluster.nodelist()[i]
+            debug("Shutting down node {}".format(node.address()))
+            node.stop(wait_other_notice=True)
+
+        debug("Updating snitch file")
         for i, node in enumerate(cluster.nodelist()):
             with open(os.path.join(node.get_conf_dir(), snitch_config_file), 'w') as topo_file:
                 for line in snitch_lines_after(i, node):
                     topo_file.write(line + os.linesep)
 
+        # wait until the config is reloaded before we restart the nodes, the default check period is
+        # 5 seconds so we wait for 10 seconds to be sure
+        debug("Waiting 10 seconds to make sure snitch file is reloaded...")
+        time.sleep(10)
+
+        for i in nodes_to_shutdown:
+            node = cluster.nodelist()[i]
+            debug("Restarting node {}".format(node.address()))
+            # Since CASSANDRA-10242 it is no longer
+            # possible to start a node with a different rack unless we specify -Dcassandra.ignore_rack and since
+            # CASSANDRA-9474 it is no longer possible to start a node with a different dc unless we specify
+            # -Dcassandra.ignore_dc.
+            node.start(jvm_args=['-Dcassandra.ignore_rack=true', '-Dcassandra.ignore_dc=true'],
+                       wait_for_binary_proto=True)
+
         self.wait_for_nodes_on_racks(cluster.nodelist(), final_racks)
 
         # nodes have joined racks, check endpoint counts again
         self.check_endpoint_count('testing', 'rf_test', cluster.nodelist(), rf)
+
+    def test_cannot_restart_with_different_rack(self):
+        """
+        @jira_ticket CASSANDRA-10242
+
+        Test that we cannot restart with a different rack if '-Dcassandra.ignore_rack=true' is not specified.
+        """
+        cluster = self.cluster
+        cluster.populate(1)
+        cluster.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.{}'
+                                          .format('GossipingPropertyFileSnitch')})
+
+        node = cluster.nodelist()[0]
+
+        with open(os.path.join(node.get_conf_dir(), 'cassandra-rackdc.properties'), 'w') as topo_file:
+            for line in ["dc={}".format(node.data_center), "rack=rack1"]:
+                topo_file.write(line + os.linesep)
+
+        debug("Starting node {} with rack1".format(node.address()))
+        node.start(wait_for_binary_proto=True)
+
+        debug("Shutting down node {}".format(node.address()))
+        node.stop(wait_other_notice=True)
+
+        debug("Updating snitch file with rack2")
+        for i, node in enumerate(cluster.nodelist()):
+            with open(os.path.join(node.get_conf_dir(), 'cassandra-rackdc.properties'), 'w') as topo_file:
+                for line in ["dc={}".format(node.data_center), "rack=rack2"]:
+                    topo_file.write(line + os.linesep)
+
+        debug("Restarting node {} with rack2".format(node.address()))
+        mark = node.mark_log()
+        node.start()
+
+        # check node not running
+        debug("Waiting for error message in log file")
+
+        if cluster.version() >= '2.2':
+            node.watch_log_for("Cannot start node if snitch's rack(.*) differs from previous rack(.*)",
+                               from_mark=mark)
+        else:
+            node.watch_log_for("Fatal exception during initialization", from_mark=mark)
+
+    def test_failed_snitch_update_gossiping_property_file_snitch(self):
+        """
+        @jira_ticket CASSANDRA-10243
+
+        Test that we cannot change the rack of a live node with GossipingPropertyFileSnitch.
+        """
+        self._test_failed_snitch_update(nodes=[3],
+                                        snitch_class_name='GossipingPropertyFileSnitch',
+                                        snitch_config_file='cassandra-rackdc.properties',
+                                        snitch_lines_before=["dc=dc1", "rack=rack1"],
+                                        snitch_lines_after=["dc=dc1", "rack=rack2"],
+                                        racks=["rack1", "rack1", "rack1"],
+                                        error='')
+
+    def test_failed_snitch_update_property_file_snitch(self):
+        """
+        @jira_ticket CASSANDRA-10243
+
+        Test that we cannot change the rack of a live node with PropertyFileSnitch.
+        """
+        self._test_failed_snitch_update(nodes=[3],
+                                        snitch_class_name='PropertyFileSnitch',
+                                        snitch_config_file='cassandra-topology.properties',
+                                        snitch_lines_before=["default=dc1:rack1"],
+                                        snitch_lines_after=["default=dc1:rack2"],
+                                        racks=["rack1", "rack1", "rack1"],
+                                        error='Cannot update data center or rack')
+
+    @since('2.0', max_version='2.1.x')
+    def test_failed_snitch_update_yaml_file_snitch(self):
+        """
+        @jira_ticket CASSANDRA-10243
+
+        Test that we cannot change the rack of a live node with YamlFileNetworkTopologySnitch.
+        """
+        self._test_failed_snitch_update(nodes=[3],
+                                        snitch_class_name='YamlFileNetworkTopologySnitch',
+                                        snitch_config_file='cassandra-topology.yaml',
+                                        snitch_lines_before=["topology:",
+                                                             "  - dc_name: dc1",
+                                                             "    racks:",
+                                                             "    - rack_name: rack1",
+                                                             "      nodes:",
+                                                             "      - broadcast_address: 127.0.0.1",
+                                                             "      - broadcast_address: 127.0.0.2",
+                                                             "      - broadcast_address: 127.0.0.3"],
+                                        snitch_lines_after=["topology:",
+                                                            "  - dc_name: dc1",
+                                                            "    racks:",
+                                                            "    - rack_name: rack2",
+                                                            "      nodes:",
+                                                            "      - broadcast_address: 127.0.0.1",
+                                                            "      - broadcast_address: 127.0.0.2",
+                                                            "      - broadcast_address: 127.0.0.3"],
+                                        racks=["rack1", "rack1", "rack1"],
+                                        error='Cannot update data center or rack')
+
+    def _test_failed_snitch_update(self, nodes, snitch_class_name, snitch_config_file,
+                                   snitch_lines_before, snitch_lines_after, racks, error):
+        cluster = self.cluster
+        cluster.populate(nodes)
+        cluster.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.{}'
+                                          .format(snitch_class_name)})
+
+        # start with initial snitch lines
+        for i, node in enumerate(cluster.nodelist()):
+            with open(os.path.join(node.get_conf_dir(), snitch_config_file), 'w') as topo_file:
+                for line in snitch_lines_before:
+                    topo_file.write(line + os.linesep)
+
+        cluster.start(wait_for_binary_proto=True)
+
+        # check racks are as specified
+        self.wait_for_nodes_on_racks(cluster.nodelist(), racks)
+
+        marks = [node.mark_log() for node in cluster.nodelist()]
+
+        debug("Updating snitch file")
+        for i, node in enumerate(cluster.nodelist()):
+            with open(os.path.join(node.get_conf_dir(), snitch_config_file), 'w') as topo_file:
+                for line in snitch_lines_after:
+                    topo_file.write(line + os.linesep)
+
+        # wait until the config is reloaded, the default check period is
+        # 5 seconds so we wait for 10 seconds to be sure
+        debug("Waiting 10 seconds to make sure snitch file is reloaded...")
+        time.sleep(10)
+
+        # check racks have not changed
+        self.wait_for_nodes_on_racks(cluster.nodelist(), racks)
+
+        # check error in log files if applicable
+        if error:
+            for node, mark in zip(cluster.nodelist(), marks):
+                node.watch_log_for(error, from_mark=mark)

--- a/replication_test.py
+++ b/replication_test.py
@@ -282,8 +282,7 @@ class SnitchConfigurationUpdateTest(Tester):
             out, err = node.nodetool(cmd)
 
             if len(err.strip()) > 0:
-                debug(err)
-                raise RuntimeError("Error running 'nodetool {}'".format(cmd))
+                debug("Error running 'nodetool {}': {}".format(cmd, err))
 
             debug("Endpoints for node {}, expected count is {}".format(node.address(), expected_count))
             debug(out)
@@ -303,7 +302,7 @@ class SnitchConfigurationUpdateTest(Tester):
 
                 debug(out)
                 if len(err.strip()) > 0:
-                    raise RuntimeError("Error trying to run nodetool status")
+                    debug("Error trying to run nodetool status: {}".format(err))
 
                 racks = []
                 for line in out.split(os.linesep):

--- a/replication_test.py
+++ b/replication_test.py
@@ -306,7 +306,7 @@ class SnitchConfigurationUpdateTest(Tester):
                         racks.append(m.group(1))
 
                 if racks == expected_racks:
-                    # great, the topology change is propogated
+                    # great, the topology change is propagated
                     debug("Topology change detected on node {}".format(i))
                     break
                 else:

--- a/replication_test.py
+++ b/replication_test.py
@@ -544,7 +544,7 @@ class SnitchConfigurationUpdateTest(Tester):
         cluster = self.cluster
         cluster.populate(1)
         cluster.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.{}'
-                                          .format('GossipingPropertyFileSnitch')})
+                                                  .format('GossipingPropertyFileSnitch')})
 
         node1 = cluster.nodelist()[0]
 
@@ -573,7 +573,7 @@ class SnitchConfigurationUpdateTest(Tester):
 
         if cluster.version() >= '2.2':
             node1.watch_log_for("Cannot start node if snitch's rack(.*) differs from previous rack(.*)",
-                               from_mark=mark)
+                                from_mark=mark)
         else:
             node1.watch_log_for("Fatal exception during initialization", from_mark=mark)
 
@@ -639,7 +639,7 @@ class SnitchConfigurationUpdateTest(Tester):
         cluster = self.cluster
         cluster.populate(nodes)
         cluster.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.{}'
-                                          .format(snitch_class_name)})
+                                                  .format(snitch_class_name)})
 
         # start with initial snitch lines
         for node in cluster.nodelist():

--- a/replication_test.py
+++ b/replication_test.py
@@ -559,7 +559,7 @@ class SnitchConfigurationUpdateTest(Tester):
         node1.stop(wait_other_notice=True)
 
         debug("Updating snitch file with rack2")
-        for i, node in enumerate(cluster.nodelist()):
+        for node in cluster.nodelist():
             with open(os.path.join(node.get_conf_dir(), 'cassandra-rackdc.properties'), 'w') as topo_file:
                 for line in ["dc={}".format(node.data_center), "rack=rack2"]:
                     topo_file.write(line + os.linesep)
@@ -642,7 +642,7 @@ class SnitchConfigurationUpdateTest(Tester):
                                           .format(snitch_class_name)})
 
         # start with initial snitch lines
-        for i, node in enumerate(cluster.nodelist()):
+        for node in cluster.nodelist():
             with open(os.path.join(node.get_conf_dir(), snitch_config_file), 'w') as topo_file:
                 for line in snitch_lines_before:
                     topo_file.write(line + os.linesep)
@@ -655,7 +655,7 @@ class SnitchConfigurationUpdateTest(Tester):
         marks = [node.mark_log() for node in cluster.nodelist()]
 
         debug("Updating snitch file")
-        for i, node in enumerate(cluster.nodelist()):
+        for node in cluster.nodelist():
             with open(os.path.join(node.get_conf_dir(), snitch_config_file), 'w') as topo_file:
                 for line in snitch_lines_after:
                     topo_file.write(line + os.linesep)

--- a/replication_test.py
+++ b/replication_test.py
@@ -546,17 +546,17 @@ class SnitchConfigurationUpdateTest(Tester):
         cluster.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.{}'
                                           .format('GossipingPropertyFileSnitch')})
 
-        node = cluster.nodelist()[0]
+        node1 = cluster.nodelist()[0]
 
-        with open(os.path.join(node.get_conf_dir(), 'cassandra-rackdc.properties'), 'w') as topo_file:
-            for line in ["dc={}".format(node.data_center), "rack=rack1"]:
+        with open(os.path.join(node1.get_conf_dir(), 'cassandra-rackdc.properties'), 'w') as topo_file:
+            for line in ["dc={}".format(node1.data_center), "rack=rack1"]:
                 topo_file.write(line + os.linesep)
 
-        debug("Starting node {} with rack1".format(node.address()))
-        node.start(wait_for_binary_proto=True)
+        debug("Starting node {} with rack1".format(node1.address()))
+        node1.start(wait_for_binary_proto=True)
 
-        debug("Shutting down node {}".format(node.address()))
-        node.stop(wait_other_notice=True)
+        debug("Shutting down node {}".format(node1.address()))
+        node1.stop(wait_other_notice=True)
 
         debug("Updating snitch file with rack2")
         for i, node in enumerate(cluster.nodelist()):
@@ -564,18 +564,18 @@ class SnitchConfigurationUpdateTest(Tester):
                 for line in ["dc={}".format(node.data_center), "rack=rack2"]:
                     topo_file.write(line + os.linesep)
 
-        debug("Restarting node {} with rack2".format(node.address()))
-        mark = node.mark_log()
-        node.start()
+        debug("Restarting node {} with rack2".format(node1.address()))
+        mark = node1.mark_log()
+        node1.start()
 
         # check node not running
         debug("Waiting for error message in log file")
 
         if cluster.version() >= '2.2':
-            node.watch_log_for("Cannot start node if snitch's rack(.*) differs from previous rack(.*)",
+            node1.watch_log_for("Cannot start node if snitch's rack(.*) differs from previous rack(.*)",
                                from_mark=mark)
         else:
-            node.watch_log_for("Fatal exception during initialization", from_mark=mark)
+            node1.watch_log_for("Fatal exception during initialization", from_mark=mark)
 
     def test_failed_snitch_update_gossiping_property_file_snitch(self):
         """


### PR DESCRIPTION
Added in stefania's PR #688, fixed the regex, and then made other fixes so that these tests work on OSX, where nodetool calls always print to stderr