### PR TITLE
Known failure decorator

### DIFF
--- a/bin/collect_known_failures.py
+++ b/bin/collect_known_failures.py
@@ -1,4 +1,15 @@
-from __future__ import division
+"""
+A script that runs the tests with --collect-only, but instead of just printing
+the tests' names, prints the information added by the tools.known_failure
+decorator.
+
+This is basically a wrapper around the `nosetests` command, so it takes the
+same arguments, though it appends some arguments to sys.argv. In particular,
+if you want to look at particular kinds of known failures, use the `-a`
+parameter on this script as you would for any of the known_failures attributes.
+In addition, you should call it from the same directory from which you'd call
+`nosetests`.
+"""
 
 from functools import partial
 import json

--- a/bin/collect_known_failures.py
+++ b/bin/collect_known_failures.py
@@ -1,0 +1,48 @@
+from __future__ import division
+
+from functools import partial
+import json
+import os
+import sys
+
+import nose
+
+
+class PrintJiraURLPlugin(nose.plugins.Plugin):
+    enabled = True
+
+    def options(self, parser, env):
+        super(PrintJiraURLPlugin, self).configure(parser, env)
+
+    def testName(self, test):
+        _, test_module, test_name = test.address()
+        test_method_name = test_name.split('.')[-1]
+        test_method = getattr(test.test, test_method_name)
+
+        get_attr_for_current_method = partial(
+            nose.plugins.attrib.get_method_attr,
+            method=test_method,
+            cls=test.test,
+        )
+
+        jira_url = get_attr_for_current_method(attr_name='jira_url')
+        flaky = get_attr_for_current_method(attr_name='known_flaky')
+        failure_source = get_attr_for_current_method(attr_name='known_failure')
+
+        return json.dumps({
+            'module': test_module,
+            'name': test_name,
+            'jira_url': jira_url,
+            'known_flaky': flaky,
+            'failure_source': failure_source
+        })
+
+
+if __name__ == '__main__':
+    argv = sys.argv + ['--collect-only', '-v']
+    env = {}
+    env.update(os.environ)
+    env['CASSANDRA_VERSION'] = 'git:trunk'  # the tests need a version to run
+    os.environ
+    nose.main(addplugins=[PrintJiraURLPlugin()],
+              argv=argv, env=env)

--- a/concurrent_schema_changes_test.py
+++ b/concurrent_schema_changes_test.py
@@ -10,7 +10,7 @@ from cassandra.concurrent import execute_concurrent
 
 from ccmlib.node import Node
 from dtest import Tester, debug
-from tools import require, since
+from tools import known_failure, require, since
 
 
 def wait(delay=2):
@@ -21,6 +21,9 @@ def wait(delay=2):
 
 
 @require(10699)
+@known_failure(failure_source='cassandra',
+               jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10699',
+               flaky=True)
 class TestConcurrentSchemaChanges(Tester):
 
     def __init__(self, *argv, **kwargs):

--- a/tools.py
+++ b/tools.py
@@ -356,7 +356,8 @@ def known_failure(failure_source, jira_url, flaky=False):
     assert isinstance(flaky, bool)
 
     def wrapper(f):
-        tagged_func = attr(known_failure=failure_source)(f)
+        tagged_func = attr(known_failure=failure_source,
+                           jira_url=jira_url)(f)
         if flaky:
             tagged_func = attr('known_flaky')(tagged_func)
         return tagged_func

--- a/tools.py
+++ b/tools.py
@@ -352,10 +352,11 @@ def known_failure(failure_source, jira_url, flaky=False):
     will have the value applied by the outermost instance of the decorator.
     """
     valid_failure_sources = ('cassandra', 'test', 'systemic')
-    assert failure_source in valid_failure_sources
-    assert isinstance(flaky, bool)
 
     def wrapper(f):
+        assert failure_source in valid_failure_sources
+        assert isinstance(flaky, bool)
+
         tagged_func = attr(known_failure=failure_source,
                            jira_url=jira_url)(f)
         if flaky:

--- a/tools.py
+++ b/tools.py
@@ -326,6 +326,43 @@ def require(require_pattern, broken_in=None):
         return tagging_decorator
 
 
+def known_failure(failure_source, jira_url, flaky=False):
+    """
+    Tag a test as a known failure. Associate it with the URL for a JIRA
+    ticket and tag it as flaky or not.
+
+    Valid values for failure_source include: 'cassandra', 'test', and
+    'systemic'.
+
+    To run all known failures, use the functionality provided by the nosetests
+    attrib plugin, using the known_failure and known_flaky attributes:
+
+        # only run tests that are known to fail
+        $ nosetests -a known_failure
+        # only run tests that are not known to fail
+        $ nosetests -a !known_failure
+        # only run tests that fail because of cassandra bugs
+        $ nosetests -a known_failure=cassandra
+        # only run tests that fail because of cassandra bugs, but are not flaky
+        $ nosetests -a known_failure=cassandra -a !known_flaky
+
+    Known limitations: a given test may only be tagged once and still work as
+    expected with the attrib plugin machinery; if you decorate a test with
+    known_failure multiple times, the known_failure attribute of that test
+    will have the value applied by the outermost instance of the decorator.
+    """
+    valid_failure_sources = ('cassandra', 'test', 'systemic')
+    assert failure_source in valid_failure_sources
+    assert isinstance(flaky, bool)
+
+    def wrapper(f):
+        tagged_func = attr(known_failure=failure_source)(f)
+        if flaky:
+            tagged_func = attr('known_flaky')(tagged_func)
+        return tagged_func
+    return wrapper
+
+
 def cassandra_git_branch(cdir=None):
     '''Get the name of the git branch at CASSANDRA_DIR.
     '''

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -19,7 +19,7 @@ from dtest import debug, freshCluster
 from thrift_bindings.v22.ttypes import ConsistencyLevel as ThriftConsistencyLevel
 from thrift_bindings.v22.ttypes import (CfDef, Column, ColumnOrSuperColumn, Mutation)
 from thrift_tests import get_thrift_client
-from tools import require, rows_to_list, since
+from tools import known_failure, require, rows_to_list, since
 from upgrade_base import UpgradeTester
 
 
@@ -922,6 +922,9 @@ class TestCQL(UpgradeTester):
             res = cursor.execute("SELECT id FROM users WHERE birth_year = 42")
             assert rows_to_list(res) == [['Tom'], ['Bob']]
 
+    @known_failure(failure_source='systemic',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10730',
+                   flaky=True)
     def deletion_test(self):
         """ Test simple deletion and in particular check for #4193 bug """
 


### PR DESCRIPTION
Supercedes #700.

> Adds simple decorator that tags a known failing test with some metadata about the failure. Also tags a couple tests for demo purposes. I smoke-tested this with
> 
> ```
> CASSANDRA_VERSION=git:cassandra-3.0 nosetests --collect-only -a known_failure -v
> CASSANDRA_VERSION=git:cassandra-3.0 nosetests --collect-only -a known_failure '!known_flaky' -v
> CASSANDRA_VERSION=git:cassandra-3.0 nosetests --collect-only -a known_failure=cassandra -v
> CASSANDRA_VERSION=git:cassandra-3.0 nosetests --collect-only -a known_failure=systemic -v
> Which demonstrates the basic functionality of the decorator.
> ```
> Printing out associated ticket URLs is a little more difficult and will involve writing a small nose plugin, I believe.
> 
> @ptnapoleon to review and give feedback. In particular
> 
> - Are these tags the model of known failures we want to present?
>   - In particular, is it acceptable that we can only tag a given test with one kind of failure? I'm trying to avoid a huge proliferation of attributes, but we may want to tag some tests as, e.g. flaky because of a systemic issue, but also failing hard because of a C* bug.
> - Will this output be consumable in the way that the failure dashboard needs? Expect that, with the above-mentioned nose plugin, it will print the ticket URL after the name and module of the test.
