### PR TITLE
add `notes` param to `known_failure`

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -326,7 +326,7 @@ def require(require_pattern, broken_in=None):
         return tagging_decorator
 
 
-def known_failure(failure_source, jira_url, flaky=False):
+def known_failure(failure_source, jira_url, flaky=False, notes=None):
     """
     Tag a test as a known failure. Associate it with the URL for a JIRA
     ticket and tag it as flaky or not.
@@ -361,6 +361,8 @@ def known_failure(failure_source, jira_url, flaky=False):
                            jira_url=jira_url)(f)
         if flaky:
             tagged_func = attr('known_flaky')(tagged_func)
+        if notes:
+            tagged_func = attr('failure_notes')(tagged_func)
         return tagged_func
     return wrapper
 


### PR DESCRIPTION
Small addition to the `known_failure` decorator. Just adds a freeform 'notes' attribute; it's not used in a meaningful way yet, but could be in the future, and might be better than comments for adding metadata like "this fails on 3.0+", which we can't handle at the moment.

@ptnapoleon to review.