### PR TITLE
add failure metadata in upgrade tests

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -2934,6 +2934,9 @@ class TestCQL(UpgradeTester):
 
             cursor.execute("SELECT dateOf(t) FROM test")
 
+    @known_failure(failure_source='cassandra',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10836',
+                   flaky=True)
     def conditional_update_test(self):
         cursor = self.prepare()
 
@@ -3037,6 +3040,9 @@ class TestCQL(UpgradeTester):
             assert_one(cursor, "UPDATE test SET v2 = 'bar' WHERE k = 0 IF v1 IN (142, 276)", [False, 2])
             assert_one(cursor, "UPDATE test SET v2 = 'bar' WHERE k = 0 IF v1 IN ()", [False, 2])
 
+    @known_failure(failure_source='cassandra',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10836',
+                   flaky=True)
     def conditional_delete_test(self):
         cursor = self.prepare()
 
@@ -3284,6 +3290,9 @@ class TestCQL(UpgradeTester):
             assert_invalid(cursor, 'SELECT DISTINCT pk0 FROM regular', matching="queries must request all the partition key columns")
             assert_invalid(cursor, 'SELECT DISTINCT pk0, pk1, ck0 FROM regular', matching="queries must only request partition key columns")
 
+    @known_failure(failure_source='cassandra',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10762',
+                   flaky=False)
     def select_distinct_with_deletions_test(self):
         cursor = self.prepare()
         cursor.execute('CREATE TABLE t1 (k int PRIMARY KEY, c int, v int)')
@@ -3751,6 +3760,9 @@ class TestCQL(UpgradeTester):
             cursor.execute("DELETE s FROM test WHERE k=0")
             assert_all(cursor, "SELECT * FROM test", [[0, 1, None, 1]])
 
+    @known_failure(failure_source='cassandra',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10836',
+                   flaky=True)
     def static_columns_cas_test(self):
         cursor = self.prepare()
 
@@ -4256,6 +4268,9 @@ class TestCQL(UpgradeTester):
                 # not supported yet
                 check_invalid("m CONTAINS 'bar'", expected=SyntaxException)
 
+    @known_failure(failure_source='cassandra',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10836',
+                   flaky=True)
     def list_item_conditional_test(self):
         # Lists
         cursor = self.prepare()
@@ -4371,6 +4386,9 @@ class TestCQL(UpgradeTester):
                 check_invalid("l[null] = null")
 
     @since('2.1.1')
+    @known_failure(failure_source='cassandra',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10836',
+                   flaky=True)
     def whole_set_conditional_test(self):
         cursor = self.prepare()
 
@@ -4522,6 +4540,9 @@ class TestCQL(UpgradeTester):
                 check_invalid("m CONTAINS null", expected=SyntaxException)
                 check_invalid("m CONTAINS KEY null", expected=SyntaxException)
 
+    @known_failure(failure_source='cassandra',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10836',
+                   flaky=True)
     def map_item_conditional_test(self):
         cursor = self.prepare()
 

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -9,7 +9,7 @@ from cassandra.query import SimpleStatement, dict_factory, named_tuple_factory
 
 from datahelp import create_rows, flatten_into_set, parse_data_into_dicts
 from dtest import debug, run_scenarios
-from tools import rows_to_list, since
+from tools import known_failure, rows_to_list, since
 from upgrade_base import UpgradeTester
 
 
@@ -1464,6 +1464,9 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             page_data = pf.page_data(i + 1)
             self.assertEquals(page_data, expected_pages_data[i])
 
+    @known_failure(failure_source='systemic',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10848',
+                   flaky=True)
     def test_single_partition_deletions(self):
         """Test single partition deletions """
         cursor = self.prepare()
@@ -1511,6 +1514,9 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             self.check_all_paging_results(cursor, expected_data, 2, [25, 15],
                                           timeout=10)
 
+    @known_failure(failure_source='systemic',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10848',
+                   flaky=True)
     def test_multiple_partition_deletions(self):
         """Test multiple partition deletions """
         cursor = self.prepare()
@@ -1531,6 +1537,9 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             self.check_all_paging_results(cursor, expected_data, 2, [25, 15],
                                           timeout=10)
 
+    @known_failure(failure_source='systemic',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10848',
+                   flaky=True)
     def test_single_row_deletions(self):
         """Test single row deletions """
         cursor = self.prepare()
@@ -1582,6 +1591,9 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             self.check_all_paging_results(cursor, expected_data, 7,
                                           [25, 25, 25, 25, 25, 25, 25])
 
+    @known_failure(failure_source='systemic',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10848',
+                   flaky=True)
     def test_single_cell_deletions(self):
         """Test single cell deletions """
         cursor = self.prepare()
@@ -1697,6 +1709,9 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             time.sleep(5)
             self.check_all_paging_results(cursor, [], 0, [])
 
+    @known_failure(failure_source='systemic',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10476',
+                   flaky=True)
     def test_failure_threshold_deletions(self):
         """Test that paging throws a failure in case of tombstone threshold """
         self.allow_log_errors = True


### PR DESCRIPTION
Part of the dtest failure audit. Adds metadata to the `upgrade_tests` module.