### PR TITLE
flatten cursor.execute to fix protocol test

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -4091,7 +4091,7 @@ class TestCQL(UpgradeTester):
             cursor.execute("INSERT INTO test (k, c1, c2) VALUES (0, 0, 'c')")
 
             p = cursor.prepare("SELECT * FROM test WHERE k=? AND (c1, c2) IN ?")
-            rows = cursor.execute(p, (0, [(0, 'b'), (0, 'c')]))
+            rows = list(cursor.execute(p, (0, [(0, 'b'), (0, 'c')])))
             self.assertEqual(2, len(rows))
             self.assertEqual((0, 0, 'b'), rows[0])
             self.assertEqual((0, 0, 'c'), rows[1])


### PR DESCRIPTION
Missed this because it isn't run on the main dtest jobs. Fixes this error:

http://cassci.datastax.com/view/Upgrades/job/storage_engine_upgrade_dtest-21_HEAD-22_tarball/82/testReport/upgrade_tests.cql_tests/TestCQLNodes3RF3/test_v2_protocol_IN_with_tuples/