### PR TITLE
Use FallthroughRetryPolicy on failure_threshold_deletions

### DIFF
--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -405,8 +405,10 @@ class TestCommitLog(Tester):
             node.wait_for_binary_interface(from_mark=mark, timeout=20)
         self.assertFalse(node.is_running())
 
+    @since('2.2')
     def test_compression_error(self):
         """
+        @jira_ticket CASSANDRA-7886
         if the commit log header refers to an unknown compression class, and the commit_failure_policy is stop, C* shouldn't startup
         """
         if not hasattr(self, 'ignore_log_patterns'):


### PR DESCRIPTION
On 2.1 we were getting OperationTimedout instead of ReadTimeout.
This was because we now have a default retry policy set.
On retry, we were ignoring the ReadTimeout error that was
correctly being sent by C*. By overring the retry policy,
we have stopped retrying, and now propagate the correct exception.

@knifewine to review. 