### PR TITLE
add failure_notes to collect_known_failures output

### DIFF
--- a/bin/collect_known_failures.py
+++ b/bin/collect_known_failures.py
@@ -39,13 +39,15 @@ class PrintJiraURLPlugin(nose.plugins.Plugin):
         jira_url = get_attr_for_current_method(attr_name='jira_url')
         flaky = get_attr_for_current_method(attr_name='known_flaky')
         failure_source = get_attr_for_current_method(attr_name='known_failure')
+        notes = get_attr_for_current_method(attr_name='failure_notes')
 
         return json.dumps({
             'module': test_module,
             'name': test_name,
             'jira_url': jira_url,
             'known_flaky': flaky,
-            'failure_source': failure_source
+            'failure_source': failure_source,
+            'notes': notes
         })
 
 

--- a/tools.py
+++ b/tools.py
@@ -362,7 +362,7 @@ def known_failure(failure_source, jira_url, flaky=False, notes=None):
         if flaky:
             tagged_func = attr('known_flaky')(tagged_func)
         if notes:
-            tagged_func = attr('failure_notes')(tagged_func)
+            tagged_func = attr(failure_notes=notes)(tagged_func)
         return tagged_func
     return wrapper
 


### PR DESCRIPTION
adds free-text notes to json output from `bin/collect_known_failures.py`.

You can try this out locally with 

```sh
python ./bin/collect_known_failures.py -a failure_notes
python ./bin/collect_known_failures.py -a known_failure
```

@ptnapoleon to review.