### PR TITLE
Fixes for CASSANDRA-9472

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -143,7 +143,7 @@ class TestOfflineTools(Tester):
 
         # test by loading large amount data so we have multiple sstables
         cluster.start(wait_for_binary_proto=True)
-        node1.stress(['write', 'n=100K', '-schema', 'replication(factor=1)'])
+        node1.stress(['write', 'n=200K', '-schema', 'replication(factor=1)'])
         node1.flush()
         self.wait_for_compactions(node1)
         cluster.stop()
@@ -162,6 +162,9 @@ class TestOfflineTools(Tester):
         initial_levels = self.get_levels(node1.run_sstablemetadata(keyspace="keyspace1", column_families=["standard1"]))
         (output, error, rc) = node1.run_sstableofflinerelevel("keyspace1", "standard1", output=True)
         final_levels = self.get_levels(node1.run_sstablemetadata(keyspace="keyspace1", column_families=["standard1"]))
+
+        debug(output)
+        debug(error)
 
         debug(initial_levels)
         debug(final_levels)


### PR DESCRIPTION
I enhanced `jmxmetrics_test.TestJMXMetrics.begin_test` to cope with offheap memtables, else it will consistently fail after CASSANDRA-9472 is committed.

I believe the known failure described in CASSANDRA-10846 for `sstableofflinerelevel_test` is probably due to a lack of overlapping tables. I had it consistently failing on the 9472 branch with offheap memtable objects whilst without offheap memtable ojects it would pass consistently. After investigating I discovered it was passing only because of 1 overlapping table. Increasing the number of records from 100K to 200K fixed it in both scenarios.