### PR TITLE
changes default arg from dict to None

### DIFF
--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -27,7 +27,7 @@ class TestMaterializedViews(Tester):
     @since 3.0
     """
 
-    def prepare(self, user_table=False, rf=1, options={}, nodes=3):
+    def prepare(self, user_table=False, rf=1, options=None, nodes=3):
         cluster = self.cluster
         cluster.populate([nodes, 0])
         if options:


### PR DESCRIPTION
I don't think that `options` is manipulated in a way that would cause
problems, but we're asking for trouble leaving it like this.

@ptnapoleon, can you review? It's teeny, I don't see any potential for issue here