### PR TITLE
Tests for CASSANDRA-9303

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -2,6 +2,7 @@
 import csv
 import datetime
 import json
+import glob
 import os
 import sys
 import time
@@ -9,9 +10,10 @@ from collections import namedtuple
 from contextlib import contextmanager
 from decimal import Decimal
 from dtest import warning
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, gettempdir
 from uuid import uuid1, uuid4
 
+from cassandra.murmur3 import murmur3
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.util import SortedSet
 from ccmlib.common import is_win
@@ -67,25 +69,31 @@ class CqlshCopyTest(Tester):
         unmonkeypatch_driver(cls._cached_driver_methods)
 
     def tearDown(self):
+        self.deleteTempFiles()
+        super(CqlshCopyTest, self).tearDown()
+
+    def deleteTempFiles(self):
         try:
-            if self.tempfile:
+            if self.tempfile and os.path.isfile(self.tempfile.name):
                 if is_win():
                     self.tempfile.close()
                 os.unlink(self.tempfile.name)
         except AttributeError:
             pass
 
-        super(CqlshCopyTest, self).tearDown()
+        for pattern in ['import_ks_*.err*', 'import_keyspace1_*.err*']:
+            for err_file in glob.glob(pattern):
+                os.unlink(err_file)
 
     def prepare(self, nodes=1, partitioner="murmur3", configuration_options=None, tokens=None):
+        p = PARTITIONERS[partitioner]
         if not self.cluster.nodelist():
-            p = PARTITIONERS[partitioner]
             self.cluster.set_partitioner(p)
             if configuration_options:
                 self.cluster.set_configuration_options(values=configuration_options)
             self.cluster.populate(nodes, tokens=tokens).start(wait_for_binary_proto=True)
         else:
-            self.assertEqual(self.cluster.partitioner, partitioner, "Cannot reuse cluster: different partitioner")
+            self.assertEqual(self.cluster.partitioner, p, "Cannot reuse cluster: different partitioner")
             self.assertEqual(len(self.cluster.nodelist()), nodes, "Cannot reuse cluster: different number of nodes")
             self.assertIsNone(configuration_options)
 
@@ -255,12 +263,13 @@ class CqlshCopyTest(Tester):
                         warning("Value in result: " + str(processed_results[0][x]))
             raise e
 
-    def format_for_csv(self, val):
+    def format_for_csv(self, val, time_format, float_precision):
         with self._cqlshlib() as cqlshlib:
             from cqlshlib.formatting import format_value
             try:
                 from cqlshlib.formatting import DateTimeFormat
                 date_time_format = DateTimeFormat()
+                date_time_format.timestamp_format = time_format
             except ImportError:
                 date_time_format = None
 
@@ -282,12 +291,15 @@ class CqlshCopyTest(Tester):
                             val,
                             encoding=encoding_name,
                             date_time_format=date_time_format,
-                            time_format=DEFAULT_TIME_FORMAT,
-                            float_precision=DEFAULT_FLOAT_PRECISION,
+                            time_format=time_format,
+                            float_precision=float_precision,
                             colormap=DummyColorMap(),
-                            nullval=None).strval
+                            nullval=None,
+                            decimal_sep=None,
+                            thousands_sep=None,
+                            boolean_styles=None).strval
 
-    def result_to_csv_rows(self, result):
+    def result_to_csv_rows(self, result, time_format=DEFAULT_TIME_FORMAT, float_precision=DEFAULT_FLOAT_PRECISION):
         """
         Given an object returned from a CQL query, returns a string formatted by
         the cqlsh formatting utilities.
@@ -295,7 +307,7 @@ class CqlshCopyTest(Tester):
         # This has no real dependencies on Tester except that self._cqlshlib has
         # to grab self.cluster's install directory. This should be pulled out
         # into a bare function if cqlshlib is made easier to interact with.
-        return [[self.format_for_csv(v) for v in row] for row in result]
+        return [[self.format_for_csv(v, time_format, float_precision) for v in row] for row in result]
 
     def test_list_data(self):
         """
@@ -543,31 +555,40 @@ class CqlshCopyTest(Tester):
         self.assertItemsEqual([tuple(d) for d in data],
                               [tuple(r) for r in rows_to_list(result)])
 
-    def test_writing_with_timeformat(self):
+    def test_datetimeformat_round_trip(self):
         """
         @jira_ticket CASSANDRA-10633
-        Test COPY TO with the time format specified in the WITH option by:
+        @jira_ticket CASSANDRA-9303
+
+        Test COPY TO and COPY FORM with the time format specified in the WITH option by:
 
         - creating and populating a table,
-        - exporting the contents of the table to a CSV file using COPY TO WITH TIMEFORMAT,
+        - exporting the contents of the table to a CSV file using COPY TO WITH DATETIMEFORMAT,
         - checking the time format written to csv.
+        - importing the CSV back into the table
+        - comparing the table contents before and after the import
+
+        CASSANDRA-9303 renamed TIMEFORMAT to DATETIMEFORMAT
         """
         self.prepare()
         self.session.execute("""
-            CREATE TABLE testtimeformat (
+            CREATE TABLE testdatetimeformat (
                 a int primary key,
                 b timestamp
             )""")
-        insert_statement = self.session.prepare("INSERT INTO testtimeformat (a, b) VALUES (?, ?)")
+        insert_statement = self.session.prepare("INSERT INTO testdatetimeformat (a, b) VALUES (?, ?)")
         args = [(1, datetime.datetime(2015, 1, 1, 07, 00, 0, 0, UTC())),
                 (2, datetime.datetime(2015, 6, 10, 12, 30, 30, 500, UTC())),
                 (3, datetime.datetime(2015, 12, 31, 23, 59, 59, 999, UTC()))]
         execute_concurrent_with_args(self.session, insert_statement, args)
+        exported_results = list(self.session.execute("SELECT * FROM testdatetimeformat"))
+
+        format = '%Y/%m/%d %H:%M'
 
         self.tempfile = NamedTemporaryFile(delete=False)
         debug('Exporting to csv file: {name}'.format(name=self.tempfile.name))
-        cmds = "COPY ks.testtimeformat TO '{name}'".format(name=self.tempfile.name)
-        cmds += " WITH TIMEFORMAT = '%Y/%m/%d %H:%M'"
+        cmds = "COPY ks.testdatetimeformat TO '{name}'".format(name=self.tempfile.name)
+        cmds += " WITH DATETIMEFORMAT = '{}'".format(format)
         self.node1.run_cqlsh(cmds=cmds)
 
         with open(self.tempfile.name, 'r') as csvfile:
@@ -577,6 +598,15 @@ class CqlshCopyTest(Tester):
                               [['1', '2015/01/01 07:00'],
                                ['2', '2015/06/10 12:30'],
                                ['3', '2015/12/31 23:59']])
+
+        self.session.execute("TRUNCATE testdatetimeformat")
+        cmds = "COPY ks.testdatetimeformat FROM '{name}'".format(name=self.tempfile.name)
+        cmds += " WITH DATETIMEFORMAT = '{}'".format(format)
+        self.node1.run_cqlsh(cmds=cmds)
+
+        imported_results = list(self.session.execute("SELECT * FROM testdatetimeformat"))
+        self.assertItemsEqual(self.result_to_csv_rows(exported_results, time_format=format),
+                              self.result_to_csv_rows(imported_results, time_format=format))
 
     @since('3.2')
     def test_reading_with_ttl(self):
@@ -616,6 +646,526 @@ class CqlshCopyTest(Tester):
 
         result = rows_to_list(self.session.execute("SELECT * FROM testttl"))
         self.assertItemsEqual([], result)
+
+    def test_reading_with_skip_and_max_rows(self):
+        """
+        Test importing a rows from a CSV file with maxrows and skiprows:
+
+        - create a large CSV file via stress write and COPY TO
+        - For a specified number of rows:
+        -- truncate the table
+        -- import the CSV file with max rows set to this number
+        -- compare the number of rows imported via select count
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+        self.tempfile = NamedTemporaryFile(delete=False)
+        stress_table = 'keyspace1.standard1'
+        max_num_rows = 10000
+
+        debug('Running stress to generate a large CSV via COPY TO')
+        self.node1.stress(['write', 'n={}'.format(max_num_rows), '-rate', 'threads=50'])
+        self.node1.run_cqlsh(cmds="COPY {} TO '{}'".format(stress_table, self.tempfile.name))
+        self.assertEqual(max_num_rows, len(open(self.tempfile.name).readlines()))
+
+        def do_test(num_rows, skip_rows):
+            debug('Preparing to test {} max rows and {} skip rows by truncating table'.format(num_rows, skip_rows))
+            self.session.execute("TRUNCATE {}".format(stress_table))
+            result = rows_to_list(self.session.execute("SELECT * FROM {}".format(stress_table)))
+            self.assertItemsEqual([], result)
+
+            debug('Importing {} rows'.format(num_rows))
+            self.node1.run_cqlsh(cmds="COPY {} FROM '{}' WITH MAXROWS = '{}' AND SKIPROWS='{}'"
+                                 .format(stress_table, self.tempfile.name, num_rows, skip_rows))
+
+            expected_rows = num_rows if 0 <= num_rows < max_num_rows else max_num_rows
+            expected_rows -= min(max_num_rows, max(0, skip_rows))
+            self.assertEqual([[expected_rows]],
+                             rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}".format(stress_table))))
+            debug('Imported {} as expected'.format(expected_rows))
+
+        # max rows tests
+        do_test(-1, 0)
+        do_test(0, 0)
+        do_test(1, 0)
+        do_test(100, 0)
+        do_test(max_num_rows, 0)
+        do_test(max_num_rows + 1, 0)
+
+        # skip rows tests
+        do_test(-1, 100)
+        do_test(max_num_rows, 100)
+        do_test(100, 100)
+        do_test(max_num_rows, max_num_rows)
+        do_test(max_num_rows, max_num_rows + 1)
+        do_test(max_num_rows, -1)
+
+    def test_reading_with_skip_cols(self):
+        """
+        Test importing a CSV file but skipping some columns:
+
+        - create a table
+        - create a csv file with all column values
+        - import the csv file with skip_columns
+        - check only the columns that were not skipped are in the table
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+        self.session.execute("""
+            CREATE TABLE testskipcols (
+                a int primary key,
+                b int,
+                c int,
+                d int,
+                e int
+            )""")
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+        data = [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]
+
+        with open(self.tempfile.name, 'w') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'c', 'd', 'e'])
+            for a, b, c, d, e in data:
+                writer.writerow({'a': a, 'b': b, 'c': c, 'd': d, 'e': e})
+            csvfile.close
+
+        def do_test(skip_cols, expected_results):
+            self.session.execute('TRUNCATE ks.testskipcols')
+            debug("Importing csv file {} with skipcols '{}'".format(self.tempfile, skip_cols))
+            out, err = self.node1.run_cqlsh(cmds="COPY ks.testskipcols FROM '{}' WITH SKIPCOLS = '{}'"
+                                            .format(self.tempfile.name, skip_cols), return_output=True, cqlsh_options=['--debug'])
+            debug(out)
+            self.assertItemsEqual(expected_results, rows_to_list(self.session.execute("SELECT * FROM ks.testskipcols")))
+
+        do_test('c, d ,e', [[1, 2, None, None, None], [6, 7, None, None, None]])
+        do_test('b,', [[1, None, 3, 4, 5], [6, None, 8, 9, 10]])
+        do_test('b', [[1, None, 3, 4, 5], [6, None, 8, 9, 10]])
+        do_test('c', [[1, 2, None, 4, 5], [6, 7, None, 9, 10]])
+        do_test(',e', [[1, 2, 3, 4, None], [6, 7, 8, 9, None]])
+        do_test('e', [[1, 2, 3, 4, None], [6, 7, 8, 9, None]])
+        do_test('a,b,c,d,e', [])
+        do_test('a,', [])  # primary key cannot be skipped, should refuse to import with an error
+        do_test('a', [])  # primary key cannot be skipped, should refuse to import with an error
+
+    def test_reading_counters_with_skip_cols(self):
+        """
+        Test importing a CSV file for a counter table but skipping some columns:
+
+        - create a table
+        - create a csv file with all column values
+        - import the csv file with skip_columns
+        - check only the columns that were not skipped are in the table
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+        self.session.execute("""
+            CREATE TABLE testskipcols (
+                a int primary key,
+                b counter,
+                c counter,
+                d counter,
+                e counter
+            )""")
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+        data = [[1, 1, 1, 1, 1], [2, 1, 1, 1, 1]]
+
+        with open(self.tempfile.name, 'w') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'c', 'd', 'e'])
+            for a, b, c, d, e in data:
+                writer.writerow({'a': a, 'b': b, 'c': c, 'd': d, 'e': e})
+            csvfile.close
+
+        def do_test(skip_cols, expected_results):
+            debug("Importing csv file {} with skipcols '{}'".format(self.tempfile, skip_cols))
+            out, err = self.node1.run_cqlsh(cmds="COPY ks.testskipcols FROM '{}' WITH SKIPCOLS = '{}'"
+                                            .format(self.tempfile.name, skip_cols), return_output=True)
+            debug(out)
+            self.assertItemsEqual(expected_results, rows_to_list(self.session.execute("SELECT * FROM ks.testskipcols")))
+
+        do_test('c, d ,e', [[1, 1, None, None, None], [2, 1, None, None, None]])
+        do_test('b', [[1, 1, 1, 1, 1], [2, 1, 1, 1, 1]])
+        do_test('b', [[1, 1, 2, 2, 2], [2, 1, 2, 2, 2]])
+        do_test('e', [[1, 2, 3, 3, 2], [2, 2, 3, 3, 2]])
+
+    def test_writing_with_token_boundaries(self):
+        """
+        Test COPY TO with the begin and end tokens specified in the WITH option by:
+
+        - creating and populating a table,
+        - exporting the contents of the table to a CSV file using COPY TO WITH MINTOKEN AND MAXTOKEN,
+        - checking that only the values with the token in the specified range were exported.
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self._test_writing_with_token_boundaries(10, 1000000000000000000, 2000000000000000000)
+        self._test_writing_with_token_boundaries(100, 1000000000000000000, 2000000000000000000)
+        self._test_writing_with_token_boundaries(1000, 1000000000000000000, 2000000000000000000)
+        self._test_writing_with_token_boundaries(10000, 1000000000000000000, 2000000000000000000)
+        self._test_writing_with_token_boundaries(10000, 1000000000000000000, 1000000000000000001)
+        self._test_writing_with_token_boundaries(10000, None, 2000000000000000000)
+        self._test_writing_with_token_boundaries(10000, 1000000000000000000, None)
+        self._test_writing_with_token_boundaries(100, 1000000000000000000, 1000000000000000000)
+        self._test_writing_with_token_boundaries(100, 2000000000000000000, 1000000000000000000)
+
+    def _test_writing_with_token_boundaries(self, num_records, begin_token, end_token):
+        self.prepare(partitioner="murmur3")
+        self.session.execute("CREATE TABLE testtokens(a text primary key)")
+
+        insert_statement = self.session.prepare("INSERT INTO testtokens (a) VALUES (?)")
+        execute_concurrent_with_args(self.session, insert_statement, [(str(i),) for i in xrange(num_records)])
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+        debug('Exporting to csv file: {name}'.format(name=self.tempfile.name))
+        cmds = "COPY ks.testtokens TO '{}'".format(self.tempfile.name)
+        if begin_token and end_token:
+            cmds += "WITH BEGINTOKEN = '{}' AND ENDTOKEN = '{}'".format(begin_token, end_token)
+        elif begin_token:
+            cmds += "WITH BEGINTOKEN = '{}'".format(begin_token)
+        elif end_token:
+            cmds += "WITH ENDTOKEN = '{}'".format(end_token)
+
+        self.node1.run_cqlsh(cmds=cmds)
+
+        max_long = 2 ** 63 - 1
+        min_long = -max_long - 1
+        if not begin_token:
+            begin_token = min_long
+        if not end_token:
+            end_token = max_long
+
+        tokens = [murmur3(str(i)) for i in xrange(num_records)]
+        result = sorted([(str(i), tokens[i]) for i in xrange(num_records) if begin_token <= tokens[i] <= end_token])
+
+        with open(self.tempfile.name, 'r') as csvfile:
+            csv_values = sorted([(v[0], tokens[int(v[0])]) for v in csv.reader(csvfile)])
+
+        # debug(result)
+        # debug(csv_values)
+        self.assertItemsEqual(csv_values, result)
+
+    def test_reading_max_parse_errors(self):
+        """
+        Test that importing a csv file is aborted when we reach the maximum number of parse errors:
+
+        - create a table
+        - create a csv file with some invalid rows
+        - import the csv file
+        - check that we import fewer rows that the total number of valid rows and
+        that we display the correct message
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+        self.session.execute("""
+            CREATE TABLE testmaxparseerrors (
+                a int,
+                b int,
+                c float,
+                PRIMARY KEY (a, b)
+            )""")
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+        num_rows = 10000
+        max_parse_errors = 10
+
+        with open(self.tempfile.name, 'w') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'c'])
+            for i in xrange(num_rows):
+                if i % 2 == 0:
+                    writer.writerow({'a': i, 'b': 0, 'c': 'abc'})  # invalid
+                else:
+                    writer.writerow({'a': i, 'b': 0, 'c': 2.0})  # valid
+            csvfile.close
+
+        debug("Importing csv file {} with {} max parse errors".format(self.tempfile.name, max_parse_errors))
+        out, err = self.node1.run_cqlsh(cmds="COPY ks.testmaxparseerrors FROM '{}' WITH MAXPARSEERRORS='{}'"
+                                        .format(self.tempfile.name, max_parse_errors),
+                                        return_output=True, cqlsh_options=['--debug'])
+
+        self.assertIn('Exceeded maximum number of parse errors {}'.format(max_parse_errors), err)
+        num_rows_imported = rows_to_list(self.session.execute("SELECT COUNT(*) FROM ks.testmaxparseerrors"))[0][0]
+        self.assertTrue(num_rows_imported < (num_rows / 2))  # less than the maximum number of valid rows in the csv
+
+    def test_reading_max_insert_errors(self):
+        """
+        Test that importing a csv file is aborted when we reach the maximum number of insert errors:
+
+        - create a table
+        - create a csv file with some data
+        - fail one batch permanently (via CQLSH_COPY_TEST_FAILURES so that chunk_size rows will fail a # of times higher than
+        the maximum number of attempts)
+        - import the csv file
+        - check that:
+         - if chunk_size is bigger than max_insert_errors the import is aborted (we import fewer rows that the total
+         number of allowed rows and we display the correct error message)
+         - otherwise the import operation completes for all rows except for the failed batch
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+        self.session.execute("""
+            CREATE TABLE testmaxinserterrors (
+                a int,
+                b int,
+                c float,
+                PRIMARY KEY (a, b)
+            )""")
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+        num_rows = 10000
+
+        with open(self.tempfile.name, 'w') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'c'])
+            for i in xrange(num_rows):
+                writer.writerow({'a': i, 'b': 0, 'c': 2.0})
+            csvfile.close
+
+        failures = {'failing_batch': {'id': 3, 'failures': 2}}
+        os.environ['CQLSH_COPY_TEST_FAILURES'] = json.dumps(failures)
+
+        def do_test(max_insert_errors, chunk_size):
+            self.session.execute("TRUNCATE ks.testmaxinserterrors")
+            num_expected_rows = num_rows - chunk_size  # one batch will fail
+
+            debug("Importing csv file {} with {} max insert errors and chunk size {}"
+                  .format(self.tempfile.name, max_insert_errors, chunk_size))
+            # Note: we use one attempt because each attempt counts as a failure
+            out, err = self.node1.run_cqlsh(cmds="COPY ks.testmaxinserterrors FROM '{}' WITH MAXINSERTERRORS='{}' "
+                                                 "AND CHUNKSIZE='{}' AND MAXATTEMPTS='1'"
+                                            .format(self.tempfile.name, max_insert_errors, chunk_size),
+                                            return_output=True, cqlsh_options=['--debug'])
+
+            num_rows_imported = rows_to_list(self.session.execute("SELECT COUNT(*) FROM ks.testmaxinserterrors"))[0][0]
+            if max_insert_errors < chunk_size:
+                self.assertIn('Exceeded maximum number of insert errors {}'.format(max_insert_errors), err)
+                self.assertTrue(num_rows_imported <= num_expected_rows,
+                                "{} < {}".format(num_rows_imported, num_expected_rows))
+            else:
+                self.assertNotIn('Exceeded maximum number of insert errors {}'.format(max_insert_errors), err)
+                self.assertIn('Failed to process {} rows'.format(chunk_size), err)
+                self.assertEquals(num_expected_rows, num_rows_imported)
+
+        do_test(50, 100)
+        do_test(100, 50)
+        do_test(50, 50)
+
+    def test_reading_with_parse_errors(self):
+        """
+        Test importing a CSV file where not all rows can be parsed:
+
+        - create a table
+        - create a csv file with some invalid rows
+        - import the csv file
+        - check that the valid rows are imported and the invalid rows are saved in a bad file.
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+        self.session.execute("""
+            CREATE TABLE testparseerrors (
+                a int,
+                b int,
+                c float,
+                PRIMARY KEY (a, b)
+            )""")
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+
+        def do_test(num_chunks, chunk_size, num_failing_per_chunk, err_file):
+            invalid_rows = []
+            valid_rows = []
+            with open(self.tempfile.name, 'w') as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'c'])
+                for i in xrange(num_chunks):
+                    for k in xrange(chunk_size):
+                        if k < num_failing_per_chunk:  # invalid
+                            if i == 0 and k == 0:  # fail on a primary key (only once)
+                                writer.writerow({'a': 'bb', 'b': k, 'c': 1.0})
+                                invalid_rows.append(['bb', k, '1.0'])
+                            else:  # fail on a value
+                                writer.writerow({'a': i, 'b': k, 'c': 'abc'})
+                                invalid_rows.append([i, k, 'abc'])
+                        else:
+                            writer.writerow({'a': i, 'b': k, 'c': 2.0})  # valid
+                            valid_rows.append([i, k, 2.0])
+                csvfile.close
+
+            err_file_name = err_file.name if err_file else 'import_ks_testparseerrors.err'
+            self.session.execute("TRUNCATE testparseerrors")
+
+            debug("Importing csv file {} with err_file {} and {}/{}/{}"
+                  .format(self.tempfile.name, err_file_name, num_chunks, chunk_size, num_failing_per_chunk))
+            cmd = "COPY ks.testparseerrors FROM '{}' WITH CHUNKSIZE={}".format(self.tempfile.name, chunk_size)
+            if err_file:
+                cmd += " AND ERRFILE='{}'".format(err_file.name)
+            self.node1.run_cqlsh(cmds=cmd)
+
+            debug('Sorting')
+            results = sorted(rows_to_list(self.session.execute("SELECT * FROM ks.testparseerrors")))
+            debug('Checking valid rows')
+            self.assertItemsEqual(valid_rows, results)
+            debug('Checking invalid rows')
+            self.assertCsvResultEqual(err_file_name, invalid_rows)
+
+        do_test(100, 2, 1, NamedTemporaryFile(delete=False))
+        do_test(10, 50, 1, NamedTemporaryFile(delete=False))
+        do_test(10, 100, 10, NamedTemporaryFile(delete=False))
+        do_test(10, 100, 100, NamedTemporaryFile(delete=False))
+
+        # at least two default files to make sure old default err file gets renamed to .YYYYMMDD_HHMMSS
+        do_test(100, 2, 1, None)
+        do_test(10, 50, 1, None)
+
+    def test_reading_with_wrong_number_of_columns(self):
+        """
+        Test importing a CSV file where not all rows have the correct number of columns:
+
+        - create a table
+        - create a csv file with some invalid rows
+        - import the csv file
+        - check that the valid rows are imported and the invalid rows are saved in a bad file.
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+        self.session.execute("""
+            CREATE TABLE testwrongnumcols (
+                a int,
+                b int,
+                c float,
+                d float,
+                e float,
+                PRIMARY KEY (a, b)
+            )""")
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+        err_file = NamedTemporaryFile(delete=True)
+
+        invalid_rows = []
+        valid_rows = []
+        with open(self.tempfile.name, 'w') as csvfile:  # c, d is missing
+            writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'e'])
+            writer.writerow({'a': 0, 'b': 0, 'e': 1.0})
+            invalid_rows.append([0, 0, '1.0'])
+
+            writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'c', 'd', 'e'])
+            for i in xrange(1, 100):
+                writer.writerow({'a': i, 'b': i, 'c': 2.0, 'd': 3.0, 'e': 4.0})
+                valid_rows.append([i, i, 2.0, 3.0, 4.0])
+
+            csvfile.close
+
+        debug("Importing csv file {} with err_file {}".format(self.tempfile.name, err_file.name))
+        cmd = "COPY ks.testwrongnumcols FROM '{}' WITH ERRFILE='{}'".format(self.tempfile.name, err_file.name)
+        self.node1.run_cqlsh(cmds=cmd, show_output=True)
+
+        debug('Sorting')
+        results = sorted(rows_to_list(self.session.execute("SELECT * FROM ks.testwrongnumcols")))
+        debug('Checking valid rows')
+        self.assertItemsEqual(valid_rows, results)
+        debug('Checking invalid rows')
+        self.assertCsvResultEqual(err_file.name, invalid_rows)
+
+    def test_reading_with_multiple_files(self):
+        """
+        Test importing multiple CSV files
+
+        - create a table
+        - create a several csv files
+        - import the csv files
+        - check that all rows were imported
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+        self.session.execute("""
+            CREATE TABLE testmultifiles (
+                a int,
+                b int,
+                c float,
+                PRIMARY KEY (a, b)
+            )""")
+
+        num_rows_per_file = 100
+        num_files = 10
+        tempfiles = []
+
+        for i in xrange(num_files):
+            tempfiles.append(NamedTemporaryFile(delete=True, prefix='testreadmult{}'.format(i), suffix='.csv'))
+
+        for i in xrange(num_files):
+            with open(tempfiles[i].name, 'w') as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'c'])
+                for k in xrange(num_rows_per_file):
+                    writer.writerow({'a': i, 'b': k, 'c': 2.0})
+                csvfile.close
+
+        def import_and_check(temp_files_str):
+            self.session.execute("TRUNCATE testmultifiles")
+
+            debug("Importing csv files {}".format(temp_files_str))
+            self.node1.run_cqlsh(cmds="COPY ks.testmultifiles FROM '{}'".format(temp_files_str))
+
+            self.assertEqual([[num_rows_per_file * len(tempfiles)]],
+                             rows_to_list(self.session.execute("SELECT COUNT(*) FROM testmultifiles")))
+
+        import_and_check(','.join([tempfile.name for tempfile in tempfiles]))
+        import_and_check(os.path.join(gettempdir(), 'testreadmult*.csv'))
+        import_and_check(','.join([os.path.join(gettempdir(), 'testreadmult[0-4]*.csv'),
+                                   os.path.join(gettempdir(), 'testreadmult[5-9]*.csv')]))
+
+    def test_writing_with_max_output_size(self):
+        """
+        Test writing to multiple CSV files:
+
+        - create a table and populate it with some data
+        - export the data with maxoutputsize
+        - check that the correct number of CSV files has been created and that
+          they have the expected number of lines
+
+        @jira_ticket CASSANDRA-9303
+        """
+        num_records = 10000
+        stress_table = 'keyspace1.standard1'
+
+        self.prepare()
+        self.node1.stress(['write', 'n={}'.format(num_records), '-rate', 'threads=50'])
+
+        def do_test(max_size, header):
+            self.tempfile = NamedTemporaryFile(delete=False, prefix='testwritemult', suffix='.csv')
+            debug('Exporting to csv file: {} with max size {} and header {}'
+                  .format(self.tempfile.name, max_size, header))
+            cmd = "COPY {} TO '{}' WITH MAXOUTPUTSIZE='{}'".format(stress_table, self.tempfile.name, max_size)
+            if header:
+                cmd += " AND HEADER='True'"
+            self.node1.run_cqlsh(cmds=cmd)
+
+            output_files = glob.glob(os.path.join(gettempdir(), 'testwritemult*.csv*'))
+            num_lines = []
+            for f in output_files:
+                num_lines.append(len(open(os.path.join(gettempdir(), f)).readlines()))
+                os.unlink(f)
+
+            num_expected_files = num_records / max_size if num_records % max_size == 0 else (num_records / max_size + 1)
+            self.assertEquals(num_expected_files, len(output_files))
+            self.assertEquals(num_records + 1 if header else num_records, sum(num_lines))
+
+            for i, n in enumerate(sorted(num_lines, reverse=True)):
+                if i < num_records / max_size:
+                    num_expected_lines = max_size + 1 if i == 0 and header else max_size
+                    self.assertEquals(num_expected_lines, n)
+                else:
+                    self.assertEquals(num_records % max_size, n)
+
+        do_test(1000, False)
+        do_test(1000, True)
+        do_test(900, False)
+        do_test(500, False)
+        do_test(100, False)
 
     def test_explicit_column_order_writing(self):
         """
@@ -874,7 +1424,7 @@ class CqlshCopyTest(Tester):
         @jira_ticket CASSANDRA-10854
         """
         self.data_validation_on_read_template([['', 1, 'test']],
-                                              expected_err="Failed to import 1 rows: ValueError - "
+                                              expected_err="Failed to import 1 rows: ParseError - "
                                                            "Cannot insert null value for primary key column")
 
     def test_read_missing_clustering_key(self):
@@ -883,7 +1433,7 @@ class CqlshCopyTest(Tester):
         @jira_ticket CASSANDRA-10854
         """
         self.data_validation_on_read_template([[1, '', 'test']],
-                                              expected_err="Failed to import 1 rows: ValueError - "
+                                              expected_err="Failed to import 1 rows: ParseError - "
                                                            "Cannot insert null value for primary key column")
 
     def test_all_datatypes_write(self):
@@ -980,6 +1530,359 @@ class CqlshCopyTest(Tester):
         assert len(imported_results) == 1
 
         self.assertEqual(exported_results, imported_results)
+
+    def test_boolstyle_round_trip(self):
+        """
+        Test that a CSV file with booleans in a different style successfully round-trips
+        via COPY by:
+
+        - creating and populating a table containing boolean values,
+        - copying that table to a CSV file,
+        - checking the contents of the CSV,
+        - truncating the table,
+        - copying the written CSV file back into the table, and
+        - asserting that the previously-SELECTed contents of the table match the
+        current contents of the table.
+
+        @jira_ticket CASSANDRA-9303
+        """
+        def do_round_trip(trueval, falseval):
+            debug('Exporting to csv file: {} with bool style {},{}'.format(self.tempfile.name, trueval, falseval))
+            self.node1.run_cqlsh(cmds="COPY ks.testbooleans TO '{}' WITH BOOLSTYLE='{}, {}'"
+                                 .format(self.tempfile.name, trueval, falseval))
+
+            self.assertItemsEqual([['0', falseval], ['1', trueval]], list(csv_rows(self.tempfile.name)))
+            exported_results = list(self.session.execute("SELECT * FROM testbooleans"))
+
+            debug('Importing from csv file: {}'.format(self.tempfile.name))
+            self.session.execute('TRUNCATE ks.testbooleans')
+            self.node1.run_cqlsh(cmds="COPY ks.testbooleans FROM '{}' WITH BOOLSTYLE='{}, {}'"
+                                 .format(self.tempfile.name, trueval, falseval))
+
+            imported_results = list(self.session.execute("SELECT * FROM testbooleans"))
+            assert len(imported_results) == 2
+            self.assertEqual(exported_results, imported_results)
+
+        self.prepare()
+        self.session.execute("""
+            CREATE TABLE testbooleans (
+                a int PRIMARY KEY,
+                b boolean
+            )""")
+
+        insert_statement = self.session.prepare("INSERT INTO testbooleans (a, b) VALUES (?, ?)")
+        self.session.execute(insert_statement, [0, False])
+        self.session.execute(insert_statement, [1, True])
+        self.tempfile = NamedTemporaryFile(delete=False)
+
+        do_round_trip('True', 'False')
+        do_round_trip('TRUE', 'FALSE')
+        do_round_trip('yes', 'no')
+        do_round_trip('1', '0')
+
+    def test_number_separators_round_trip(self):
+        """
+        Test that a CSV file containing numbers with decimal and thousands separators in a different format
+        successfully round-trips via COPY by:
+
+        - creating and populating a table containing a numbers,
+        - copying that table to a CSV file,
+        - checking the contents of the CSV,
+        - truncating the table,
+        - copying the written CSV file back into the table, and
+        - asserting that the previously selected contents of the table match the
+        current contents of the table.
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+
+        if self.cluster.version() < '2.2':
+            self.session.execute("""
+                CREATE TABLE testnumberseps (
+                    a int PRIMARY KEY,
+                    b int,
+                    c bigint,
+                    d varint,
+                    e decimal,
+                    f float,
+                    g double
+                )""")
+
+            insert_statement = self.session.prepare("INSERT INTO testnumberseps (a, b, c, d, e, f, g)"
+                                                    " VALUES (?, ?, ?, ?, ?, ?, ?)")
+            self.session.execute(insert_statement, [0, 10, 10, 10, Decimal(10), 10, 10])
+            self.session.execute(insert_statement, [1, 1000, 1000, 1000, Decimal(5.5), 5.5, 5.12345678])
+            self.session.execute(insert_statement, [2, 1000000, 1000000, 1000000, Decimal("0.001"), 0.001, 0.001])
+            self.session.execute(insert_statement, [3, 1000000005, 1000000005, 1000000005,
+                                                    Decimal("1234.56"), 1234.56, 123456789.56])
+            self.session.execute(insert_statement, [4, -1000000005, -1000000005, -1000000005,
+                                                    Decimal("-1234.56"), -1234.56, -1234.56])
+            self.session.execute(insert_statement, [1000000, 0, 0, 0, Decimal(0), 0, 0])
+
+            # comma as thousands sep and dot as decimal sep
+            expected_vals_usual = [
+                ['0', '10', '10', '10', '10', '10', '10'],
+                ['1', '1,000', '1,000', '1,000', '5.5', '5.5', '5.12346'],
+                ['2', '1,000,000', '1,000,000', '1,000,000', '0.001', '0.001', '0.001'],
+                ['3', '1,000,000,005', '1,000,000,005', '1,000,000,005', '1,234.56', '1,234.56006', '123,456,789.56'],
+                ['4', '-1,000,000,005', '-1,000,000,005', '-1,000,000,005', '-1,234.56', '-1,234.56006', '-1,234.56'],
+                ['1,000,000', '0', '0', '0', '0', '0', '0']
+            ]
+
+            # dot as thousands sep and comma as decimal sep
+            expected_vals_inverted = [
+                ['0', '10', '10', '10', '10', '10', '10'],
+                ['1', '1.000', '1.000', '1.000', '5,5', '5,5', '5,12346'],
+                ['2', '1.000.000', '1.000.000', '1.000.000', '0,001', '0,001', '0,001'],
+                ['3', '1.000.000.005', '1.000.000.005', '1.000.000.005', '1.234,56', '1.234,56006', '123.456.789,56'],
+                ['4', '-1.000.000.005', '-1.000.000.005', '-1.000.000.005', '-1.234,56', '-1.234,56006', '-1.234,56'],
+                ['1.000.000', '0', '0', '0', '0', '0', '0']
+            ]
+
+        else:
+            self.session.execute("""
+                CREATE TABLE testnumberseps (
+                    a int PRIMARY KEY,
+                    b tinyint,
+                    c smallint,
+                    d int,
+                    e bigint,
+                    f varint,
+                    g decimal,
+                    h float,
+                    i double
+                )""")
+
+            insert_statement = self.session.prepare("INSERT INTO testnumberseps (a, b, c, d, e, f, g, h, i)"
+                                                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
+            self.session.execute(insert_statement, [0, 10, 10, 10, 10, 10, Decimal(10), 10, 10])
+            self.session.execute(insert_statement, [1, 127, 255, 1000, 1000, 1000, Decimal(5.5), 5.5, 5.12345678])
+            self.session.execute(insert_statement, [2, 127, 255, 1000000, 1000000, 1000000,
+                                                    Decimal("0.001"), 0.001, 0.001])
+            self.session.execute(insert_statement, [3, 127, 255, 1000000005, 1000000005, 1000000005,
+                                                    Decimal("1234.56"), 1234.56, 123456789.56])
+            self.session.execute(insert_statement, [4, 127, 255, -1000000005, -1000000005, -1000000005,
+                                                    Decimal("-1234.56"), -1234.56, -1234.56])
+            self.session.execute(insert_statement, [1000000, 0, 0, 0, 0, 0, Decimal(0), 0, 0])
+
+            # comma as thousands sep and dot as decimal sep
+            expected_vals_usual = [
+                ['0', '10', '10', '10', '10', '10', '10', '10', '10'],
+                ['1', '127', '255', '1,000', '1,000', '1,000', '5.5', '5.5', '5.12346'],
+                ['2', '127', '255', '1,000,000', '1,000,000', '1,000,000', '0.001', '0.001', '0.001'],
+                ['3', '127', '255', '1,000,000,005', '1,000,000,005', '1,000,000,005',
+                 '1,234.56', '1,234.56006', '123,456,789.56'],
+                ['4', '127', '255', '-1,000,000,005', '-1,000,000,005', '-1,000,000,005',
+                 '-1,234.56', '-1,234.56006', '-1,234.56'],
+                ['1,000,000', '0', '0', '0', '0', '0', '0', '0', '0']
+            ]
+
+            # dot as thousands sep and comma as decimal sep
+            expected_vals_inverted = [
+                ['0', '10', '10', '10', '10', '10', '10', '10', '10'],
+                ['1', '127', '255', '1.000', '1.000', '1.000', '5,5', '5,5', '5,12346'],
+                ['2', '127', '255', '1.000.000', '1.000.000', '1.000.000', '0,001', '0,001', '0,001'],
+                ['3', '127', '255', '1.000.000.005', '1.000.000.005', '1.000.000.005',
+                 '1.234,56', '1.234,56006', '123.456.789,56'],
+                ['4', '127', '255', '-1.000.000.005', '-1.000.000.005', '-1.000.000.005',
+                 '-1.234,56', '-1.234,56006', '-1.234,56'],
+                ['1.000.000', '0', '0', '0', '0', '0', '0', '0', '0']
+            ]
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+
+        def do_test(expected_vals, thousands_sep, decimal_sep):
+            debug('Exporting to csv file: {} with thousands_sep {} and decimal_sep {}'
+                  .format(self.tempfile.name, thousands_sep, decimal_sep))
+            self.node1.run_cqlsh(cmds="COPY ks.testnumberseps TO '{}' WITH THOUSANDSSEP='{}' AND DECIMALSEP='{}'"
+                                 .format(self.tempfile.name, thousands_sep, decimal_sep))
+
+            exported_results = list(self.session.execute("SELECT * FROM testnumberseps"))
+            self.maxDiff = None
+            self.assertItemsEqual(expected_vals, list(csv_rows(self.tempfile.name)))
+
+            debug('Importing from csv file: {} with thousands_sep {} and decimal_sep {}'
+                  .format(self.tempfile.name, thousands_sep, decimal_sep))
+            self.session.execute('TRUNCATE ks.testnumberseps')
+            self.node1.run_cqlsh(cmds="COPY ks.testnumberseps FROM '{}' WITH THOUSANDSSEP='{}' AND DECIMALSEP='{}'"
+                                 .format(self.tempfile.name, thousands_sep, decimal_sep))
+
+            imported_results = list(self.session.execute("SELECT * FROM testnumberseps"))
+            self.assertEqual(len(expected_vals), len(imported_results))
+            self.assertEqual(self.result_to_csv_rows(exported_results),  # we format as if we were comparing to csv
+                             self.result_to_csv_rows(imported_results))  # to overcome loss of precision in the import
+
+        do_test(expected_vals_usual, ',', '.')
+        do_test(expected_vals_inverted, '.', ',')
+
+    def test_round_trip_with_num_processes(self):
+        """
+        Test exporting a large number of rows into a csv file with a fixed number of child processes.
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.prepare()
+
+        num_records = 10000
+        num_processes = 4
+        stress_table = 'keyspace1.standard1'
+
+        debug('Running stress without any user profile')
+        self.node1.stress(['write', 'n={}'.format(num_records), '-rate', 'threads=50'])
+
+        self.tempfile = NamedTemporaryFile(delete=False)
+        debug('Exporting to csv file: {}'.format(self.tempfile.name))
+        out, _ = self.node1.run_cqlsh(cmds="COPY {} TO '{}' WITH NUMPROCESSES='{}'"
+                                      .format(stress_table, self.tempfile.name, num_processes),
+                                      return_output=True)
+        debug(out)
+        self.assertIn('Using {} child processes'.format(num_processes), out)
+        self.assertEqual(num_records, len(open(self.tempfile.name).readlines()))
+
+        self.session.execute("TRUNCATE {}".format(stress_table))
+        debug('Importing from csv file: {}'.format(self.tempfile.name))
+        out, _ = self.node1.run_cqlsh(cmds="COPY {} FROM '{}' WITH NUMPROCESSES='{}'"
+                                      .format(stress_table, self.tempfile.name, num_processes),
+                                      return_output=True)
+        debug(out)
+        self.assertIn('Using {} child processes'.format(num_processes), out)
+        self.assertEqual([[num_records]], rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}"
+                                                                            .format(stress_table))))
+
+    def test_round_trip_with_rate_file(self):
+        """
+        Test a round trip with a large number of rows and a rate file. Make sure the rate file contains
+        output statistics
+
+        @jira_ticket CASSANDRA-9303
+        """
+        num_rows = 200000
+        report_frequency = 0.1  # every 100 milliseconds
+        stress_table = 'keyspace1.standard1'
+        ratefile = NamedTemporaryFile(delete=True)
+        self.tempfile = NamedTemporaryFile(delete=False)
+
+        def check_rate_file():
+            # check that the rate file has at least 10 lines (given that the report
+            # frequency is every 100 milliseconds this should be the number of lines written in 1 second)
+            # and that the last line indicates all rows were processed
+            lines = [line.rstrip('\n') for line in open(ratefile.name)]
+            self.assertTrue(len(lines) >= 10, "Expected at least 10 lines but got {} lines".format(len(lines)))
+            self.assertTrue(lines[-1].startswith('Processed: {} rows;'.format(num_rows)))
+
+        self.prepare()
+
+        debug('Running stress')
+        self.node1.stress(['write', 'n={}'.format(num_rows), '-rate', 'threads=50'])
+
+        debug('Exporting to csv file: {}'.format(self.tempfile.name))
+        self.node1.run_cqlsh(cmds="COPY {} TO '{}' WITH RATEFILE='{}' AND REPORTFREQUENCY='{}'"
+                             .format(stress_table, self.tempfile.name, ratefile.name, report_frequency))
+
+        # check all records were exported
+        self.assertEqual(num_rows, len(open(self.tempfile.name).readlines()))
+
+        check_rate_file()
+
+        # clean-up
+        os.unlink(ratefile.name)
+        self.session.execute("TRUNCATE {}".format(stress_table))
+
+        debug('Importing from csv file: {}'.format(self.tempfile.name))
+        self.node1.run_cqlsh(cmds="COPY {} FROM '{}' WITH RATEFILE='{}' AND REPORTFREQUENCY='{}'"
+                             .format(stress_table, self.tempfile.name, ratefile.name, report_frequency))
+
+        # check all records were imported
+        self.assertEqual([[num_rows]], rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}"
+                                                                         .format(stress_table))))
+
+        check_rate_file()
+
+    def test_copy_options_from_config_file(self):
+        """
+        Test that we can specify configuration options in a config file, optionally using multiple sections,
+        and that we can still overwrite options from the command line.
+        We must pass the debug flag --debug to cqlsh so that we can retrieve options from stdout in order to check,
+        see maybe_read_config_file() in copy.py.
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self.tempfile = NamedTemporaryFile(delete=False)
+        self.prepare(nodes=1)
+
+        debug('Running stress')
+        stress_table = 'keyspace1.standard1'
+        self.node1.stress(['write', 'n=1K', '-rate', 'threads=50'])
+
+        def create_config_file(config_lines):
+            config_file = NamedTemporaryFile(delete=False)
+            debug('Creating config file {}'.format(config_file.name))
+
+            with open(config_file.name, 'wb') as config:
+                for line in config_lines:
+                    config.write(line + os.linesep)
+                config.close()
+
+            return config_file.name
+
+        def extract_options(out):
+            prefix = 'Using options: '
+            for l in out.split(os.linesep):
+                if l.startswith(prefix):
+                    return l[len(prefix):].strip().strip("'").replace("'", "\"")
+            return ''
+
+        def check_options(out, expected_options):
+            opts = extract_options(out)
+            debug('Options: {}'.format(opts))
+            d = json.loads(opts)
+            for k, v in expected_options:
+                self.assertEqual(v, d[k])
+
+        def do_test(config_lines, expected_options):
+            config_file = create_config_file(config_lines)
+
+            cmd = "COPY {} {} '{}'".format(stress_table, direction, self.tempfile.name)
+            if not use_default:
+                cmd += " WITH CONFIGFILE = '{}'".format(config_file)
+
+            cqlsh_options = ['--debug']
+            if use_default:
+                cqlsh_options.append('--cqlshrc={}'.format(config_file))
+
+            debug('{} with options {}'.format(cmd, cqlsh_options))
+            out, _ = self.node1.run_cqlsh(cmds=cmd, return_output=True, cqlsh_options=cqlsh_options)
+            debug(out)
+            check_options(out, expected_options)
+
+        for use_default in [True, False]:
+            for direction in ['TO', 'FROM']:
+                do_test(['[copy]', 'header = True', 'maxattempts = 10'],
+                        [('header', 'True'), ('maxattempts', '10')])
+
+                do_test(['[copy]', 'header = True', 'maxattempts = 10',
+                         '[copy:{}]'.format(stress_table), 'maxattempts = 9'],
+                        [('header', 'True'), ('maxattempts', '9')])
+
+                do_test(['[copy]', 'header = True', 'maxattempts = 10',
+                         '[copy-from]', 'maxattempts = 9',
+                         '[copy-to]', 'maxattempts = 8'],
+                        [('header', 'True'), ('maxattempts', '8' if direction == 'TO' else '9')])
+
+                do_test(['[copy]', 'header = True', 'maxattempts = 10',
+                         '[copy-from]', 'maxattempts = 9',
+                         '[copy-to]', 'maxattempts = 8',
+                         '[copy:{}]'.format(stress_table), 'maxattempts = 7'],
+                        [('header', 'True'), ('maxattempts', '7')])
+
+                do_test(['[copy]', 'header = True', 'maxattempts = 10',
+                         '[copy-from]', 'maxattempts = 9',
+                         '[copy-to]', 'maxattempts = 8',
+                         '[copy:{}]'.format(stress_table), 'maxattempts = 7',
+                         '[copy-from:{}]'.format(stress_table), 'maxattempts = 6',
+                         '[copy-to:{}]'.format(stress_table), 'maxattempts = 5'],
+                        [('header', 'True'), ('maxattempts', '5' if direction == 'TO' else '6')])
 
     def test_wrong_number_of_columns(self):
         """
@@ -1122,10 +2025,17 @@ class CqlshCopyTest(Tester):
         os.unlink(commandfile.name)
 
     def _test_bulk_round_trip(self, nodes, partitioner,
-                              num_operations, profile=None, stress_table='keyspace1.standard1',
-                              page_size=1000, page_timeout=10, configuration_options=None):
+                              num_operations, profile=None,
+                              stress_table='keyspace1.standard1',
+                              configuration_options=None,
+                              skip_count_checks=False,
+                              copy_to_options={'PAGETIMEOUT': 10, 'PAGESIZE': 1000},
+                              copy_from_options=None):
         """
         Test exporting a large number of rows into a csv file.
+
+        If skip_count_checks is True then it means we cannot use "SELECT COUNT(*)" as it may time out but
+        it also means that we can be sure that one operation is one record and hence num_records=num_operations.
         """
         self.prepare(nodes=nodes, partitioner=partitioner, configuration_options=configuration_options)
 
@@ -1137,31 +2047,45 @@ class CqlshCopyTest(Tester):
             self.node1.stress(['user', 'profile={}'.format(profile), 'ops(insert=1)',
                                'n={}'.format(num_operations), '-rate', 'threads=50'])
 
-        num_records = rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}".format(stress_table)))[0][0]
-        debug('Generated {} records'.format(num_records))
-
-        self.assertTrue(num_records >= num_operations, 'cassandra-stress did not import enough records')
+        if skip_count_checks:
+            num_records = num_operations
+        else:
+            num_records = rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}".format(stress_table)))[0][0]
+            debug('Generated {} records'.format(num_records))
+            self.assertTrue(num_records >= num_operations, 'cassandra-stress did not import enough records')
 
         self.tempfile = NamedTemporaryFile(delete=False)
 
         debug('Exporting to csv file: {}'.format(self.tempfile.name))
         start = datetime.datetime.now()
-        self.node1.run_cqlsh(cmds="COPY {} TO '{}' WITH PAGETIMEOUT='{}' AND PAGESIZE='{}'"
-                             .format(stress_table, self.tempfile.name, page_timeout, page_size))
+        cmd = "COPY {} TO '{}'".format(stress_table, self.tempfile.name)
+        if copy_to_options:
+            cmd += ' WITH ' + ' AND '.join('{} = {}'.format(k, v) for k, v in copy_to_options.iteritems())
+        debug(cmd)
+        self.node1.run_cqlsh(cmds=cmd, show_output=True, cqlsh_options=['--debug'])
         debug("COPY TO took {} to export {} records".format(datetime.datetime.now() - start, num_records))
 
         # check all records were exported
-        self.assertEqual(num_records, sum(1 for line in open(self.tempfile.name)))
+        self.assertEqual(num_records, sum(1 for _ in open(self.tempfile.name)))
 
         self.session.execute("TRUNCATE {}".format(stress_table))
 
         debug('Importing from csv file: {}'.format(self.tempfile.name))
         start = datetime.datetime.now()
-        self.node1.run_cqlsh(cmds="COPY {} FROM '{}'".format(stress_table, self.tempfile.name))
+        cmd = "COPY {} FROM '{}'".format(stress_table, self.tempfile.name)
+        if copy_from_options:
+            cmd += ' WITH ' + ' AND '.join('{} = {}'.format(k, v) for k, v in copy_from_options.iteritems())
+        debug(cmd)
+        self.node1.run_cqlsh(cmds=cmd, show_output=True, cqlsh_options=['--debug'])
         debug("COPY FROM took {} to import {} records".format(datetime.datetime.now() - start, num_records))
 
-        self.assertEqual([[num_records]], rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}"
-                                                                            .format(stress_table))))
+        if not skip_count_checks:
+            self.assertEqual([[num_records]], rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}"
+                                                                                .format(stress_table))))
+        # else:
+        # we could export again and count the number of records exported but we just assume everything is fine
+        # if we get no errors when importing, this case is only for testing the back-off policy
+        # (test_bulk_round_trip_with_timeouts)
 
     @known_failure(failure_source='cassandra',
                    jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10938')
@@ -1185,19 +2109,34 @@ class CqlshCopyTest(Tester):
         """
         self._test_bulk_round_trip(nodes=3, partitioner="murmur3", num_operations=10000,
                                    profile=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'blogposts.yaml'),
-                                   stress_table='stresscql.blogposts', page_timeout=60)
+                                   stress_table='stresscql.blogposts',
+                                   copy_to_options={'PAGETIMEOUT': 60, 'PAGESIZE': 1000})
 
     @freshCluster()
     def test_bulk_round_trip_with_timeouts(self):
         """
         Test bulk import with very short read and write timeout values, this should exercise the
-        retry and back-off policies
+        retry and back-off policies. We cannot check the counts because "SELECT COUNT(*)" could timeout
+        on Jenkins making the test flacky.
 
         @jira_ticket CASSANDRA-9302
         """
         self._test_bulk_round_trip(nodes=1, partitioner="murmur3", num_operations=100000,
-                                   configuration_options={'range_request_timeout_in_ms': '300',
-                                                          'write_request_timeout_in_ms': '200'})
+                                   configuration_options={'range_request_timeout_in_ms': '200',
+                                                          'write_request_timeout_in_ms': '100'},
+                                   copy_to_options={'PAGETIMEOUT': 60, 'PAGESIZE': 1000},
+                                   skip_count_checks=True)
+
+    @freshCluster()
+    def test_bulk_round_trip_with_low_ingestrate(self):
+        """
+        Test bulk import with default stress import (one row per operation) and a low
+        ingestrate of only 1500 rows per second.
+
+        @jira_ticket CASSANDRA-9303
+        """
+        self._test_bulk_round_trip(nodes=3, partitioner="murmur3", num_operations=10000,
+                                   copy_from_options={'INGESTRATE': 1500})
 
     def prepare_copy_to_with_failures(self):
         """
@@ -1366,6 +2305,9 @@ class CqlshCopyTest(Tester):
         We set a batch id that will cause a batch to fail fewer times than the maximum number of attempts,
         therefore we expect this COPY TO job to succeed.
 
+        We also set a low ingest rate to ensure we exercise the code path that might split a retry if it
+        exceeds the intest rate.
+
         @jira_ticket CASSANDRA-9302
         """
         num_records = 1000
@@ -1381,10 +2323,10 @@ class CqlshCopyTest(Tester):
 
         self.session.execute("TRUNCATE {}".format(stress_table))
 
-        failures = {'failing_batch': {'id': 30, 'failures': 3}}
+        failures = {'failing_batch': {'id': 3, 'failures': 3}}
         os.environ['CQLSH_COPY_TEST_FAILURES'] = json.dumps(failures)
         debug('Importing from csv file {} with {}'.format(self.tempfile.name, os.environ['CQLSH_COPY_TEST_FAILURES']))
-        out, err = self.node1.run_cqlsh(cmds="COPY {} FROM '{}' WITH CHUNKSIZE='1' AND MAXATTEMPTS='5'"
+        out, err = self.node1.run_cqlsh(cmds="COPY {} FROM '{}' WITH CHUNKSIZE=100 AND MAXATTEMPTS=5 AND INGESTRATE=101"
                                         .format(stress_table, self.tempfile.name), return_output=True)
         debug(out)
         debug(err)
@@ -1425,6 +2367,6 @@ class CqlshCopyTest(Tester):
         debug(out)
         debug(err)
 
-        self.assertIn('Failed to process', err)
+        self.assertIn('1 child process(es) died unexpectedly, aborting', err)
         num_records_imported = rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}".format(stress_table)))[0][0]
         self.assertTrue(num_records_imported < num_records)

--- a/dtest.py
+++ b/dtest.py
@@ -669,7 +669,7 @@ class Tester(TestCase):
 
     def get_jfr_jvm_args(self):
         """
-        :return: The JVM arguments required for attaching flight recorder to a Java process.
+        @return The JVM arguments required for attaching flight recorder to a Java process.
         """
         return ["-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder"]
 

--- a/dtest.py
+++ b/dtest.py
@@ -667,6 +667,37 @@ class Tester(TestCase):
         raise TimeoutError(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()) +
                            " Unable to find :" + pattern + " in any node log within " + str(timeout) + "s")
 
+    def get_jfr_jvm_args(self):
+        """
+        :return: The JVM arguments required for attaching flight recorder to a Java process.
+        """
+        return ["-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder"]
+
+    def start_jfr_recording(self, nodes):
+        """
+        Start Java flight recorder provided the cluster was started with the correct jvm arguments.
+        """
+        for node in nodes:
+            p = subprocess.Popen(['jcmd', str(node.pid), 'JFR.start'],
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            debug(stdout)
+            debug(stderr)
+
+    def dump_jfr_recording(self, nodes):
+        """
+        Save Java flight recorder results to file for analyzing with mission control.
+        """
+        for node in nodes:
+            p = subprocess.Popen(['jcmd', str(node.pid), 'JFR.dump',
+                                  'recording=1', 'filename=recording_{}.jfr'.format(node.address())],
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            debug(stdout)
+            debug(stderr)
+
 
 def canReuseCluster(Tester):
     orig_init = Tester.__init__


### PR DESCRIPTION
These are the tests for the new COPY options introduced by CASSANDRA-9303. Because of the new parameters of `format_value()` in pylib `formatting.py`, once CASSANDRA-9303 is committed the existing tests will break. For the same reason we should not merge until 9303 is committed, I also omitted `@require`.

There is a bit of code to review so take your time, we can hold the commit of 9303 until this review is completed.