### PR TITLE
Remove known_failure decorator on failed_bootstrap_wiped_node_can_join_test

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -351,8 +351,6 @@ class TestBootstrap(Tester):
         node2.start(wait_other_notice=True)
         node2.watch_log_for("JOINING:", from_mark=mark)
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10844')
     def failed_bootstrap_wiped_node_can_join_test(self):
         """
         @jira_ticket CASSANDRA-9765


### PR DESCRIPTION
This failure has been resolved in [CASSANDRA-10844](https://issues.apache.org/jira/browse/CASSANDRA-10844).

A clean run without this test failing can be seen on [CassCI](http://cassci.datastax.com/job/cassandra-2.1_dtest/391/testReport/bootstrap_test/TestBootstrap/failed_bootstrap_wiped_node_can_join_test/history/).