### PR TITLE
Wait on nodes detecting one another on upgrade (CASSANDRA-11016)

### DIFF
--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -207,7 +207,7 @@ class UpgradeTester(Tester):
                           'with Cassandra version {}'.format(self.protocol_version, new_version_from_build))
             node1.set_log_level("DEBUG" if DEBUG else "INFO")
             node1.set_configuration_options(values={'internode_compression': 'none'})
-            node1.start(wait_for_binary_proto=True)
+            node1.start(wait_for_binary_proto=True, wait_other_notice=True)
 
         if UPGRADE_MODE == "all":
             node2.set_install_dir(**install_kwargs)
@@ -218,7 +218,7 @@ class UpgradeTester(Tester):
                           'with Cassandra version {}'.format(self.protocol_version, new_version_from_build))
             node2.set_log_level("DEBUG" if DEBUG else "INFO")
             node2.set_configuration_options(values={'internode_compression': 'none'})
-            node2.start(wait_for_binary_proto=True)
+            node2.start(wait_for_binary_proto=True, wait_other_notice=True)
 
         sessions = []
         if QUERY_UPGRADED:


### PR DESCRIPTION
Some of the tests do a truncate just after a do_upgrade(). As do_upgrade() restart a node but doesn't wait for the other(s) to have detected the restart of that new node, the truncate might actually fail saying some node are down as pointed in CASSANDRA-11016. The fix is trivial, we just wait for other nodes to notice the restart.