### PR TITLE
clean up the way we iterate over data directories

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -392,7 +392,7 @@ class TestBootstrap(Tester):
         node2.stop(wait_other_notice=False)
 
         # Wipe its data
-        for data_dir in [os.path.join(node2.get_path(), "data{0}".format(x)) for x in xrange(0, self.cluster.data_dir_count)]:
+        for data_dir in node2.data_directories():
             debug("Deleting {}".format(data_dir))
             shutil.rmtree(data_dir)
 
@@ -492,9 +492,8 @@ class TestBootstrap(Tester):
             assert_one(session, "SELECT count(*) from keyspace1.standard1", [500000], cl=ConsistencyLevel.ONE)
 
     def _cleanup(self, node):
-        data_dirs = [os.path.join(node.get_path(), 'data{0}'.format(x)) for x in xrange(0, self.cluster.data_dir_count)]
         commitlog_dir = os.path.join(node.get_path(), 'commitlogs')
-        for data_dir in data_dirs:
+        for data_dir in node.data_directories():
             debug("Deleting {}".format(data_dir))
             shutil.rmtree(data_dir)
         shutil.rmtree(commitlog_dir)

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -180,8 +180,7 @@ class TestCommitLog(Tester):
         self.assertTrue(len(commitlog_files) > 0)
 
         debug("Verify no SSTables were flushed before abrupt stop")
-        for x in xrange(0, self.cluster.data_dir_count):
-            data_dir = os.path.join(node1.get_path(), 'data{0}'.format(x))
+        for data_dir in node1.data_directories():
             cf_id = [s for s in os.listdir(os.path.join(data_dir, "test")) if s.startswith("users")][0]
             cf_data_dir = glob.glob("{data_dir}/test/{cf_id}".format(**locals()))[0]
             cf_data_dir_files = os.listdir(cf_data_dir)
@@ -369,9 +368,8 @@ class TestCommitLog(Tester):
         node.stop(gently=False)
 
         # check that ks.tbl hasn't been flushed
-        path = node.get_path()
-        for x in xrange(0, self.cluster.data_dir_count):
-            ks_dir = os.path.join(path, 'data{0}'.format(x), 'ks')
+        for data_dir in node.data_directories():
+            ks_dir = os.path.join(data_dir, 'ks')
             db_dir = os.listdir(ks_dir)[0]
             sstables = len([f for f in os.listdir(os.path.join(ks_dir, db_dir)) if f.endswith('.db')])
             self.assertEqual(sstables, 0)
@@ -444,10 +442,9 @@ class TestCommitLog(Tester):
         node.stop(gently=False)
 
         # check that ks1.tbl hasn't been flushed
-        path = node.get_path()
         sstables = 0
-        for x in xrange(0, self.cluster.data_dir_count):
-            ks_dir = os.path.join(path, 'data{0}'.format(x), 'ks1')
+        for data_dir in node.data_directories():
+            ks_dir = os.path.join(data_dir, 'ks1')
             db_dir = os.listdir(ks_dir)[0]
             sstables = sstables + len([f for f in os.listdir(os.path.join(ks_dir, db_dir)) if f.endswith('.db')])
         self.assertEqual(sstables, 0)

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -123,9 +123,9 @@ class TestCompaction(Tester):
         block_on_compaction_log(node1, ks='ks', table='cf')
         time.sleep(1)
         try:
-            for x in xrange(0, cluster.data_dir_count):
-                cfs = os.listdir(node1.get_path() + "/data{0}/ks".format(x))
-                ssdir = os.listdir(node1.get_path() + "/data{0}/ks/{1}".format(x, cfs[0]))
+            for data_dir in node1.data_directories():
+                cfs = os.listdir(os.path.join(data_dir, "ks"))
+                ssdir = os.listdir(os.path.join(data_dir, "ks", cfs[0]))
                 for afile in ssdir:
                     self.assertFalse("Data" in afile, afile)
 

--- a/scrub_test.py
+++ b/scrub_test.py
@@ -19,8 +19,8 @@ class TestHelper(Tester):
         """
         node1 = self.cluster.nodelist()[0]
         paths = []
-        for x in xrange(0, self.cluster.data_dir_count):
-            basepath = os.path.join(node1.get_path(), "data{0}".format(x), KEYSPACE)
+        for data_dir in node1.data_directories():
+            basepath = os.path.join(data_dir, KEYSPACE)
             for x in os.listdir(basepath):
                 if x.startswith(table):
                     paths.append(os.path.join(basepath, x))

--- a/secondary_indexes_test.py
+++ b/secondary_indexes_test.py
@@ -290,8 +290,8 @@ class TestSecondaryIndexes(Tester):
         self.assertEqual(1, len(list(session.execute(stmt, [lookup_value]))))
         before_files = []
         index_sstables_dirs = []
-        for x in xrange(0, cluster.data_dir_count):
-            data_dir = os.path.join(node1.get_path(), 'data{0}/keyspace1'.format(x))
+        for data_dir in node1.data_directories():
+            data_dir = os.path.join(data_dir, 'keyspace1')
             base_tbl_dir = os.path.join(data_dir, [s for s in os.listdir(data_dir) if s.startswith("standard1")][0])
             index_sstables_dir = os.path.join(base_tbl_dir, '.ix_c0')
             before_files.extend(os.listdir(index_sstables_dir))

--- a/snapshot_test.py
+++ b/snapshot_test.py
@@ -30,13 +30,11 @@ class SnapshotTester(Tester):
         tmpdir = safe_mkdtemp()
         os.mkdir(os.path.join(tmpdir, ks))
         os.mkdir(os.path.join(tmpdir, ks, cf))
-        node_dir = node.get_path()
-
         # Find the snapshot dir, it's different in various C*
-        for x in xrange(0, self.cluster.data_dir_count):
-            snapshot_dir = "{node_dir}/data{x}/{ks}/{cf}/snapshots/{name}".format(**locals())
+        for data_dir in node.data_directories():
+            snapshot_dir = "{data_dir}/{ks}/{cf}/snapshots/{name}".format(**locals())
             if not os.path.isdir(snapshot_dir):
-                snapshot_dirs = glob.glob("{node_dir}/data{x}/{ks}/{cf}-*/snapshots/{name}".format(**locals()))
+                snapshot_dirs = glob.glob("{data_dir}/{ks}/{cf}-*/snapshots/{name}".format(**locals()))
                 if len(snapshot_dirs) > 0:
                     snapshot_dir = snapshot_dirs[0]
                 else:

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -67,8 +67,8 @@ class TestSSTableGenerationAndLoading(Tester):
         node1.stop()
         time.sleep(1)
         paths = []
-        for x in xrange(0, cluster.data_dir_count):
-            basepath = os.path.join(node1.get_path(), 'data{0}'.format(x), 'keyspace1')
+        for data_dir in node1.data_directories():
+            basepath = os.path.join(data_dir, 'keyspace1')
             for x in os.listdir(basepath):
                 if x.startswith("standard1"):
                     path = os.path.join(basepath, x)

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -178,8 +178,8 @@ class SSTableUtilTest(Tester):
         Read sstable files directly from disk
         """
         ret = []
-        for x in xrange(0, self.cluster.data_dir_count):
-            keyspace_dir = os.path.join(node.get_path(), 'data{0}'.format(x), ks)
+        for data_dir in node.data_directories():
+            keyspace_dir = os.path.join(data_dir, ks)
             for ext in ('*.db', '*.txt', '*.adler32', '*.crc32'):
                 ret.extend(glob.glob(os.path.join(keyspace_dir, table + '-*', ext)))
 
@@ -187,8 +187,8 @@ class SSTableUtilTest(Tester):
 
     def _get_sstable_transaction_logs(self, node, ks, table):
         ret = []
-        for x in xrange(0, self.cluster.data_dir_count):
-            keyspace_dir = os.path.join(node.get_path(), 'data{0}'.format(x), ks)
+        for data_dir in node.data_directories():
+            keyspace_dir = os.path.join(data_dir, ks)
             ret.extend(glob.glob(os.path.join(keyspace_dir, table + '-*', "*.log")))
 
         return sorted(ret)


### PR DESCRIPTION
Quite ugly to do the 'for x in xrange(0, self.cluster.data_dir_count)' everywhere, this uses https://github.com/pcmanus/ccm/pull/441 to get the actual data directories instead (note that the ccm-PR needs to be merged first)