### PR TITLE
Don't wait other notice after decommission

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -364,7 +364,7 @@ class TestBootstrap(Tester):
 
         # Decommission the new node and wipe its data
         node4.decommission()
-        node4.stop(wait_other_notice=True)
+        node4.stop()
         self._cleanup(node4)
         # Now start it, it should be allowed to join
         mark = node4.mark_log()


### PR DESCRIPTION
The decommission will have already caused the node DOWN
notifications to come up. So we won't see more on stop, so waiting
will cause us to timeout

@mambocab to review. Please make your preferred fixes and merge yourself, as I'll be on vacation, and don't want to let this set until I return.