### PR TITLE
Unskip required

### DIFF
--- a/batch_test.py
+++ b/batch_test.py
@@ -7,12 +7,11 @@ import sys
 from assertions import assert_invalid, assert_unavailable, assert_one
 from unittest import skipIf
 from dtest import CASSANDRA_DIR, Tester, debug
-from tools import debug, since, require
+from tools import debug, since
 
 
 class TestBatch(Tester):
 
-    @require(10711)
     def empty_batch_throws_no_error_test(self):
         """
         @jira_ticket CASSANDRA-10711

--- a/batch_test.py
+++ b/batch_test.py
@@ -7,7 +7,7 @@ import sys
 from assertions import assert_invalid, assert_unavailable, assert_one
 from unittest import skipIf
 from dtest import CASSANDRA_DIR, Tester, debug
-from tools import debug, since
+from tools import since
 
 
 class TestBatch(Tester):

--- a/metadata_tests.py
+++ b/metadata_tests.py
@@ -2,7 +2,6 @@ import time
 import threading
 
 from dtest import Tester
-from tools import require
 
 
 class TestMetadata(Tester):
@@ -28,7 +27,6 @@ class TestMetadata(Tester):
         node1.stress(['read', 'no-warmup', 'n=30000', '-schema', 'replication(factor=2)', 'compression=LZ4Compressor',
                       '-rate', 'threads=1'])
 
-    @require(9831, broken_in='2.0')
     def metadata_reset_while_compact_test(self):
         """
         Resets the schema while a compact, read and repair happens.


### PR DESCRIPTION
@knifewine can you review? These are passing now in the skipped-with-require CassCI job, and the relevant JIRAs were closed.

I also removed the re-import of `debug` in `batch_test.py`. The `debug` defined in `tools.py` is the one that's imported from `dtest`, so they actually point to the same function. Thus, this change won't change the behavior of `debug` in the module.