### PR TITLE
Support microseconds in the default timestamp format, CASSANDRA-10428

### DIFF
--- a/cqlsh_tests/cqlsh_tools.py
+++ b/cqlsh_tests/cqlsh_tools.py
@@ -1,7 +1,5 @@
 import csv
-import datetime
 import random
-import time
 
 import cassandra
 from nose.tools import assert_items_equal
@@ -23,16 +21,6 @@ def csv_rows(filename, delimiter=None):
     with open(filename, 'rb') as csvfile:
         for row in csv.reader(csvfile, **reader_opts):
             yield row
-
-
-def strip_timezone_if_time_string(s):
-    try:
-        time_string_no_tz = s[:19]
-        time_struct = time.strptime(time_string_no_tz, '%Y-%m-%d %H:%M:%S')
-        dt_no_timezone = datetime.datetime(*time_struct[:6])
-        return dt_no_timezone.strftime('%Y-%m-%d %H:%M:%S')
-    except (TypeError, ValueError):
-        return s
 
 
 def assert_csvs_items_equal(filename1, filename2):

--- a/json_test.py
+++ b/json_test.py
@@ -62,6 +62,12 @@ def build_doc_context(tester, test_name, prepare=True, connection=None, nodes=No
         cli = os.path.join(cdir, 'bin', common.platform_binary('cqlsh'))
         env = common.make_cassandra_env(cdir, nodes[0].get_path())
         env['LANG'] = 'en_US.UTF-8'
+
+        # CASSANDRA-10428 changes the default time format to include microseconds (%f) but only
+        # for version 3.2 onwards, so we fix the default timestamp for the time-being, to
+        # avoid having multiple versions of these tests since it would be a bit messy to change the docstrings
+        env['CQLSH_DEFAULT_TIMESTAMP_FORMAT'] = '%Y-%m-%d %H:%M:%S%z'
+
         if LooseVersion(tester.cluster.version()) >= LooseVersion('2.1'):
             host = nodes[0].network_interfaces['binary'][0]
             port = nodes[0].network_interfaces['binary'][1]


### PR DESCRIPTION
Some fixes to support microseconds in the timestamp and a new test for it (3.2+ only). Please wait for CASSANDRA-10428 to be committed before merging.