### PR TITLE
Adds a @no_offheap skip test decorator and applies it to index_summary_upgrade

### DIFF
--- a/index_summary_upgrade_test.py
+++ b/index_summary_upgrade_test.py
@@ -1,11 +1,13 @@
 from cassandra.concurrent import execute_concurrent_with_args
 
 from dtest import Tester, debug
+from tools import no_offheap
 from jmxutils import JolokiaAgent, make_mbean, remove_perf_disable_shared_mem
 
 
 class TestUpgradeIndexSummary(Tester):
 
+    @no_offheap()
     def test_upgrade_index_summary(self):
         cluster = self.cluster
         cluster.populate(1)

--- a/tools.py
+++ b/tools.py
@@ -16,7 +16,7 @@ from cassandra.query import SimpleStatement
 from nose.plugins.attrib import attr
 
 from ccmlib.node import Node
-from dtest import CASSANDRA_DIR, DISABLE_VNODES, IGNORE_REQUIRE, debug
+from dtest import CASSANDRA_DIR, DISABLE_VNODES, IGNORE_REQUIRE, OFFHEAP_MEMTABLES, debug
 
 
 def rows_to_list(rows):
@@ -263,6 +263,9 @@ def no_vnodes():
     """Skips the decorated test or test class if using vnodes."""
     return unittest.skipIf(not DISABLE_VNODES, 'Test disabled for vnodes')
 
+def no_offheap():
+    """Skips the decorated test or test class if using offheap memtables."""
+    return unittest.skipIf(OFFHEAP_MEMTABLES, 'Test disabled for offheap memtables')
 
 def require(require_pattern, broken_in=None):
     """Skips the decorated class or method, unless the argument

--- a/tools.py
+++ b/tools.py
@@ -263,9 +263,11 @@ def no_vnodes():
     """Skips the decorated test or test class if using vnodes."""
     return unittest.skipIf(not DISABLE_VNODES, 'Test disabled for vnodes')
 
+
 def no_offheap():
     """Skips the decorated test or test class if using offheap memtables."""
     return unittest.skipIf(OFFHEAP_MEMTABLES, 'Test disabled for offheap memtables')
+
 
 def require(require_pattern, broken_in=None):
     """Skips the decorated class or method, unless the argument


### PR DESCRIPTION
@mambocab mentioned it is probably a good candidate for porting this test over to the new upgrade framework, but for now I just disabled this test for offheap runs as I don't see any offheap considerations here, and the upgrade mechanics here are already pretty manual.