### PR TITLE
version name simple sanitize

### DIFF
--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -501,8 +501,13 @@ class UpgradeTester(Tester):
             "Current upgrade path: {}".format(
                 vers[:curr_index] + ['***' + current_tag + '***'] + vers[curr_index + 1:]))
 
+    def _safe_name(self, tag):
+        # add prefix letter so we don't break C* naming rules in the case of bare versions
+        # and make sure no ccm ':' delimiters sneak in
+        return "t{tag}".format(tag).replace(":", "_")
+
     def _create_metadata_schemas(self, tag):
-        safe_name = "t" + tag  # add a letter so we don't break C* naming rules in the case of bare versions
+        safe_name = self._safe_name(tag)
 
         self.created_metadata_versions.append((self.cluster.version(), tag))
         session = self.patient_cql_connection(self.node2)
@@ -514,7 +519,7 @@ class UpgradeTester(Tester):
             getattr(schema_metadata_test, m)(self.cluster.version(), session, safe_name)
 
     def _check_metadata_schemas(self, version, tag):
-        safe_name = "t" + tag  # mirrors the name safety convention in _create_metadata_schemas
+        safe_name = self._safe_name(tag)
 
         session = self.patient_cql_connection(self.node2)
         session.execute('use upgrade')


### PR DESCRIPTION
fix for dynamic cql object names not working due to ':' that snuck in from ccm ver specifier.

this is cherry picked from my 21_22_tentatives branch because that branch isn't intented to every get merged. code is running on that other branch here http://cassci.datastax.com/view/Upgrades/job/upgrade_through_versions_all/30/