### PR TITLE
Fix version for CASSANDRA-10428

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -318,7 +318,7 @@ class CqlshCopyTest(Tester):
                             val,
                             encoding=encoding_name,
                             date_time_format=date_time_format,
-                            time_format=self.default_time_format,
+                            time_format=time_format,
                             float_precision=float_precision,
                             colormap=DummyColorMap(),
                             nullval=None,
@@ -1744,7 +1744,7 @@ class CqlshCopyTest(Tester):
         do_test(expected_vals_usual, ',', '.')
         do_test(expected_vals_inverted, '.', ',')
 
-    @since('3.2')
+    @since('3.4')
     def test_round_trip_with_sub_second_precision(self):
         """
         Test that we can import and export timestamp values with millisecond precision:

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -143,14 +143,14 @@ class TestCqlsh(Tester):
 
         output, err = self.run_cqlsh(node1, 'use simple; SELECT * FROM simpledate')
 
-        if self.cluster.version() >= '3.2':
+        if self.cluster.version() >= '3.4':
             self.assertIn("2143-04-19 11:21:01.000000+0000", output)
             self.assertIn("1943-04-19 11:21:01.000000+0000", output)
         else:
             self.assertIn("2143-04-19 11:21:01+0000", output)
             self.assertIn("1943-04-19 11:21:01+0000", output)
 
-    @since('3.2')
+    @since('3.4')
     def test_sub_second_precision(self):
         """
         Test that we can query at millisecond precision.


### PR DESCRIPTION
When tests for CASSANDRA-10428 were written, trunk was still at 3.2 but now it is at 3.4 and therefore the version tags need updating. At the moment 3 cqlsh tests are failing on 3.3.