### PR TITLE
Bump materialized view migration timeout up (again) to 5s

### DIFF
--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -23,7 +23,7 @@ from assertions import assert_all, assert_one, assert_invalid, assert_unavailabl
 # pathological case of flushing schema keyspace for multiple data directories. See CASSANDRA-6696
 # for multiple data directory changes and CASSANDRA-10421 for compaction logging that must be
 # written.
-MIGRATION_WAIT = 2
+MIGRATION_WAIT = 5
 
 
 @since('3.0')


### PR DESCRIPTION
We have seen flapping on this test in a couple places. Most recently here:

http://cassci.datastax.com/job/cassandra-3.3_dtest/70/testReport/materialized_views_test/TestMaterializedViews/add_write_survey_node_after_mv_test/

Bumping up the migration time a few more seconds will hopefully fix this flapping