### PR TITLE
Unrequire metadata test

### DIFF
--- a/metadata_tests.py
+++ b/metadata_tests.py
@@ -3,7 +3,7 @@ import threading
 from unittest import skip
 
 from dtest import Tester
-from tools import require
+from tools import known_failure
 
 
 class TestMetadata(Tester):
@@ -30,7 +30,10 @@ class TestMetadata(Tester):
                       '-rate', 'threads=1'])
 
     @skip('hangs CI')
-    @require(11095, broken_in='2.0')
+    @known_failure(failure_source='test',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11095',
+                   flaky=True,
+                   notes='hangs CI on 2.0+')
     def metadata_reset_while_compact_test(self):
         """
         Resets the schema while a compact, read and repair happens.

--- a/tools.py
+++ b/tools.py
@@ -107,7 +107,6 @@ def putget(cluster, session, cl=ConsistencyLevel.QUORUM):
     _put_with_overwrite(cluster, session, 1, cl)
 
     # reads by name
-    ks = ["\'c%02d\'" % i for i in xrange(0, 100)]
     # We do not support proper IN queries yet
     # if cluster.version() >= "1.2":
     #    session.execute('SELECT * FROM cf USING CONSISTENCY %s WHERE key=\'k0\' AND c IN (%s)' % (cl, ','.join(ks)))

--- a/tools.py
+++ b/tools.py
@@ -169,7 +169,8 @@ def range_putget(cluster, session, cl=ConsistencyLevel.QUORUM):
 
 
 def replace_in_file(filepath, search_replacements):
-    """In-place file search and replace.
+    """
+    In-place file search and replace.
 
     filepath - The path of the file to edit
     search_replacements - a list of tuples (regex, replacement) that
@@ -259,12 +260,15 @@ class since(object):
 
 
 def no_vnodes():
-    """Skips the decorated test or test class if using vnodes."""
+    """
+    Skips the decorated test or test class if using vnodes.
+    """
     return unittest.skipIf(not DISABLE_VNODES, 'Test disabled for vnodes')
 
 
 def require(require_pattern, broken_in=None):
-    """Skips the decorated class or method, unless the argument
+    """
+    Skips the decorated class or method, unless the argument
     'require_pattern' is a case-insensitive regex match for the name of the git
     branch in the directory from which Cassandra is running. For example, the
     method defined here:


### PR DESCRIPTION
As discussed privately: `@require`ing this test is incorrect -- we want to skip it everywhere, all the time. Its hanging is hanging our `@require`d-test-auditing job, which we don't want.

Also a couple cleanup commits in there to deal with stuff that `flake8` found.