### PR TITLE
Start cluster in replication test one node at a time

### DIFF
--- a/replication_test.py
+++ b/replication_test.py
@@ -528,7 +528,8 @@ class SnitchConfigurationUpdateTest(Tester):
                 for line in snitch_lines_before(i, node):
                     topo_file.write(line + os.linesep)
 
-        cluster.start(wait_for_binary_proto=True)
+        for node in cluster.nodelist():
+            node.start(wait_for_binary_proto=True)
 
         session = self.patient_cql_connection(cluster.nodelist()[0])
 


### PR DESCRIPTION
Seeing an issue on cassci where with jdk7, nodes all started
at once could have the same vnodes set. Starting the cluster
in serial should prevent this.

@mambocab or @jkni to review