### PR TITLE
New upgrade classes

### DIFF
--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -20,15 +20,23 @@ from cassandra.query import SimpleStatement
 from dtest import Tester, debug
 from tools import generate_ssl_stores, known_failure, new_node
 
-trunk_version = '3.4'
+# these should be latest tentative tags, falling back to the most recent release if no pending tentative
 latest_2dot0 = '2.0.17'
 latest_2dot1 = '2.1.12'
 latest_2dot2 = '2.2.4'
-latest_3dot0 = '3.0.2'
+latest_3dot0 = 'git:tentative-3.0.3'
 latest_3dot1 = '3.1.1'
 latest_3dot2 = '3.2.1'
-latest_3dot3 = '3.3'
-trunk_ccm_string = 'git:trunk'
+latest_3dot3 = 'git:tentative-3.3'
+
+head_2dot0 = 'git:cassandra-2.0'
+head_2dot1 = 'git:cassandra-2.1'
+head_2dot2 = 'git:cassandra-2.2'
+head_3dot0 = 'git:cassandra-3.0'
+head_3dot1 = 'git:cassandra-3.1'
+head_3dot2 = 'git:cassandra-3.2'
+head_3dot3 = 'git:cassandra-3.3'
+head_trunk = 'git:trunk'
 
 
 def sanitize_version(version, allow_ambiguous=True):
@@ -39,7 +47,7 @@ def sanitize_version(version, allow_ambiguous=True):
     If allow_ambiguous is False, will raise RuntimeError if no version is found.
     """
     if (version == 'git:trunk') or (version == 'trunk'):
-        return LooseVersion(trunk_ccm_string)
+        return LooseVersion(head_trunk)
 
     match = re.match('^.*(\d+\.+\d+\.*\d*).*$', unicode(version))
     if match:
@@ -856,24 +864,24 @@ def create_upgrade_class(clsname, version_list, protocol_version,
 # Proto v1 upgrade classes (v1 supported on 2.0, 2.1, 2.2)
 create_upgrade_class(
     'ProtoV1Upgrade_2_0_UpTo_2_1',
-    [latest_2dot0, 'git:cassandra-2.1'],
+    [latest_2dot0, head_2dot1],
     bootstrap_test=True,
     protocol_version=1
 )
 create_upgrade_class(
     'ProtoV1Upgrade_2_1_UpTo_2_2',
-    [latest_2dot1, 'git:cassandra-2.2'],
+    [latest_2dot1, head_2dot2],
     bootstrap_test=True,
     protocol_version=1
 )
 create_upgrade_class(
     'ProtoV1Upgrade_AllVersions',
-    [latest_2dot0, latest_2dot1, 'git:cassandra-2.2'],
+    [latest_2dot0, latest_2dot1, head_2dot2],
     protocol_version=1
 )
 create_upgrade_class(
     'ProtoV1Upgrade_AllVersions_RandomPartitioner',
-    [latest_2dot0, latest_2dot1, 'git:cassandra-2.2'],
+    [latest_2dot0, latest_2dot1, head_2dot2],
     protocol_version=1,
     extra_config=(
         ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
@@ -883,24 +891,24 @@ create_upgrade_class(
 # Proto v2 upgrade classes (v2 is supported on 2.0, 2.1, 2.2)
 create_upgrade_class(
     'ProtoV2Upgrade_2_0_UpTo_2_1',
-    [latest_2dot0, 'git:cassandra-2.1'],
+    [latest_2dot0, head_2dot1],
     bootstrap_test=True,
     protocol_version=2
 )
 create_upgrade_class(
     'ProtoV2Upgrade_2_1_UpTo_2_2',
-    [latest_2dot1, 'git:cassandra-2.2'],
+    [latest_2dot1, head_2dot2],
     bootstrap_test=True,
     protocol_version=2
 )
 create_upgrade_class(
     'ProtoV2Upgrade_AllVersions',
-    [latest_2dot0, latest_2dot1, 'git:cassandra-2.2'],
+    [latest_2dot0, latest_2dot1, head_2dot2],
     protocol_version=2
 )
 create_upgrade_class(
     'ProtoV2Upgrade_AllVersions_RandomPartitioner',
-    [latest_2dot0, latest_2dot1, 'git:cassandra-2.2'],
+    [latest_2dot0, latest_2dot1, head_2dot2],
     protocol_version=2,
     extra_config=(
         ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
@@ -911,53 +919,53 @@ create_upgrade_class(
 # Proto v3 upgrade classes (v3 is supported on 2.1, 2.2, 3.0, 3.1, trunk)
 create_upgrade_class(
     'ProtoV3Upgrade_2_1_UpTo_2_2',
-    [latest_2dot1, 'git:cassandra-2.2'],
+    [latest_2dot1, head_2dot2],
     bootstrap_test=True,
     protocol_version=3
 )
 create_upgrade_class(  # special case upgrade skipping 2.2
     'ProtoV3Upgrade_2_1_UpTo_3_0',
-    [latest_2dot1, 'git:cassandra-3.0'],
+    [latest_2dot1, head_3dot0],
     bootstrap_test=True,
     protocol_version=3
 )
 create_upgrade_class(
     'ProtoV3Upgrade_2_2_UpTo_3_0',
-    [latest_2dot2, 'git:cassandra-3.0'],
+    [latest_2dot2, head_3dot0],
     bootstrap_test=True,
     protocol_version=3
 )
 create_upgrade_class(
     'ProtoV3Upgrade_3_0_UpTo_3_1',
-    [latest_3dot0, 'git:cassandra-3.1'],
+    [latest_3dot0, head_3dot1],
     bootstrap_test=True,
     protocol_version=3
 )
 create_upgrade_class(
     'ProtoV3Upgrade_3_1_UpTo_3_2',
-    [latest_3dot1, latest_3dot2],
+    [latest_3dot1, head_3dot2],
     bootstrap_test=True,
     protocol_version=3
 )
 create_upgrade_class(
     'ProtoV3Upgrade_3_2_UpTo_Trunk',
-    [latest_3dot2, trunk_ccm_string],
+    [latest_3dot2, head_trunk],
     bootstrap_test=True,
     protocol_version=3
 )
 create_upgrade_class(
     'ProtoV3Upgrade_AllVersions',
-    [latest_2dot1, latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, trunk_ccm_string],
+    [latest_2dot1, latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=3
 )
 create_upgrade_class(  # special case upgrade skipping 2.2
     'ProtoV3Upgrade_AllVersions_Skip_2_2',
-    [latest_2dot1, latest_3dot0, latest_3dot1, latest_3dot2, trunk_ccm_string],
+    [latest_2dot1, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=3
 )
 create_upgrade_class(
     'ProtoV3Upgrade_AllVersions_RandomPartitioner',
-    [latest_2dot1, latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, trunk_ccm_string],
+    [latest_2dot1, latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=3,
     extra_config=(
         ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
@@ -965,7 +973,7 @@ create_upgrade_class(
 )
 create_upgrade_class(
     'ProtoV3Upgrade_AllVersions_RandomPartitioner_Skip_2_2',
-    [latest_2dot1, latest_3dot0, latest_3dot1, latest_3dot2, trunk_ccm_string],
+    [latest_2dot1, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=3,
     extra_config=(
         ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
@@ -976,36 +984,36 @@ create_upgrade_class(
 # Proto v4 upgrade classes (v4 is supported on 2.2, 3.0, 3.1, trunk)
 create_upgrade_class(
     'ProtoV4Upgrade_2_2_UpTo_3_0',
-    [latest_2dot2, 'git:cassandra-3.0'],
+    [latest_2dot2, head_3dot0],
     bootstrap_test=True,
     protocol_version=4
 )
 create_upgrade_class(
     'ProtoV4Upgrade_3_0_UpTo_3_1',
-    [latest_3dot0, 'git:cassandra-3.1'],
+    [latest_3dot0, head_3dot1],
     bootstrap_test=True,
     protocol_version=4
 )
 create_upgrade_class(
     'ProtoV4Upgrade_3_1_UpTo_3_2',
-    [latest_3dot1, latest_3dot2],
+    [latest_3dot1, head_3dot2],
     bootstrap_test=True,
     protocol_version=4
 )
 create_upgrade_class(
     'ProtoV4Upgrade_3_2_UpTo_Trunk',
-    [latest_3dot2, trunk_ccm_string],
+    [latest_3dot2, head_trunk],
     bootstrap_test=True,
     protocol_version=4
 )
 create_upgrade_class(
     'ProtoV4Upgrade_AllVersions',
-    [latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, trunk_ccm_string],
+    [latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=4
 )
 create_upgrade_class(
     'ProtoV4Upgrade_AllVersions_RandomPartitioner',
-    [latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, trunk_ccm_string],
+    [latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=4,
     extra_config=(
         ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),

--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -861,110 +861,226 @@ def create_upgrade_class(clsname, version_list, protocol_version,
     return newcls
 
 
+def is_unreleased(version_or_tag):
+    """
+    For gating unnecessary testing of already released upgrade tests endpoints.
+    """
+    if 'tentative' in version_or_tag:
+        return True
+
+    return False
+
+
 # Proto v1 upgrade classes (v1 supported on 2.0, 2.1, 2.2)
 create_upgrade_class(
-    'ProtoV1Upgrade_2_0_UpTo_2_1',
+    'ProtoV1Upgrade_2_0_UpTo_2_1_HEAD',
     [latest_2dot0, head_2dot1],
     bootstrap_test=True,
     protocol_version=1
 )
+if is_unreleased(latest_2dot1):
+    create_upgrade_class(
+        'ProtoV1Upgrade_2_0_UpTo_2_1_Latest',
+        [latest_2dot0, latest_2dot1],
+        bootstrap_test=True,
+        protocol_version=1
+    )
 create_upgrade_class(
-    'ProtoV1Upgrade_2_1_UpTo_2_2',
+    'ProtoV1Upgrade_2_1_UpTo_2_2_HEAD',
     [latest_2dot1, head_2dot2],
     bootstrap_test=True,
     protocol_version=1
 )
+if is_unreleased(latest_2dot2):
+    create_upgrade_class(
+        'ProtoV1Upgrade_2_1_UpTo_2_2_Latest',
+        [latest_2dot1, latest_2dot2],
+        bootstrap_test=True,
+        protocol_version=1
+    )
 create_upgrade_class(
-    'ProtoV1Upgrade_AllVersions',
+    'ProtoV1Upgrade_AllVersions_EndsAt_2_2_HEAD',
     [latest_2dot0, latest_2dot1, head_2dot2],
     protocol_version=1
 )
+if is_unreleased(latest_2dot2):
+    create_upgrade_class(
+        'ProtoV1Upgrade_AllVersions_EndsAt_2_2_Latest',
+        [latest_2dot0, latest_2dot1, latest_2dot2],
+        protocol_version=1
+    )
 create_upgrade_class(
-    'ProtoV1Upgrade_AllVersions_RandomPartitioner',
+    'ProtoV1Upgrade_AllVersions_RandomPartitioner_EndsAt_2_2_HEAD',
     [latest_2dot0, latest_2dot1, head_2dot2],
     protocol_version=1,
     extra_config=(
         ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
     )
 )
+if is_unreleased(latest_2dot2):
+    create_upgrade_class(
+        'ProtoV1Upgrade_AllVersions_RandomPartitioner_EndsAt_2_2_Latest',
+        [latest_2dot0, latest_2dot1, latest_2dot2],
+        protocol_version=1,
+        extra_config=(
+            ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
+        )
+    )
 
 # Proto v2 upgrade classes (v2 is supported on 2.0, 2.1, 2.2)
 create_upgrade_class(
-    'ProtoV2Upgrade_2_0_UpTo_2_1',
+    'ProtoV2Upgrade_2_0_UpTo_2_1_HEAD',
     [latest_2dot0, head_2dot1],
     bootstrap_test=True,
     protocol_version=2
 )
+if is_unreleased(latest_2dot1):
+    create_upgrade_class(
+        'ProtoV2Upgrade_2_0_UpTo_2_1_Latest',
+        [latest_2dot0, latest_2dot1],
+        bootstrap_test=True,
+        protocol_version=2
+    )
 create_upgrade_class(
-    'ProtoV2Upgrade_2_1_UpTo_2_2',
+    'ProtoV2Upgrade_2_1_UpTo_2_2_HEAD',
     [latest_2dot1, head_2dot2],
     bootstrap_test=True,
     protocol_version=2
 )
+if is_unreleased(latest_2dot2):
+    create_upgrade_class(
+        'ProtoV2Upgrade_2_1_UpTo_2_2_Latest',
+        [latest_2dot1, latest_2dot2],
+        bootstrap_test=True,
+        protocol_version=2
+    )
 create_upgrade_class(
-    'ProtoV2Upgrade_AllVersions',
+    'ProtoV2Upgrade_AllVersions_EndsAt_2_2_HEAD',
     [latest_2dot0, latest_2dot1, head_2dot2],
     protocol_version=2
 )
+if is_unreleased(latest_2dot2):
+    create_upgrade_class(
+        'ProtoV2Upgrade_AllVersions_EndsAt_2_2_Latest',
+        [latest_2dot0, latest_2dot1, latest_2dot2],
+        protocol_version=2
+    )
 create_upgrade_class(
-    'ProtoV2Upgrade_AllVersions_RandomPartitioner',
+    'ProtoV2Upgrade_AllVersions_RandomPartitioner_EndsAt_2_2_HEAD',
     [latest_2dot0, latest_2dot1, head_2dot2],
     protocol_version=2,
     extra_config=(
         ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
     )
 )
+if is_unreleased(latest_2dot2):
+    create_upgrade_class(
+        'ProtoV2Upgrade_AllVersions_RandomPartitioner_EndsAt_2_2_Latest',
+        [latest_2dot0, latest_2dot1, latest_2dot2],
+        protocol_version=2,
+        extra_config=(
+            ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
+        )
+    )
 
 
 # Proto v3 upgrade classes (v3 is supported on 2.1, 2.2, 3.0, 3.1, trunk)
 create_upgrade_class(
-    'ProtoV3Upgrade_2_1_UpTo_2_2',
+    'ProtoV3Upgrade_2_1_UpTo_2_2_HEAD',
     [latest_2dot1, head_2dot2],
     bootstrap_test=True,
     protocol_version=3
 )
+if is_unreleased(latest_2dot2):
+    create_upgrade_class(
+        'ProtoV3Upgrade_2_1_UpTo_2_2_Latest',
+        [latest_2dot1, latest_2dot2],
+        bootstrap_test=True,
+        protocol_version=3
+    )
 create_upgrade_class(  # special case upgrade skipping 2.2
-    'ProtoV3Upgrade_2_1_UpTo_3_0',
+    'ProtoV3Upgrade_2_1_UpTo_3_0_HEAD',
     [latest_2dot1, head_3dot0],
     bootstrap_test=True,
     protocol_version=3
 )
+if is_unreleased(latest_3dot0):
+    create_upgrade_class(  # special case upgrade skipping 2.2
+        'ProtoV3Upgrade_2_1_UpTo_3_0_Latest',
+        [latest_2dot1, latest_3dot0],
+        bootstrap_test=True,
+        protocol_version=3
+    )
 create_upgrade_class(
-    'ProtoV3Upgrade_2_2_UpTo_3_0',
+    'ProtoV3Upgrade_2_2_UpTo_3_0_HEAD',
     [latest_2dot2, head_3dot0],
     bootstrap_test=True,
     protocol_version=3
 )
+if is_unreleased(latest_3dot0):
+    create_upgrade_class(
+        'ProtoV3Upgrade_2_2_UpTo_3_0_Latest',
+        [latest_2dot2, latest_3dot0],
+        bootstrap_test=True,
+        protocol_version=3
+    )
 create_upgrade_class(
-    'ProtoV3Upgrade_3_0_UpTo_3_1',
+    'ProtoV3Upgrade_3_0_UpTo_3_1_HEAD',
     [latest_3dot0, head_3dot1],
     bootstrap_test=True,
     protocol_version=3
 )
+if is_unreleased(latest_3dot1):
+    create_upgrade_class(
+        'ProtoV3Upgrade_3_0_UpTo_3_1_Latest',
+        [latest_3dot0, latest_3dot1],
+        bootstrap_test=True,
+        protocol_version=3
+    )
 create_upgrade_class(
-    'ProtoV3Upgrade_3_1_UpTo_3_2',
+    'ProtoV3Upgrade_3_1_UpTo_3_2_HEAD',
     [latest_3dot1, head_3dot2],
     bootstrap_test=True,
     protocol_version=3
 )
+if is_unreleased(latest_3dot2):
+    create_upgrade_class(
+        'ProtoV3Upgrade_3_1_UpTo_3_2_Latest',
+        [latest_3dot1, latest_3dot2],
+        bootstrap_test=True,
+        protocol_version=3
+    )
 create_upgrade_class(
-    'ProtoV3Upgrade_3_2_UpTo_Trunk',
+    'ProtoV3Upgrade_3_2_UpTo_3_3_HEAD',
     [latest_3dot2, head_trunk],
     bootstrap_test=True,
     protocol_version=3
 )
+if is_unreleased(latest_3dot3):
+    create_upgrade_class(
+        'ProtoV3Upgrade_3_2_UpTo_3_3_Latest',
+        [latest_3dot2, latest_3dot3],
+        bootstrap_test=True,
+        protocol_version=3
+    )
 create_upgrade_class(
-    'ProtoV3Upgrade_AllVersions',
+    'ProtoV3Upgrade_3_3_UpTo_Trunk_HEAD',
+    [latest_3dot3, head_trunk],
+    bootstrap_test=True,
+    protocol_version=3
+)
+create_upgrade_class(
+    'ProtoV3Upgrade_AllVersions_EndsAt_Trunk_HEAD',
     [latest_2dot1, latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=3
 )
 create_upgrade_class(  # special case upgrade skipping 2.2
-    'ProtoV3Upgrade_AllVersions_Skip_2_2',
+    'ProtoV3Upgrade_AllVersions_Skip_2_2_EndsAt_Trunk_HEAD',
     [latest_2dot1, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=3
 )
 create_upgrade_class(
-    'ProtoV3Upgrade_AllVersions_RandomPartitioner',
+    'ProtoV3Upgrade_AllVersions_RandomPartitioner_EndsAt_Trunk_HEAD',
     [latest_2dot1, latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=3,
     extra_config=(
@@ -972,7 +1088,7 @@ create_upgrade_class(
     )
 )
 create_upgrade_class(
-    'ProtoV3Upgrade_AllVersions_RandomPartitioner_Skip_2_2',
+    'ProtoV3Upgrade_AllVersions_RandomPartitioner_Skip_2_2_EndsAt_Trunk_HEAD',
     [latest_2dot1, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=3,
     extra_config=(
@@ -983,36 +1099,70 @@ create_upgrade_class(
 
 # Proto v4 upgrade classes (v4 is supported on 2.2, 3.0, 3.1, trunk)
 create_upgrade_class(
-    'ProtoV4Upgrade_2_2_UpTo_3_0',
+    'ProtoV4Upgrade_2_2_UpTo_3_0_HEAD',
     [latest_2dot2, head_3dot0],
     bootstrap_test=True,
     protocol_version=4
 )
+if is_unreleased(latest_3dot0):
+    create_upgrade_class(
+        'ProtoV4Upgrade_2_2_UpTo_3_0_Latest',
+        [latest_2dot2, latest_3dot0],
+        bootstrap_test=True,
+        protocol_version=4
+    )
 create_upgrade_class(
-    'ProtoV4Upgrade_3_0_UpTo_3_1',
+    'ProtoV4Upgrade_3_0_UpTo_3_1_HEAD',
     [latest_3dot0, head_3dot1],
     bootstrap_test=True,
     protocol_version=4
 )
+if is_unreleased(latest_3dot1):
+    create_upgrade_class(
+        'ProtoV4Upgrade_3_0_UpTo_3_1_Latest',
+        [latest_3dot0, latest_3dot1],
+        bootstrap_test=True,
+        protocol_version=4
+    )
 create_upgrade_class(
-    'ProtoV4Upgrade_3_1_UpTo_3_2',
+    'ProtoV4Upgrade_3_1_UpTo_3_2_HEAD',
     [latest_3dot1, head_3dot2],
     bootstrap_test=True,
     protocol_version=4
 )
+if is_unreleased(latest_3dot2):
+    create_upgrade_class(
+        'ProtoV4Upgrade_3_1_UpTo_3_2_Latest',
+        [latest_3dot1, latest_3dot2],
+        bootstrap_test=True,
+        protocol_version=4
+    )
 create_upgrade_class(
-    'ProtoV4Upgrade_3_2_UpTo_Trunk',
-    [latest_3dot2, head_trunk],
+    'ProtoV4Upgrade_3_2_UpTo_3_3_HEAD',
+    [latest_3dot2, head_3dot3],
+    bootstrap_test=True,
+    protocol_version=4
+)
+if is_unreleased(latest_3dot3):
+    create_upgrade_class(
+        'ProtoV4Upgrade_3_2_UpTo_3_3_Latest',
+        [latest_3dot2, latest_3dot3],
+        bootstrap_test=True,
+        protocol_version=4
+    )
+create_upgrade_class(
+    'ProtoV4Upgrade_3_3_UpTo_Trunk_HEAD',
+    [latest_3dot3, head_trunk],
     bootstrap_test=True,
     protocol_version=4
 )
 create_upgrade_class(
-    'ProtoV4Upgrade_AllVersions',
+    'ProtoV4Upgrade_AllVersions_EndsAt_Trunk_HEAD',
     [latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=4
 )
 create_upgrade_class(
-    'ProtoV4Upgrade_AllVersions_RandomPartitioner',
+    'ProtoV4Upgrade_AllVersions_RandomPartitioner_EndsAt_Trunk_HEAD',
     [latest_2dot2, latest_3dot0, latest_3dot1, latest_3dot2, latest_3dot3, head_trunk],
     protocol_version=4,
     extra_config=(

--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -865,10 +865,7 @@ def is_unreleased(version_or_tag):
     """
     For gating unnecessary testing of already released upgrade tests endpoints.
     """
-    if 'tentative' in version_or_tag:
-        return True
-
-    return False
+    return 'tentative' in version_or_tag
 
 
 # Proto v1 upgrade classes (v1 supported on 2.0, 2.1, 2.2)

--- a/upgrade_through_versions_test.py
+++ b/upgrade_through_versions_test.py
@@ -24,10 +24,10 @@ from tools import generate_ssl_stores, known_failure, new_node
 latest_2dot0 = '2.0.17'
 latest_2dot1 = '2.1.12'
 latest_2dot2 = '2.2.4'
-latest_3dot0 = 'git:tentative-3.0.3'
+latest_3dot0 = 'git:3.0.3-tentative'
 latest_3dot1 = '3.1.1'
 latest_3dot2 = '3.2.1'
-latest_3dot3 = 'git:tentative-3.3'
+latest_3dot3 = 'git:3.3-tentative'
 
 head_2dot0 = 'git:cassandra-2.0'
 head_2dot1 = 'git:cassandra-2.1'


### PR DESCRIPTION
we need to pay closer attention to both head of branch testing, as well as testing of provisional releases as an upgrade's terminating version.

these changes introduce vars to track both the head of various branches, and also others to track 'latest' versions available. in specific release testing we'll be using tags assigned to these latest vars. to reduce unnecessary testing and noise, these are currently gated on whether or not the 'latest' appears to be a provisional unreleased version (currently simply if it has 'tentative' in the name we include it for testing).

this also adds some missing cases for testing 3.3 (along with the new conditional classes that correspond).