### PR TITLE
Remove upgrade_tests default upgrade logic

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -5242,9 +5242,9 @@ specs = [
      '__test__': True},
 ]
 
-for s in specs:
-    num_nodes, rf = s['NODES'], s['RF']
+for spec in specs:
+    num_nodes, rf = spec['NODES'], spec['RF']
     suffix = 'Nodes{num_nodes}RF{rf}'.format(num_nodes=num_nodes, rf=rf)
     gen_class_name = TestCQL.__name__ + suffix
     assert gen_class_name not in globals()
-    globals()[gen_class_name] = type(gen_class_name, (TestCQL,), s)
+    globals()[gen_class_name] = type(gen_class_name, (TestCQL,), spec)

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -1712,20 +1712,20 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
             self.assertTrue(failed, "Cannot find tombstone failure threshold error in log for {} node".format(("upgraded" if is_upgraded else "old")))
 
 
-for klaus in BasePagingTester.__subclasses__():
-    specs = [
-        {'NODES': 3,
-         'RF': 3,
-         'CL': CL.ALL,
-         '__test__': True},
-        {'NODES': 2,
-         'RF': 1,
-         '__test__': True},
-    ]
+specs = [
+    {'NODES': 3,
+     'RF': 3,
+     'CL': CL.ALL,
+     '__test__': True},
+    {'NODES': 2,
+     'RF': 1,
+     '__test__': True},
+]
 
-    for s in specs:
-        num_nodes, rf = s['NODES'], s['RF']
+for klaus in BasePagingTester.__subclasses__():
+    for spec in specs:
+        num_nodes, rf = spec['NODES'], spec['RF']
         suffix = 'Nodes{num_nodes}RF{rf}'.format(num_nodes=num_nodes, rf=rf)
         gen_klaus_name = klaus.__name__ + suffix
         assert gen_klaus_name not in globals()
-        globals()[gen_klaus_name] = type(gen_klaus_name, (klaus,), s)
+        globals()[gen_klaus_name] = type(gen_klaus_name, (klaus,), spec)

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -19,11 +19,10 @@ OLD_CASSANDRA_VERSION = os.environ.get('OLD_CASSANDRA_VERSION', None)
 UPGRADE_TO = os.environ.get('UPGRADE_TO', None)
 UPGRADE_TO_DIR = os.environ.get('UPGRADE_TO_DIR', None)
 
-
 UPGRADE_TEST_RUN = os.environ.get('UPGRADE_TEST_RUN', '').lower() in {'true', 'yes'}
 
 
-UpgradePath = namedtuple('UpgradePath', ('starting_version', 'upgrade_version'))
+UpgradePath = namedtuple('UpgradePath', ('name', 'starting_version', 'upgrade_version'))
 
 
 # these should be latest tentative tags, falling back to the most recent release if no pending tentative
@@ -116,7 +115,10 @@ def get_default_upgrade_path(job_version, cdir=None):
 
     err = 'Expected one or two upgrade path endpoints to be None; found {}'.format((start_version, upgrade_version))
     assert [start_version, upgrade_version].count(None) >= 1, err
-    upgrade_path = UpgradePath(start_version, upgrade_version)
+    upgrade_path = UpgradePath(
+        name='',
+        starting_version=start_version,
+        upgrade_version=upgrade_version)
     debug(upgrade_path)
     return upgrade_path
 

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -44,6 +44,19 @@ head_3dot3 = 'git:cassandra-3.3'
 head_trunk = 'git:trunk'
 
 
+VALID_UPGRADE_PAIRS = (
+    # UpgradePath(name='2_0_UpTo_2_1_HEAD', starting_version=latest_2dot0, upgrade_version='git:cassandra-2.1'),
+    UpgradePath(name='2_1_UpTo_2_2_HEAD', starting_version=latest_2dot1, upgrade_version=head_2dot2),
+    UpgradePath(name='2_1_UpTo_3_0_HEAD', starting_version=latest_2dot1, upgrade_version=head_3dot0),
+    UpgradePath(name='2_2_UpTo_3_0_HEAD', starting_version=latest_2dot2, upgrade_version=head_3dot0),
+    UpgradePath(name='2_1_HEAD_UpTo_2_2', starting_version=head_2dot1, upgrade_version=latest_2dot2),
+    UpgradePath(name='2_1_HEAD_UpTo_3_0', starting_version=head_2dot1, upgrade_version=latest_3dot0),
+    UpgradePath(name='2_2_HEAD_UpTo_3_0', starting_version=head_2dot2, upgrade_version=latest_3dot0),
+    UpgradePath(name='3_0_UpTo_Trunk', starting_version=latest_3dot0, upgrade_version=head_trunk),
+    UpgradePath(name='3_2_UpTo_Trunk', starting_version=latest_3dot2, upgrade_version=head_trunk),
+)
+
+
 def sanitize_version(version, allow_ambiguous=True):
     """
     Takes version of the form cassandra-1.2, 2.0.10, or trunk.


### PR DESCRIPTION
I feel like there's some cleanup to do in this history, and these commits will need to be rebased onto master after #787 is merged, but the code is in place.

The big change is the removal of `upgrade_tests.upgrade_base.get_default_upgrade_path` and the code that calls it. It's replaced by code that extends the upgrade-test-generation code introduced in #787 by attaching the specified upgrade path to the test class, rather than specifying it through a mess of environment variables and weird logic defining the default path.

This is currently running here:

http://cassci.datastax.com/view/Dev/view/mambocab/job/mambocab-consolidated-upgrades/20/

We can use this job to run all our upgrade tests on a single job if we like.