### PR TITLE
gate upgrade test discovery on env var

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -23,7 +23,7 @@ from thrift_bindings.v22.ttypes import (CfDef, Column, ColumnOrSuperColumn,
                                         Mutation)
 from thrift_tests import get_thrift_client
 from tools import known_failure, require, rows_to_list, since
-from upgrade_base import VALID_UPGRADE_PAIRS, UpgradeTester
+from upgrade_base import UPGRADE_TEST_RUN, VALID_UPGRADE_PAIRS, UpgradeTester
 
 
 class TestCQL(UpgradeTester):
@@ -5242,7 +5242,7 @@ topology_specs = [
     {'NODES': 2,
      'RF': 1},
 ]
-specs = [dict(s, UPGRADE_PATH=p, __test__=True)
+specs = [dict(s, UPGRADE_PATH=p, __test__=UPGRADE_TEST_RUN)
          for s, p in itertools.product(topology_specs, VALID_UPGRADE_PAIRS)]
 
 for spec in specs:

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -10,7 +10,7 @@ from cassandra.query import SimpleStatement, dict_factory, named_tuple_factory
 from datahelp import create_rows, flatten_into_set, parse_data_into_dicts
 from dtest import debug, run_scenarios
 from tools import known_failure, rows_to_list, since
-from upgrade_base import VALID_UPGRADE_PAIRS, UpgradeTester
+from upgrade_base import UPGRADE_TEST_RUN, VALID_UPGRADE_PAIRS, UpgradeTester
 
 
 def assert_read_timeout_or_failure(session, query):
@@ -1720,7 +1720,7 @@ topology_specs = [
      'RF': 1},
 ]
 
-specs = [dict(s, UPGRADE_PATH=p, __test__=True)
+specs = [dict(s, UPGRADE_PATH=p, __test__=UPGRADE_TEST_RUN)
          for s, p in itertools.product(topology_specs, VALID_UPGRADE_PAIRS)]
 
 for klaus in BasePagingTester.__subclasses__():

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -17,11 +17,11 @@ from six import print_
 import schema_metadata_test
 from dtest import Tester, debug
 from tools import generate_ssl_stores, known_failure, new_node
-from upgrade_base import (head_2dot1, head_2dot2, head_3dot0, head_3dot1,
-                          head_3dot2, head_3dot3, head_trunk, latest_2dot0,
-                          latest_2dot1, latest_2dot2, latest_3dot0,
-                          latest_3dot1, latest_3dot2, latest_3dot3,
-                          switch_jdks)
+from upgrade_base import (UPGRADE_TEST_RUN, head_2dot1, head_2dot2, head_3dot0,
+                          head_3dot1, head_3dot2, head_3dot3, head_trunk,
+                          latest_2dot0, latest_2dot1, latest_2dot2,
+                          latest_3dot0, latest_3dot1, latest_3dot2,
+                          latest_3dot3, switch_jdks)
 
 
 def data_writer(tester, to_verify_queue, verification_done_queue, rewrite_probability=0):
@@ -801,7 +801,7 @@ def create_upgrade_class(clsname, version_list, protocol_version,
     newcls = type(
         clsname,
         parent_classes,
-        {'test_versions': version_list, '__test__': True, 'protocol_version': protocol_version, 'extra_config': extra_config}
+        {'test_versions': version_list, '__test__': UPGRADE_TEST_RUN, 'protocol_version': protocol_version, 'extra_config': extra_config}
     )
 
     if clsname in globals():


### PR DESCRIPTION
This sets `__test__` based on the value of the `UPGRADE_TEST_RUN` env var -- so, rather than skip the test, it removes it from test discovery entirely. This works around problems we had on non-upgrade jobs after merging #798, where `nosetests` threw up when passed too many test names.

On my machine, this seems to work:

```sh
$ CASSANDRA_VERSION=git:trunk nosetests --collect-only 2>&1 -vv | grep upgrade_tests  
upgrade_tests/regression_test.py:TestForRegressions.test_10822 ... ok
                                                                                                                                  
$ UPGRADE_TEST_RUN=true CASSANDRA_VERSION=git:trunk nosetests --collect-only 2>&1 -vv | grep upgrade_tests | wc -l
2921
```

Can a reviewer please verify?