### PR TITLE
tag known failures

### DIFF
--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -260,6 +260,9 @@ class UpgradeTester(Tester):
                 values=dict(self.extra_config)
             )
 
+    @known_failure(failure_source='test',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11162',
+                   flaky=False)
     def parallel_upgrade_test(self):
         """
         Test upgrading cluster all at once (requires cluster downtime).
@@ -272,6 +275,9 @@ class UpgradeTester(Tester):
         """
         self.upgrade_scenario(rolling=True)
 
+    @known_failure(failure_source='test',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11162',
+                   flaky=False)
     def parallel_upgrade_with_internode_ssl_test(self):
         """
         Test upgrading cluster all at once (requires cluster downtime), with internode ssl.


### PR DESCRIPTION
Tags failures from [CASSANDRA-11162](https://issues.apache.org/jira/browse/CASSANDRA-11162).

Looks like we might not be able to do the `TestClass.test_method = known_failure(**known_failure_args)(TestClass.test_method)` thing. For one thing, because each instance of `test_method` is actually the same object, you might as well just decorate the test on the base class. Also, I got a kinda cryptic errorThe error I got when I tried to actually do this was kinda cryptic, though, so I could be wrong here. I didn't dig too far. @knifewine and @ptnapoleon, could you review, please, and try to think of a different solution?