### PR TITLE
Add wait for compactions to finish after starting node

### DIFF
--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -84,6 +84,8 @@ class SSTableUtilTest(Tester):
 
         # restart to make sure not data is lost
         node.start(wait_for_binary_proto=True)
+        # in some environments, a compaction may start that would change sstable files. We should wait if so
+        node.wait_for_compactions()
 
         finalfiles, tmpfiles = self._check_files(node, KeyspaceName, TableName)
         self.assertEqual(0, len(tmpfiles))


### PR DESCRIPTION
PR #765 removed a line to wait for compactions after a node started. This line watched the log for compaction completion, which was problematic because compactions were not always triggered. This change looked good on CassCI.

Locally, dtests are always failing on 3.0 because this line was removed. Investigating, I found it was because a compaction did in fact start so files changed during the test. I've also seen the issue on [CassCI](http://cassci.datastax.com/view/Dev/view/jkni/job/jkni-10736-3.0-dtest/2/testReport/).

I asked Marcus about this and he suggested this change; in this case, if a compaction is triggered, we will wait for its completion, but if none are ongoing, we will proceed. I think this might open a very small race condition where we check before a compaction starts, but it's certainly better than before. 

A clean CassCI run after this change can be seen [here](https://cassci.datastax.com/view/Dev/view/jkni/job/jkni-sstableutil-fork/2/).