### PR TITLE
Logwatch callback

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -368,7 +368,7 @@ class Tester(TestCase):
         """
         Callback handler used in conjunction with begin_active_log_watch.
         When called prepares exception instance, then will indirectly
-        cause catch_interrupt to be called, which can raise the exception in the main
+        cause _catch_interrupt to be called, which can raise the exception in the main
         program thread.
         """
         # in some cases self.allow_log_errors may get set after proactive log checking has been enabled

--- a/dtest.py
+++ b/dtest.py
@@ -62,6 +62,7 @@ REUSE_CLUSTER = os.environ.get('REUSE_CLUSTER', '').lower() in ('yes', 'true')
 SILENCE_DRIVER_ON_SHUTDOWN = os.environ.get('SILENCE_DRIVER_ON_SHUTDOWN', 'true').lower() in ('yes', 'true')
 IGNORE_REQUIRE = os.environ.get('IGNORE_REQUIRE', '').lower() in ('yes', 'true')
 DATADIR_COUNT = os.environ.get('DATADIR_COUNT', '3')
+ENABLE_ACTIVE_LOG_WATCHING = os.environ.get('ENABLE_ACTIVE_LOG_WATCHING', '').lower() in ('yes', 'true')
 
 CURRENT_TEST = ""
 
@@ -332,8 +333,9 @@ class Tester(TestCase):
                 pass
 
         self.cluster = self._get_cluster()
-        if not self.allow_log_errors:
-            self.begin_active_log_watch()
+        if ENABLE_ACTIVE_LOG_WATCHING:
+            if not self.allow_log_errors:
+                self.begin_active_log_watch()
         if RECORD_COVERAGE:
             self.__setup_jacoco()
 

--- a/dtest.py
+++ b/dtest.py
@@ -370,6 +370,8 @@ class Tester(TestCase):
         When called prepares exception instance, then will indirectly
         cause _catch_interrupt to be called, which can raise the exception in the main
         program thread.
+
+        @param errordata is a dictonary mapping node name to failure list.
         """
         # in some cases self.allow_log_errors may get set after proactive log checking has been enabled
         # so we need to double-check first thing before proceeding
@@ -398,6 +400,13 @@ class Tester(TestCase):
         thread.interrupt_main()
 
     def _catch_interrupt(self, signal, frame):
+        """
+        Signal handler for registering on SIGINT.
+
+        If called will look for a stored exception and raise it to abort test.
+        If a stored exception is not present, this handler has likely caught a
+        user interrupt via CTRL-C, and will raise a KeyboardInterrupt.
+        """
         try:
             # check if we have a persisted exception to fail with
             raise self.exit_with_exception

--- a/dtest.py
+++ b/dtest.py
@@ -394,8 +394,8 @@ class Tester(TestCase):
         # thread.interrupt_main will SIGINT in the main thread, which we can
         # catch to raise an exception with useful information
         debug('Errors were just seen in logs, ending test!')
-        thread.interrupt_main()
         self.exit_with_exception = AssertionError(message)
+        thread.interrupt_main()
 
     def _catch_interrupt(self, signal, frame):
         try:


### PR DESCRIPTION
adds support for continuous watching of cassandra logs, to enable closer association between dtest actions and resulting log failures (esp among upgrade tests).

when enabled, this will trigger ccm to open a continuous log watching thread, which will call back when errors are encountered, and dtest can then take actions to halt and cleanup test execution.

currently gated by an env var, but that will change soon, in line with command line flags