### PR TITLE
Tag failing upgrade tests

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -3680,6 +3680,9 @@ class TestCQL(UpgradeTester):
             assert_all(cursor, "SELECT k, v FROM test WHERE m CONTAINS 2", [[0, 1]])
             assert_none(cursor, "SELECT k, v FROM test  WHERE m CONTAINS 4")
 
+    @known_failure(failure_source='test',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11186',
+                   flaky=False)
     def map_keys_indexing_test(self):
         cursor = self.prepare()
 

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -269,6 +269,9 @@ class UpgradeTester(Tester):
         """
         self.upgrade_scenario()
 
+    @known_failure(failure_source='test',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10612',
+                   flaky=True)
     def rolling_upgrade_test(self):
         """
         Test rolling upgrade of the cluster, so we have mixed versions part way through.
@@ -278,6 +281,9 @@ class UpgradeTester(Tester):
     @known_failure(failure_source='test',
                    jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11162',
                    flaky=False)
+    @known_failure(failure_source='test',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10612',
+                   flaky=True)
     def parallel_upgrade_with_internode_ssl_test(self):
         """
         Test upgrading cluster all at once (requires cluster downtime), with internode ssl.
@@ -731,9 +737,6 @@ class BootstrapMixin(object):
         # try and add a new node
         self.upgrade_scenario(after_upgrade_call=(self._bootstrap_new_node,))
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10610',
-                   flaky=False)
     def bootstrap_multidc_test(self):
         # try and add a new node
         # multi dc, 2 nodes in each dc


### PR DESCRIPTION
This does some tagging work for failing upgrade tests.