### PR TITLE
cut known_failure from index_summary_upgrade_test

### DIFF
--- a/index_summary_upgrade_test.py
+++ b/index_summary_upgrade_test.py
@@ -2,13 +2,10 @@ from cassandra.concurrent import execute_concurrent_with_args
 
 from dtest import OFFHEAP_MEMTABLES, Tester, debug
 from jmxutils import JolokiaAgent, make_mbean, remove_perf_disable_shared_mem
-from tools import known_failure
 
 
 class TestUpgradeIndexSummary(Tester):
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11127')
     def test_upgrade_index_summary(self):
         """
         @jira_ticket CASSANDRA-8993


### PR DESCRIPTION
@mshuler Could you have a look at this? If I understand correctly, #801 should  have fixed [CASSANDRA-11127](https://issues.apache.org/jira/browse/CASSANDRA-11127).

With the changes from #801, this test passes locally. There is a [flap on CassCI](http://cassci.datastax.com/job/trunk_dtest/1014/testReport/junit/index_summary_upgrade_test/TestUpgradeIndexSummary/test_upgrade_index_summary/) but it seems unrelated/looks like another flap I've seen elsewhere. Otherwise [it looks pretty clean the past couple weeks](http://cassci.datastax.com/job/trunk_dtest/1014/testReport/junit/index_summary_upgrade_test/TestUpgradeIndexSummary/test_upgrade_index_summary/history/).

If this is good to go, then #801 obviated the need for #775 as well, and we should close that without merge.