### PR TITLE
untag failing test from CASSANDRA-11108

### DIFF
--- a/cql_tests.py
+++ b/cql_tests.py
@@ -15,7 +15,7 @@ from thrift_bindings.v22.ttypes import \
 from thrift_bindings.v22.ttypes import (CfDef, Column, ColumnOrSuperColumn,
                                         Mutation)
 from thrift_tests import get_thrift_client
-from tools import known_failure, debug, rows_to_list, since
+from tools import debug, rows_to_list, since
 
 
 class CQLTester(Tester):
@@ -233,8 +233,6 @@ class MiscellaneousCQLTester(CQLTester):
     required.
     """
 
-    @known_failure(failure_source='driver',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11108')
     @since('2.1', max_version='3.0')
     def large_collection_errors_test(self):
         """


### PR DESCRIPTION
I think CASSANDRA-11108 is good to be closed -- see [this comment on JIRA](https://issues.apache.org/jira/browse/CASSANDRA-11108?focusedCommentId=15159075&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15159075). If that gets closed, we can merge this; if not, we can close without merge.