### PR TITLE
Cql tests audit followup

### DIFF
--- a/cql_tests.py
+++ b/cql_tests.py
@@ -488,7 +488,6 @@ class MiscellaneousCQLTester(CQLTester):
 
         # TODO this basically tests driver behavior if I read it correctly.
         # Should this be in dtests at all?
-        # TODO should these assert that the ALTERs happened correctly?
         """
         session = self.prepare()
 

--- a/cql_tests.py
+++ b/cql_tests.py
@@ -482,9 +482,6 @@ class MiscellaneousCQLTester(CQLTester):
         - assert prepared statement containing that column also still works
         - ALTER the table, changing the type of a column
         - assert that both prepared statements still work
-
-        # TODO this basically tests driver behavior if I read it correctly.
-        # Should this be in dtests at all?
         """
         session = self.prepare()
 

--- a/cql_tests.py
+++ b/cql_tests.py
@@ -408,7 +408,6 @@ class MiscellaneousCQLTester(CQLTester):
         - INSERT a row via CQL
         - ALTER the name of the table via CQL
         - SELECT from the table and assert the values inserted are there
-        # TODO why doesn't this check that the column names were actually changed?
         """
         session = self.prepare(start_rpc=True)
 

--- a/cql_tests.py
+++ b/cql_tests.py
@@ -440,9 +440,6 @@ class MiscellaneousCQLTester(CQLTester):
         client.system_add_column_family(cfdef)
 
         session.execute("INSERT INTO ks.test (key, column1, column2, column3, value) VALUES ('foo', 4, 3, 2, 'bar')")
-
-        time.sleep(1)
-
         session.execute("ALTER TABLE test RENAME column1 TO foo1 AND column2 TO foo2 AND column3 TO foo3")
         assert_one(session, "SELECT foo1, foo2, foo3 FROM test", [4, 3, 2])
 

--- a/cql_tests.py
+++ b/cql_tests.py
@@ -211,6 +211,7 @@ class StorageProxyCQLTester(CQLTester):
         session.execute("ALTER TYPE address_t ADD phones set<text>")
         self.assertIn('phones', types_meta['address_t'].field_names)
 
+        # drop the table so we can safely drop the type it uses
         session.execute("DROP TABLE test4")
 
         session.execute("DROP TYPE address_t")

--- a/tools.py
+++ b/tools.py
@@ -13,9 +13,9 @@ from threading import Thread
 from cassandra import ConsistencyLevel
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.query import SimpleStatement
+from ccmlib.node import Node
 from nose.plugins.attrib import attr
 
-from ccmlib.node import Node
 from dtest import CASSANDRA_DIR, DISABLE_VNODES, IGNORE_REQUIRE, debug
 
 

--- a/tools.py
+++ b/tools.py
@@ -436,3 +436,15 @@ class KillOnBootstrap(Thread):
     def run(self):
         self.node.watch_log_for("JOINING: Starting to bootstrap")
         self.node.stop(gently=False)
+
+
+def get_keyspace_metadata(session, keyspace_name):
+    cluster = session.cluster
+    cluster.refresh_keyspace_metadata(keyspace_name)
+    return cluster.metadata.keyspaces[keyspace_name]
+
+
+def get_schema_metadata(session):
+    cluster = session.cluster
+    cluster.refresh_schema_metadata()
+    return cluster.metadata

--- a/tools.py
+++ b/tools.py
@@ -448,3 +448,9 @@ def get_schema_metadata(session):
     cluster = session.cluster
     cluster.refresh_schema_metadata()
     return cluster.metadata
+
+
+def get_table_metadata(session, keyspace_name, table_name):
+    cluster = session.cluster
+    cluster.refresh_table_metadata(keyspace_name, table_name)
+    return cluster.metadata.keyspaces[keyspace_name].tables[table_name]

--- a/utils/metadata_wrapper.py
+++ b/utils/metadata_wrapper.py
@@ -1,0 +1,109 @@
+from abc import ABCMeta, abstractproperty
+
+
+class UpdatingMetadataWrapperBase(object):
+    __metaclass__ = ABCMeta
+
+    @abstractproperty
+    def _wrapped(self):
+        pass
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+    def __getitem__(self, idx):
+        return self._wrapped[idx]
+
+
+class UpdatingMetadataDictWrapper(UpdatingMetadataWrapperBase):
+    """
+    A dictionary-like object that, given a parent implementing the
+    UpdatingMetadataWrapperBase interface and the name of an attribute, updates
+    its parent before checking indexes or attributes on the object at the
+    attribute.
+    """
+    def __init__(self, parent, attr_name):
+        self._parent = parent
+        self._attr_name = attr_name
+
+    @property
+    def _wrapped(self):
+        return getattr(self._parent._wrapped, self._attr_name)
+
+    def __iter__(self):
+        for k in self._wrapped:
+            yield k
+
+    def __repr__(self):
+        return '{cls_name}(parent={parent}, attr_name={attr_name})'.format(
+            cls_name=self.__class__.__name__,
+            parent=repr(self._parent),
+            attr_name=self._attr_name)
+
+    def __str__(self):
+        return str(self._wrapped)
+
+
+class UpdatingTableMetadataWrapper(UpdatingMetadataWrapperBase):
+    """
+    A class that provides an interface to a table's metadata that is refreshed
+    on access.
+    """
+    def __init__(self, cluster, ks_name, table_name):
+        self._cluster = cluster
+        self._ks_name = ks_name
+        self._table_name = table_name
+
+    @property
+    def _wrapped(self):
+        self._cluster.refresh_table_metadata(self._ks_name, self._table_name)
+        return self._cluster.metadata.keyspaces[self._ks_name].tables[self._table_name]
+
+    def __repr__(self):
+        return '{cls_name}(cluster={cluster}, ks_name={ks_name}, table_name={table_name})'.format(
+            cls_name=self.__class__.__name__,
+            cluster=repr(self._cluster),
+            ks_name=self._ks_name,
+            table_name=self._table_name)
+
+
+class UpdatingKeyspaceMetadataWrapper(UpdatingMetadataWrapperBase):
+    """
+    A class that provides an interface to a keyspace's metadata that is
+    refreshed on access.
+    """
+    def __init__(self, cluster, ks_name):
+        self._cluster = cluster
+        self._ks_name = ks_name
+
+    @property
+    def _wrapped(self):
+        self._cluster.refresh_keyspace_metadata(self._ks_name)
+        return self._cluster.metadata.keyspaces[self._ks_name]
+
+    def __repr__(self):
+        return '{cls_name}(cluster={cluster}, ks_name={ks_name})'.format(
+            cls_name=self.__class__.__name__,
+            cluster=repr(self._cluster),
+            ks_name=self._ks_name)
+
+
+class UpdatingClusterMetadataWrapper(UpdatingMetadataWrapperBase):
+    """
+    A class that provides an interface to a cluster's metadata that is
+    refreshed on access.
+    """
+    def __init__(self, cluster):
+        """
+        @param cluster The cassandra.cluster.Cluster object to wrap.
+        """
+        self._cluster = cluster
+
+    @property
+    def _wrapped(self):
+        self._cluster.refresh_schema_metadata()
+        return self._cluster.metadata
+
+    def __repr__(self):
+        return '{cls_name}(cluster={cluster})'.format(
+            cls_name=self.__class__.__name__, cluster=repr(self._cluster))


### PR DESCRIPTION
This is ready for review. I'm going to make another PR pulling out the `SELECT` assertions to use functions from the `assertions` module. @knifewine and/or @ptnapoleon to review.

Much of this uses checks over the driver's cluster metadata instead of the previous assertions -- for example, rather than adding a column to a table, then asserting that a query has the result we expect, we directly check `<metadata object>'.columns`. To make this easier, I've added a collection of objects that, when accessing items or attributes, refresh the appropriate metadata and update themselves. The API there is up for grabs, but the idea is that it basically looks like a `cassandra.metadata.Metadata` object, except you don't have to refresh the metadata before accessing its attributes.

I'm still running these locally and I'll have to make changes if stuff fails. I'm just looking to get discussion started.