### PR TITLE
add space to tracing error check

### DIFF
--- a/cql_tracing_test.py
+++ b/cql_tracing_test.py
@@ -163,6 +163,6 @@ class TestCqlTracing(Tester):
             # make sure it logged the error for the correct reason. this isn't
             # part of the expected error to avoid having to escape parens and
             # periods for regexes.
-            self.assertIn("Default constructor for Tracing class"
+            self.assertIn("Default constructor for Tracing class "
                           "'org.apache.cassandra.tracing.TracingImpl' is inaccessible.",
                           err)


### PR DESCRIPTION
Fixes the mistake that causes the failure here:

http://cassci.datastax.com/view/trunk/job/trunk_dtest/1026/testReport/junit/cql_tracing_test/TestCqlTracing/tracing_default_impl_test/history/

@ptnapoleon or @knifewine can you review? The test in question is `cql_tracing_test.py:TestCqlTracing.tracing_default_impl_test`.