### PR TITLE
Remove blist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-blist
 git+https://github.com/datastax/python-driver.git@cassandra-test
 git+https://github.com/pcmanus/ccm.git
 cql

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ git+https://github.com/datastax/python-driver.git@cassandra-test
 git+https://github.com/pcmanus/ccm.git
 cql
 decorator
+docopt
 enum34
 flaky
 futures
@@ -11,4 +12,3 @@ psutil
 pycassa
 six
 thrift
-docopt


### PR DESCRIPTION
`blist` shouldn't be necessary anymore since the changes to the driver last year.

(this also sorts the bare package installs in `requirements.txt`, I didn't add `docopt` in the correct position in the file.)