### PR TITLE
add since to test failing on 2.2

### DIFF
--- a/thrift_tests.py
+++ b/thrift_tests.py
@@ -1901,6 +1901,7 @@ class TestMutations(ThriftTester):
         time.sleep(3)
         _expect_missing(lambda: client.get('key1', ColumnPath('Expiring', column='cttl3'), ConsistencyLevel.ONE))
 
+    @since('3.6')
     def test_expiration_with_default_ttl_and_zero_ttl(self):
         """
         Test that we can remove the default ttl by setting the ttl explicitly to zero


### PR DESCRIPTION
@blerer This test fails on 2.2:

http://cassci.datastax.com/job/cassandra-2.2_novnode_dtest/227/testReport/thrift_tests/TestMutations/test_expiration_with_default_ttl_and_zero_ttl/

http://cassci.datastax.com/job/cassandra-2.2_dtest/539/testReport/thrift_tests/TestMutations/test_expiration_with_default_ttl_and_zero_ttl/

Is it meant to pass there? If so, I'll file a ticket; otherwise, we can just apply `@since` to it.