### PR TITLE
add notes for known failures

### DIFF
--- a/index_summary_upgrade_test.py
+++ b/index_summary_upgrade_test.py
@@ -8,7 +8,8 @@ from tools import known_failure
 class TestUpgradeIndexSummary(Tester):
 
     @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11127')
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11127',
+                   notes='Fails on Linux on 3.0 branch, fails on Windows')
     def test_upgrade_index_summary(self):
         """
         @jira_ticket CASSANDRA-8993

--- a/jmx_test.py
+++ b/jmx_test.py
@@ -60,7 +60,8 @@ class TestJMX(Tester):
 
     @known_failure(failure_source='test',
                    jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10915',
-                   flaky=False)
+                   flaky=False,
+                   notes='Fails on Windows, flaps on Linux')
     def netstats_test(self):
         """
         Check functioning of nodetool netstats, especially with restarts.

--- a/jmxmetrics_test.py
+++ b/jmxmetrics_test.py
@@ -84,7 +84,8 @@ class TestJMXMetrics(Tester):
         Tester.__init__(self, *args, **kwargs)
 
     @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10845')
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-10845',
+                   notes='depends on a number of invalid assumptions about metrics')
     @require('10845')
     def begin_test(self):
         """

--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -708,7 +708,8 @@ class TestMaterializedViews(Tester):
 
     @known_failure(failure_source='test',
                    jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11265',
-                   flaky=True)
+                   flaky=True,
+                   notes='fails on various 3.0 and 3.X branches')
     def view_tombstone_test(self):
         """
         Test that a materialized views properly tombstone

--- a/repair_tests/repair_test.py
+++ b/repair_tests/repair_test.py
@@ -367,7 +367,8 @@ class TestRepair(Tester):
 
     @known_failure(failure_source='test',
                    jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11229',
-                   flaky=True)
+                   flaky=True,
+                   notes='has flapped on 2.2 and trunk offheap tests')
     def local_dc_repair_test(self):
         """
         * Set up a multi DC cluster


### PR DESCRIPTION
@knifewine can you have a quick look? this is just more information in the `notes` fields of some `known_failure`s.