### PR TITLE
Make changes to tests based on CCM node start API changes

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -156,7 +156,7 @@ class TestBootstrap(Tester):
         # keep timeout low so that test won't hang
         node3.set_configuration_options(values={'streaming_socket_timeout_in_ms': 1000})
         try:
-            node3.start()
+            node3.start(wait_other_notice=False)
         except NodeError:
             pass  # node doesn't start as expected
         t.join()
@@ -350,7 +350,7 @@ class TestBootstrap(Tester):
         self._cleanup(node4)
         # Now start it, it should not be allowed to join.
         mark = node4.mark_log()
-        node4.start(no_wait=True)
+        node4.start(no_wait=True, wait_other_notice=False)
         node4.watch_log_for("A node with address /127.0.0.4 already exists, cancelling join", from_mark=mark)
 
     @known_failure(failure_source='test',
@@ -502,7 +502,7 @@ class TestBootstrap(Tester):
         node2.start(wait_other_notice=True)
 
         node3 = new_node(cluster, remote_debug_port='2003')
-        process = node3.start()
+        process = node3.start(wait_other_notice=False)
         stdout, stderr = process.communicate()
         self.assertIn(bootstrap_error, stderr, msg=stderr)
         time.sleep(.5)

--- a/consistency_test.py
+++ b/consistency_test.py
@@ -921,7 +921,6 @@ class TestConsistency(Tester):
             tokens = cluster.balanced_tokens(3)
             cluster.populate(3, tokens=tokens).start()
         node1, node2, node3 = cluster.nodelist()
-        cluster.start()
 
         debug("Set to talk to node 2")
         session = self.patient_cql_connection(node2)

--- a/consistent_bootstrap_test.py
+++ b/consistent_bootstrap_test.py
@@ -16,7 +16,6 @@ class TestBootstrapConsistency(Tester):
 
         cluster.populate(3, tokens=[0, 2**48, 2**62]).start()
         node1, node2, node3 = cluster.nodelist()
-        cluster.start()
 
         debug("Set to talk to node 2")
         n2session = self.patient_cql_connection(node2)
@@ -53,7 +52,7 @@ class TestBootstrapConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False, 'write_request_timeout_in_ms': 60000,
                                                   'read_request_timeout_in_ms': 60000, 'dynamic_snitch_badness_threshold': 0.0}, batch_commitlog=True)
 
-        cluster.populate(2).start()
+        cluster.populate(2)
         node1, node2 = cluster.nodelist()
         cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
 

--- a/global_row_key_cache_test.py
+++ b/global_row_key_cache_test.py
@@ -19,6 +19,7 @@ class TestGlobalRowKeyCache(Tester):
 
         for keycache_size in (0, 10):
             for rowcache_size in (0, 10):
+                cluster.stop()
                 debug("Testing with keycache size of %d MB, rowcache size of %d MB " %
                       (keycache_size, rowcache_size))
                 keyspace_name = 'ks_%d_%d' % (keycache_size, rowcache_size)

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -65,7 +65,7 @@ class TestReplaceAddress(Tester):
         debug(numNodes)
 
         debug("Inserting Data...")
-        node1.stress(['write', 'n=10000', '-schema', 'replication(factor=3)'])
+        node1.stress(['write', 'n=10K', '-schema', 'replication(factor=3)'])
 
         session = self.patient_cql_connection(node1)
         session.default_timeout = 45
@@ -105,7 +105,7 @@ class TestReplaceAddress(Tester):
 
         # check that restarting node 3 doesn't work
         debug("Try to restart node 3 (should fail)")
-        node3.start()
+        node3.start(wait_other_notice=False)
         checkCollision = node1.grep_log("between /127.0.0.3 and /127.0.0.4; /127.0.0.4 is the new owner")
         debug(checkCollision)
         self.assertEqual(len(checkCollision), 1)
@@ -123,7 +123,7 @@ class TestReplaceAddress(Tester):
         cluster.add(node4, False)
 
         mark = node4.mark_log()
-        node4.start(replace_address='127.0.0.3')
+        node4.start(replace_address='127.0.0.3', wait_other_notice=False)
         node4.watch_log_for("java.lang.UnsupportedOperationException: Cannot replace a live node...", from_mark=mark)
         self.check_not_running(node4)
 
@@ -139,7 +139,7 @@ class TestReplaceAddress(Tester):
 
         # try to replace an unassigned ip address
         mark = node4.mark_log()
-        node4.start(replace_address='127.0.0.5')
+        node4.start(replace_address='127.0.0.5', wait_other_notice=False)
         node4.watch_log_for("java.lang.RuntimeException: Cannot replace_address /127.0.0.5 because it doesn't exist in gossip", from_mark=mark)
         self.check_not_running(node4)
 
@@ -166,7 +166,7 @@ class TestReplaceAddress(Tester):
         debug(numNodes)
 
         debug("Inserting Data...")
-        node1.stress(['write', 'n=10000', '-schema', 'replication(factor=3)'])
+        node1.stress(['write', 'n=10K', '-schema', 'replication(factor=3)'])
 
         session = self.patient_cql_connection(node1)
         stress_table = 'keyspace1.standard1'
@@ -202,7 +202,7 @@ class TestReplaceAddress(Tester):
 
         # check that restarting node 3 doesn't work
         debug("Try to restart node 3 (should fail)")
-        node3.start()
+        node3.start(wait_other_notice=False)
         checkCollision = node1.grep_log("between /127.0.0.3 and /127.0.0.4; /127.0.0.4 is the new owner")
         debug(checkCollision)
         self.assertEqual(len(checkCollision), 1)
@@ -230,7 +230,7 @@ class TestReplaceAddress(Tester):
         cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
-        node1.stress(['write', 'n=100000', '-schema', 'replication(factor=3)'])
+        node1.stress(['write', 'n=100K', '-schema', 'replication(factor=3)'])
 
         session = self.patient_cql_connection(node1)
         stress_table = 'keyspace1.standard1'
@@ -300,7 +300,7 @@ class TestReplaceAddress(Tester):
         node4 = Node('node4', cluster, True, ('127.0.0.4', 9160), ('127.0.0.4', 7000), '7400', '0', None, binary_interface=('127.0.0.4', 9042))
         cluster.add(node4, False)
         try:
-            node4.start(jvm_args=["-Dcassandra.replace_address_first_boot=127.0.0.3"])
+            node4.start(jvm_args=["-Dcassandra.replace_address_first_boot=127.0.0.3"], wait_other_notice=False)
         except NodeError:
             pass  # node doesn't start as expected
         t.join()

--- a/snitch_test.py
+++ b/snitch_test.py
@@ -63,7 +63,7 @@ class TestGossipingPropertyFileSnitch(Tester):
         stress_table = 'keyspace1.standard1'
         original_rows = list(session.execute("SELECT * FROM {}".format(stress_table)))
 
-        node2.start(wait_for_binary_proto=True)
+        node2.start(wait_for_binary_proto=True, wait_other_notice=False)
         node2.watch_log_for("Starting Messaging Service on /{}:{}".format(NODE2_LISTEN_ADDRESS, STORAGE_PORT), timeout=60)
         node2.watch_log_for("Starting Messaging Service on /{}:{}".format(NODE2_BROADCAST_ADDRESS, STORAGE_PORT), timeout=60)
         self._test_connect(NODE2_LISTEN_ADDRESS, STORAGE_PORT)


### PR DESCRIPTION
https://github.com/pcmanus/ccm/pull/464. wait-other-notice now defaults to True, so we need
to set it to False in some places. Also, start is no longer
idempotent, so we can't double start() in some tests

Running here:
http://cassci.datastax.com/view/Dev/view/ptnapoleon/job/ptnapoleon-cassandra-2.2-dtest/