### PR TITLE
whole_list_condition_test flakiness fix

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -4267,6 +4267,8 @@ class TestCQL(UpgradeTester):
                 l frozen<list<text>>
             )""")
 
+        cl = getattr(self, 'CL', ConsistencyLevel.ONE)
+
         for is_upgraded, cursor in self.do_upgrade(cursor):
             debug("Querying %s node" % ("upgraded" if is_upgraded else "old",))
             cursor.execute("TRUNCATE tlist")
@@ -4275,11 +4277,11 @@ class TestCQL(UpgradeTester):
             for frozen in (False, True):
 
                 table = "frozentlist" if frozen else "tlist"
-                cursor.execute("INSERT INTO %s(k, l) VALUES (0, ['foo', 'bar', 'foobar'])" % (table,))
+                cursor.execute("INSERT INTO {}(k, l) VALUES (0, ['foo', 'bar', 'foobar'])".format(table))
 
                 def check_applies(condition):
-                    assert_one(cursor, "UPDATE %s SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF %s" % (table, condition), [True])
-                    assert_one(cursor, "SELECT * FROM %s" % (table,), [0, ['foo', 'bar', 'foobar']])
+                    assert_one(cursor, "UPDATE {} SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF {}".format(table, condition), [True], cl=cl)
+                    assert_one(cursor, "SELECT * FROM {}".format(table), [0, ['foo', 'bar', 'foobar']])  # read back at default cl.one
 
                 check_applies("l = ['foo', 'bar', 'foobar']")
                 check_applies("l != ['baz']")
@@ -4294,9 +4296,9 @@ class TestCQL(UpgradeTester):
                 check_applies("l != null AND l IN (['foo', 'bar', 'foobar'])")
 
                 def check_does_not_apply(condition):
-                    assert_one(cursor, "UPDATE %s SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF %s" % (table, condition),
-                               [False, ['foo', 'bar', 'foobar']])
-                    assert_one(cursor, "SELECT * FROM %s" % (table,), [0, ['foo', 'bar', 'foobar']])
+                    assert_one(cursor, "UPDATE {} SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF {}".format(table, condition),
+                               [False, ['foo', 'bar', 'foobar']], cl=cl)
+                    assert_one(cursor, "SELECT * FROM {}".format((table)), [0, ['foo', 'bar', 'foobar']])  # read back at default cl.one
 
                 # should not apply
                 check_does_not_apply("l = ['baz']")
@@ -4313,8 +4315,8 @@ class TestCQL(UpgradeTester):
                 check_does_not_apply("l > ['zzz'] AND l < ['zzz']")
 
                 def check_invalid(condition, expected=InvalidRequest):
-                    assert_invalid(cursor, "UPDATE %s SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF %s" % (table, condition), expected=expected)
-                    assert_one(cursor, "SELECT * FROM %s" % (table,), [0, ['foo', 'bar', 'foobar']])
+                    assert_invalid(cursor, "UPDATE {} SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF {}".format(table, condition), expected=expected)
+                    assert_one(cursor, "SELECT * FROM {}".format(table), [0, ['foo', 'bar', 'foobar']], cl=cl)
 
                 check_invalid("l = [null]")
                 check_invalid("l < null")

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -4267,8 +4267,6 @@ class TestCQL(UpgradeTester):
                 l frozen<list<text>>
             )""")
 
-        cl = getattr(self, 'CL', ConsistencyLevel.ONE)
-
         for is_upgraded, cursor in self.do_upgrade(cursor):
             debug("Querying %s node" % ("upgraded" if is_upgraded else "old",))
             cursor.execute("TRUNCATE tlist")
@@ -4280,7 +4278,7 @@ class TestCQL(UpgradeTester):
                 cursor.execute("INSERT INTO {}(k, l) VALUES (0, ['foo', 'bar', 'foobar'])".format(table))
 
                 def check_applies(condition):
-                    assert_one(cursor, "UPDATE {} SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF {}".format(table, condition), [True], cl=cl)
+                    assert_one(cursor, "UPDATE {} SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF {}".format(table, condition), [True], cl=self.CL)
                     assert_one(cursor, "SELECT * FROM {}".format(table), [0, ['foo', 'bar', 'foobar']])  # read back at default cl.one
 
                 check_applies("l = ['foo', 'bar', 'foobar']")
@@ -4297,7 +4295,7 @@ class TestCQL(UpgradeTester):
 
                 def check_does_not_apply(condition):
                     assert_one(cursor, "UPDATE {} SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF {}".format(table, condition),
-                               [False, ['foo', 'bar', 'foobar']], cl=cl)
+                               [False, ['foo', 'bar', 'foobar']], cl=self.CL)
                     assert_one(cursor, "SELECT * FROM {}".format((table)), [0, ['foo', 'bar', 'foobar']])  # read back at default cl.one
 
                 # should not apply
@@ -4316,7 +4314,7 @@ class TestCQL(UpgradeTester):
 
                 def check_invalid(condition, expected=InvalidRequest):
                     assert_invalid(cursor, "UPDATE {} SET l = ['foo', 'bar', 'foobar'] WHERE k=0 IF {}".format(table, condition), expected=expected)
-                    assert_one(cursor, "SELECT * FROM {}".format(table), [0, ['foo', 'bar', 'foobar']], cl=cl)
+                    assert_one(cursor, "SELECT * FROM {}".format(table), [0, ['foo', 'bar', 'foobar']], cl=self.CL)
 
                 check_invalid("l = [null]")
                 check_invalid("l < null")


### PR DESCRIPTION
write and read back at more appropriate levels
write at cl.all and read back at cl.one

it's possible that this test was failing previously
when a coordinator (and selfsame replica) would defer
to another node at cl.one, allowing a stale data read
and therefore an assertion failure