### PR TITLE
Extended test for CASSANDRA-9043

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -546,19 +546,21 @@ class CqlshCopyTest(Tester):
         self.prepare()
         self.session.execute("""
             CREATE TABLE testcounter (
-                a int primary key,
-                b counter
+                a int,
+                b text,
+                c counter,
+                PRIMARY KEY (a, b)
             )""")
 
         tempfile = self.get_temp_file()
 
-        data = [[1, 20], [2, 40], [3, 60], [4, 80]]
+        data = [[1, '1', 20], [2, '2', 40], [3, '3', 60], [4, '4', 80]]
 
         with open(tempfile.name, 'w') as csvfile:
-            writer = csv.DictWriter(csvfile, fieldnames=['a', 'b'])
+            writer = csv.DictWriter(csvfile, fieldnames=['a', 'b', 'c'])
             writer.writeheader()
-            for a, b in data:
-                writer.writerow({'a': a, 'b': b})
+            for a, b, c in data:
+                writer.writerow({'a': a, 'b': b, 'c': c})
 
         cmds = "COPY ks.testcounter FROM '{name}'".format(name=tempfile.name)
         cmds += " WITH HEADER = true"


### PR DESCRIPTION
I've added a text column to the primary key of `test_reading_counter`, which was introduced by CASSANDRA-9043. For counter tables we need to test values that require quotes as well: there was an issue with missing quotes that was introduced by CASSANDRA-9302 and fixed by CASSANDRA-11053. Unfortunately this problem found its way to a customer and so I would like to ensure this does not happen again in future.