### PR TITLE
Removed known failure for CASSANDRA-11185

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -1774,8 +1774,6 @@ class CqlshCopyTest(Tester):
         do_test(expected_vals_inverted, '.', ',')
 
     @since('3.4')
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11185')
     def test_round_trip_with_sub_second_precision(self):
         """
         Test that we can import and export timestamp values with millisecond precision:


### PR DESCRIPTION
CASSANDRA-11184 and CASSANDRA-11185 have been fixed for quite some time, so I closed them and removed the known failure for CASSANDRA-11185.