### PR TITLE
remove known_failure annotation

### DIFF
--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -226,7 +226,12 @@ class TestReplaceAddress(Tester):
                    flaky=False,
                    notes='fails hard on linux')
     def resumable_replace_test(self):
-        """Test resumable bootstrap while replacing node"""
+        """
+        Test resumable bootstrap while replacing node. Feature introduced in
+        2.2 with ticket https://issues.apache.org/jira/browse/CASSANDRA-8838
+
+        @jira_ticket https://issues.apache.org/jira/browse/CASSANDRA-8838
+        """
 
         cluster = self.cluster
         cluster.populate(3).start()

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -220,11 +220,11 @@ class TestReplaceAddress(Tester):
         debug(movedTokensList[0])
         self.assertEqual(len(movedTokensList), numNodes)
 
-    @since('2.2')
     @known_failure(failure_source='test',
                    jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11376',
                    flaky=False,
                    notes='fails hard on linux')
+    @since('2.2')
     def resumable_replace_test(self):
         """
         Test resumable bootstrap while replacing node. Feature introduced in

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -221,6 +221,10 @@ class TestReplaceAddress(Tester):
         self.assertEqual(len(movedTokensList), numNodes)
 
     @since('2.2')
+    @known_failure(failure_source='test',
+                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11376',
+                   flaky=False,
+                   notes='fails hard on linux')
     def resumable_replace_test(self):
         """Test resumable bootstrap while replacing node"""
 

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -221,9 +221,6 @@ class TestReplaceAddress(Tester):
         self.assertEqual(len(movedTokensList), numNodes)
 
     @since('2.2')
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-9831',
-                   flaky=True)
     def resumable_replace_test(self):
         """Test resumable bootstrap while replacing node"""
 


### PR DESCRIPTION
Removing the annotation since the ticket was closed. Do we know why we skip this pre-2.2? If it hangs or something we should skip it.