### PR TITLE
Fix node start in crash_during_decommission

### DIFF
--- a/topology_test.py
+++ b/topology_test.py
@@ -208,10 +208,6 @@ class TestTopology(Tester):
 
         self.assertFalse(node3.is_running())
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11377',
-                   flaky=True,
-                   notes="flaps when a node doesn't come up")
     @since('3.0')
     def crash_during_decommission_test(self):
         """
@@ -236,7 +232,7 @@ class TestTopology(Tester):
                 break
             debug("Restarting node2")
             node2.stop(gently=False)
-            node2.start(wait_for_binary_proto=True)
+            node2.start(wait_for_binary_proto=True, wait_other_notice=False)
 
         debug("Waiting for decommission to complete")
         t.join()


### PR DESCRIPTION
Node1 is being decommissioned while we restart node2. thus we
cannot guarantee that node1 will be alive to detect node2 is up.
So we must start node2 with wait_other_notice=False each time

@mambocab or @knifewine to review