### PR TITLE
Remove known failure from sstable_repairedset_test after CASSANDRA-11317

### DIFF
--- a/repair_tests/incremental_repair_test.py
+++ b/repair_tests/incremental_repair_test.py
@@ -146,10 +146,6 @@ class TestIncRepair(Tester):
 
         assert_one(session, "SELECT COUNT(*) FROM ks.cf LIMIT 200", [149])
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11317',
-                   flaky=False,
-                   notes='fails on linux on C* 2.2')
     def sstable_repairedset_test(self):
         """
         * Launch a two node cluster


### PR DESCRIPTION
This PR removes the known_failure annotation from sstable_repairedset_test in incremental_repair_test.py.

[History for sstable_repairedset_test](http://cassci.datastax.com/job/cassandra-2.2_dtest/552/testReport/repair_tests.incremental_repair_test/TestIncRepair/sstable_repairedset_test/history/) shows this has been passing for 3 runs now.

CASSANDRA-9598 solved the issue by making cassandra.yaml available on the classpath, so that sstablerepairedset no longer fails on loading config.