### PR TITLE
join_ring=False also needs wait_other_notice=False

### DIFF
--- a/cql_tests.py
+++ b/cql_tests.py
@@ -636,7 +636,7 @@ class AbortedQueriesTester(CQLTester):
         cluster.populate(2)
         node1, node2 = cluster.nodelist()
 
-        node1.start(wait_for_binary_proto=True, join_ring=False)  # ensure other node executes queries
+        node1.start(wait_for_binary_proto=True, join_ring=False, wait_other_notice=False)  # ensure other node executes queries
         node2.start(wait_for_binary_proto=True,
                     jvm_args=["-Dcassandra.monitoring_check_interval_ms=50",
                               "-Dcassandra.test.read_iteration_delay_ms=1500"])  # see above for explanation
@@ -744,7 +744,7 @@ class AbortedQueriesTester(CQLTester):
         cluster.populate(2)
         node1, node2 = cluster.nodelist()
 
-        node1.start(wait_for_binary_proto=True, join_ring=False)  # ensure other node executes queries
+        node1.start(wait_for_binary_proto=True, join_ring=False, wait_other_notice=False)  # ensure other node executes queries
         node2.start(wait_for_binary_proto=True,
                     jvm_args=["-Dcassandra.monitoring_check_interval_ms=50",
                               "-Dcassandra.test.read_iteration_delay_ms=1500"])  # see above for explanation

--- a/topology_test.py
+++ b/topology_test.py
@@ -20,7 +20,7 @@ class TestTopology(Tester):
         cluster = self.cluster.populate(1)
         node1, = cluster.nodelist()
 
-        node1.start(wait_for_binary_proto=True, join_ring=False,
+        node1.start(wait_for_binary_proto=True, join_ring=False, wait_other_notice=False,
                     jvm_args=["-Dcassandra.size_recorder_interval=1"])
 
         # initial delay is 30s


### PR DESCRIPTION
A node started with "-Dcassandra.join_ring=false" will not get recognised as UP by the other nodes.

That is `node.start(join_ring=False)` needs to be `node.start(join_ring=False, wait_other_notice=False)`

ref:
 - https://github.com/pcmanus/ccm/pull/479
 - http://cassci.datastax.com/job/trunk_dtest/1076/testReport/