### PR TITLE
Skip all 6+ node tests on CI

### DIFF
--- a/conf/cassandra-2.1_test-select.cfg
+++ b/conf/cassandra-2.1_test-select.cfg
@@ -1,1 +1,14 @@
 [exclude]
+# Subsequent repair is a long test, ~40-50 minutes
+incremental_repair_test.py:TestIncRepair.multiple_subsequent_repair_test
+  tools.py:TestIncRepair.multiple_subsequent_repair_test
+consistency_test.py:TestAvailability.test_network_topology_strategy
+consistency_test.py:TestAvailability.test_network_topology_strategy_each_quorum
+  tools.py:TestAvailability.test_network_topology_strategy_each_quorum
+consistency_test.py:TestAccuracy.test_network_topology_strategy_users
+consistency_test.py:TestAccuracy.test_network_topology_strategy_each_quorum_users
+  tools.py:TestAccuracy.test_network_topology_strategy_each_quorum_users
+consistency_test.py:TestAccuracy.test_network_topology_strategy_each_quorum_counters
+  tools.py:TestAccuracy.test_network_topology_strategy_each_quorum_counters
+consistency_test.py:TestAccuracy.test_network_topology_strategy_counters
+

--- a/conf/cassandra-2.2_test-select.cfg
+++ b/conf/cassandra-2.2_test-select.cfg
@@ -1,1 +1,14 @@
 [exclude]
+# Subsequent repair is a long test, ~40-50 minutes
+incremental_repair_test.py:TestIncRepair.multiple_subsequent_repair_test
+  tools.py:TestIncRepair.multiple_subsequent_repair_test
+consistency_test.py:TestAvailability.test_network_topology_strategy
+consistency_test.py:TestAvailability.test_network_topology_strategy_each_quorum
+  tools.py:TestAvailability.test_network_topology_strategy_each_quorum
+consistency_test.py:TestAccuracy.test_network_topology_strategy_users
+consistency_test.py:TestAccuracy.test_network_topology_strategy_each_quorum_users
+  tools.py:TestAccuracy.test_network_topology_strategy_each_quorum_users
+consistency_test.py:TestAccuracy.test_network_topology_strategy_each_quorum_counters
+  tools.py:TestAccuracy.test_network_topology_strategy_each_quorum_counters
+consistency_test.py:TestAccuracy.test_network_topology_strategy_counters
+

--- a/conf/trunk_test-select.cfg
+++ b/conf/trunk_test-select.cfg
@@ -1,1 +1,13 @@
 [exclude]
+# Subsequent repair is a long test, ~40-50 minutes
+incremental_repair_test.py:TestIncRepair.multiple_subsequent_repair_test
+  tools.py:TestIncRepair.multiple_subsequent_repair_test
+consistency_test.py:TestAvailability.test_network_topology_strategy
+consistency_test.py:TestAvailability.test_network_topology_strategy_each_quorum
+  tools.py:TestAvailability.test_network_topology_strategy_each_quorum
+consistency_test.py:TestAccuracy.test_network_topology_strategy_users
+consistency_test.py:TestAccuracy.test_network_topology_strategy_each_quorum_users
+  tools.py:TestAccuracy.test_network_topology_strategy_each_quorum_users
+consistency_test.py:TestAccuracy.test_network_topology_strategy_each_quorum_counters
+  tools.py:TestAccuracy.test_network_topology_strategy_each_quorum_counters
+consistency_test.py:TestAccuracy.test_network_topology_strategy_counters

--- a/consistency_test.py
+++ b/consistency_test.py
@@ -12,7 +12,7 @@ from cassandra.query import SimpleStatement
 from assertions import assert_none, assert_unavailable
 from dtest import DISABLE_VNODES, Tester, debug
 from tools import (create_c1c2_table, insert_c1c2, insert_columns,
-                   known_failure, query_c1c2, require, rows_to_list, since)
+                   known_failure, query_c1c2, rows_to_list, since)
 
 
 class TestHelper(Tester):
@@ -306,11 +306,6 @@ class TestAvailability(TestHelper):
 
         self._test_simple_strategy(combinations)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11438',
-                   flaky=True,
-                   notes='Fails on CI because too many nodes started')
-    @require(11438)
     def test_network_topology_strategy(self):
         """
         Test for multiple datacenters, using network topology replication strategy.
@@ -342,12 +337,7 @@ class TestAvailability(TestHelper):
 
         self._test_network_topology_strategy(combinations)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11438',
-                   flaky=True,
-                   notes='Fails on CI because too many nodes started')
     @since("3.0")
-    @require(11438)
     def test_network_topology_strategy_each_quorum(self):
         """
         @jira_ticket CASSANDRA-10584
@@ -576,11 +566,6 @@ class TestAccuracy(TestHelper):
         self.log("Testing single dc, users, each quorum reads")
         self._run_test_function_in_parallel(TestAccuracy.Validation.validate_users, [self.nodes], [self.rf], combinations)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11438',
-                   flaky=True,
-                   notes='Fails on CI because too many nodes started')
-    @require(11438)
     def test_network_topology_strategy_users(self):
         """
         Test for multiple datacenters, users table.
@@ -616,12 +601,7 @@ class TestAccuracy(TestHelper):
         self.log("Testing multiple dcs, users")
         self._run_test_function_in_parallel(TestAccuracy.Validation.validate_users, self.nodes, self.rf.values(), combinations),
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11438',
-                   flaky=True,
-                   notes='Fails on CI because too many nodes started')
     @since("3.0")
-    @require(11438)
     def test_network_topology_strategy_each_quorum_users(self):
         """
         @jira_ticket CASSANDRA-10584
@@ -688,10 +668,6 @@ class TestAccuracy(TestHelper):
         self.log("Testing single dc, counters, each quorum reads")
         self._run_test_function_in_parallel(TestAccuracy.Validation.validate_counters, [self.nodes], [self.rf], combinations)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11438',
-                   flaky=True,
-                   notes='Fails on CI because too many nodes started')
     def test_network_topology_strategy_counters(self):
         """
         Test for multiple datacenters, counters table.


### PR DESCRIPTION
@mambocab and @exlt to review.

Testing here:
http://cassci.datastax.com/view/Dev/view/ptnapoleon/job/ptnapoleon-cassandra-2.1-dtest/12/console

All job configs will need changed to use the fast-select.cfg instead of test-select.cfg