### PR TITLE
sleep before getting sstables after flush

### DIFF
--- a/scrub_test.py
+++ b/scrub_test.py
@@ -124,7 +124,7 @@ class TestHelper(Tester):
         in a dict keyed by the table or index name.
         """
         self.perform_node_tool_cmd('flush', table, indexes)
-        time.sleep(.1)
+        time.sleep(1)
         return self.get_sstables(table, indexes)
 
     def scrub(self, table, *indexes):

--- a/scrub_test.py
+++ b/scrub_test.py
@@ -124,6 +124,7 @@ class TestHelper(Tester):
         in a dict keyed by the table or index name.
         """
         self.perform_node_tool_cmd('flush', table, indexes)
+        time.sleep(.1)
         return self.get_sstables(table, indexes)
 
     def scrub(self, table, *indexes):


### PR DESCRIPTION
This was added in the scrub method in `ee436c340946240ff4995277d5114db59b8bfd5d`, and maybe should be added here as well. This is to attempt to address https://issues.apache.org/jira/browse/CASSANDRA-11446.