### PR TITLE
UDTs prior to 7423 should always be frozen

### DIFF
--- a/user_functions_test.py
+++ b/user_functions_test.py
@@ -223,7 +223,7 @@ class TestUserFunctions(Tester):
         if LooseVersion(self.cluster.version()) >= LooseVersion('3.6'):
             frozen_vals = (False, True)
         else:
-            frozen_vals = (False,)
+            frozen_vals = (True,)
 
         for frozen in frozen_vals:
             debug("Using {} UDTs".format("frozen" if frozen else "non-frozen"))


### PR DESCRIPTION
Boolean condition was accidentally negated

Fixes bug in #829 