### PR TITLE
Commitlog test debugging and path getting refactor

### DIFF
--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -211,7 +211,7 @@ class TestCommitLog(Tester):
         debug("Verify commit log was replayed on startup")
         node1.start()
         node1.watch_log_for("Log replay complete")
-        # Here we verify there was more than 0 replayed mutations
+        # Here we verify there were more than 0 replayed mutations
         zero_replays = node1.grep_log(" 0 replayed mutations")
         self.assertEqual(0, len(zero_replays))
 
@@ -298,12 +298,14 @@ class TestCommitLog(Tester):
         self.assertTrue(self.node1.is_running(), "Node1 should still be running")
 
         # Cannot write anymore after the failure
+        debug('attempting to insert to node with failing commitlog; should fail')
         with self.assertRaises((OperationTimedOut, WriteTimeout)):
             self.session1.execute("""
               INSERT INTO test (key, col1) VALUES (2, 2);
             """)
 
         # Should be able to read
+        debug('attempting to read from node with failing commitlog; should succeed')
         assert_one(
             self.session1,
             "SELECT * FROM test where key=2;",

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -110,7 +110,7 @@ class TestCommitLog(Tester):
         time.sleep(1)
 
         commitlogs = self._get_commitlog_files()
-        self.assertTrue(len(commitlogs) > 0, "No commit log files were created")
+        self.assertGreater(len(commitlogs), 0, 'No commit log files were created')
 
         # the most recently-written segment of the commitlog may be smaller
         # than the expected size, so we allow exactly one segment to be smaller

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -78,21 +78,6 @@ class TestCommitLog(Tester):
         path = self._get_commitlog_path()
         return [os.path.join(path, p) for p in os.listdir(path)]
 
-    def _get_commitlog_size(self):
-        """
-        Returns the commitlog directory size in MB
-        """
-        path = self._get_commitlog_path()
-        cmd_args = ['du', '-m', path]
-        p = subprocess.Popen(cmd_args, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-        stdout, stderr = p.communicate()
-        exit_status = p.returncode
-        self.assertEqual(0, exit_status,
-                         "du exited with a non-zero status: %d" % exit_status)
-        size = int(stdout.split('\t')[0])
-        return size
-
     def _segment_size_test(self, segment_size_in_mb, compressed=False):
         """
         Execute a basic commitlog test and validate the commitlog files

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -120,6 +120,7 @@ class TestCommitLog(Tester):
             size_in_mb = int(size / 1024 / 1024)
             debug('segment file {} {}; smaller already found: {}'.format(f, size_in_mb, smaller_found))
             if size_in_mb < 1 or size < (segment_size * 0.1):
+                debug('segment file not yet used; moving to next file')
                 continue  # commitlog not yet used
 
             try:

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -132,7 +132,7 @@ class TestCommitLog(Tester):
                     # if no compression is used, the size will be close to what we expect
                     assert_almost_equal(size, segment_size, error=0.05)
             except AssertionError as e:
-                #  the last segment may be smaller
+                # the last segment may be smaller
                 if not smaller_found:
                     self.assertLessEqual(size, segment_size)
                     smaller_found = True

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -89,7 +89,7 @@ class TestCommitLog(Tester):
 
     def _get_commitlog_files(self):
         """
-        Returns the number of commitlog files in the directory
+        Returns the paths to commitlog files
         """
         return [os.path.join(path, filename)
                 for path in self._get_commitlog_paths()


### PR DESCRIPTION
A couple major internal API changes:

- removes unused size-getting method
- changes the commitlog-dir-getting code to return a list, since commitlogs are going to be in `{data}/commitlogs` and `{data}/cdc` now

as well as some some small cleanup changes