### PR TITLE
Fix 11608

### DIFF
--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -5,7 +5,7 @@ from cassandra.query import SimpleStatement
 from ccmlib.node import Node, NodeError
 
 from dtest import DISABLE_VNODES, Tester, debug
-from tools import InterruptBootstrap, known_failure, since
+from tools import InterruptBootstrap, since
 
 
 class NodeUnavailable(Exception):
@@ -151,10 +151,6 @@ class TestReplaceAddress(Tester):
 
         self.assertFalse(node.is_running())
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11608',
-                   flaky=True,
-                   notes='flapped on offheap job on 2.2')
     def replace_first_boot_test(self):
         debug("Starting cluster with 3 nodes.")
         cluster = self.cluster
@@ -213,7 +209,7 @@ class TestReplaceAddress(Tester):
 
         # restart node4 (if error's might have to change num_tokens)
         node4.stop(gently=False)
-        node4.start(wait_for_binary_proto=True)
+        node4.start(wait_for_binary_proto=True, wait_other_notice=False)
 
         debug("Verifying querying works again.")
         finalData = list(session.execute(query))


### PR DESCRIPTION
The problem is that when we don't gently stop the node, and we immediately start it right back up, the other nodes sometimes don't even notice it was down in the first place! This means the fact that we were waiting for other notice was bad, because that doesn't happen in that case.

@mambocab  or @knifewine to review. I ran this 500 times and it fixes the issue.