### PR TITLE
Fix commitlog replay test

### DIFF
--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -200,13 +200,7 @@ class TestCommitLog(Tester):
         self.assertTrue(len(commitlog_files) > 0)
 
         debug("Verify no SSTables were flushed before abrupt stop")
-        for data_dir in node1.data_directories():
-            cf_id = [s for s in os.listdir(os.path.join(data_dir, "test")) if s.startswith("users")][0]
-            cf_data_dir = glob.glob("{data_dir}/test/{cf_id}".format(**locals()))[0]
-            cf_data_dir_files = os.listdir(cf_data_dir)
-            if "backups" in cf_data_dir_files:
-                cf_data_dir_files.remove("backups")
-            self.assertEqual(0, len(cf_data_dir_files))
+        self.assertEqual(0, len(node1.get_sstables('test', 'users')))
 
         debug("Verify commit log was replayed on startup")
         node1.start()

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -10,6 +10,7 @@ from cassandra import WriteTimeout
 from cassandra.cluster import NoHostAvailable, OperationTimedOut
 from ccmlib.common import is_win
 from ccmlib.node import Node, TimeoutError
+from parse import parse
 
 from assertions import assert_almost_equal, assert_none, assert_one
 from dtest import Tester, debug
@@ -205,9 +206,15 @@ class TestCommitLog(Tester):
         debug("Verify commit log was replayed on startup")
         node1.start()
         node1.watch_log_for("Log replay complete")
-        # Here we verify there were more than 0 replayed mutations
-        zero_replays = node1.grep_log(" 0 replayed mutations")
-        self.assertEqual(0, len(zero_replays))
+        # Here we verify from the logs that some mutations were replayed
+        replays = [match_tuple[0] for match_tuple in node1.grep_log(" \d+ replayed mutations")]
+        debug('The following log lines indicate that mutations were replayed: {msgs}'.format(msgs=replays))
+        num_replayed_mutations = [
+            parse('{} {num_mutations:d} replayed mutations{}', line).named['num_mutations']
+            for line in replays
+        ]
+        # assert there were some lines where more than zero mutations were replayed
+        self.assertNotEqual([m for m in num_replayed_mutations if m > 0], [])
 
         debug("Make query and ensure data is present")
         session = self.patient_cql_connection(node1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ flaky
 futures
 nose
 nose-test-select
+parse
 psutil
 pycassa
 six


### PR DESCRIPTION
DON'T MERGE UNTIL WE'VE UPDATED DEPENDENCIES IN OUR INSTALL SCRIPTS.

I have a few concerns about this one.

- @ptnapoleon Could you please run this test on Windows to make sure `parse` behaves the way we expect?
- I'm worried about the change in SSTable-grabbing code -- I don't think there was a reason to write custom to grab SSTables. Can someone confirm?

I'm actually quite happy with the way the log-checking code turned out. Of course, please have a good hard look at it. Asking for reviews from both @ptnapoleon and @knifewine please.
