### PR TITLE
new upgrade version logic

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -23,7 +23,8 @@ from thrift_bindings.v22.ttypes import (CfDef, Column, ColumnOrSuperColumn,
                                         Mutation)
 from thrift_tests import get_thrift_client
 from tools import known_failure, require, rows_to_list, since
-from upgrade_base import UPGRADE_TEST_RUN, VALID_UPGRADE_PAIRS, UpgradeTester
+from upgrade_base import UPGRADE_TEST_RUN, UpgradeTester
+from upgrade_manifest import build_upgrade_pairs
 
 
 class TestCQL(UpgradeTester):
@@ -5260,7 +5261,7 @@ topology_specs = [
      'RF': 1},
 ]
 specs = [dict(s, UPGRADE_PATH=p, __test__=UPGRADE_TEST_RUN)
-         for s, p in itertools.product(topology_specs, VALID_UPGRADE_PAIRS)]
+         for s, p in itertools.product(topology_specs, build_upgrade_pairs())]
 
 for spec in specs:
     suffix = 'Nodes{num_nodes}RF{rf}_{pathname}'.format(num_nodes=spec['NODES'],

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -10,7 +10,8 @@ from cassandra.query import SimpleStatement, dict_factory, named_tuple_factory
 from datahelp import create_rows, flatten_into_set, parse_data_into_dicts
 from dtest import debug, run_scenarios
 from tools import known_failure, rows_to_list, since
-from upgrade_base import UPGRADE_TEST_RUN, VALID_UPGRADE_PAIRS, UpgradeTester
+from upgrade_base import UPGRADE_TEST_RUN, UpgradeTester
+from upgrade_manifest import build_upgrade_pairs
 
 
 def assert_read_timeout_or_failure(session, query):
@@ -1722,7 +1723,7 @@ topology_specs = [
 ]
 
 specs = [dict(s, UPGRADE_PATH=p, __test__=UPGRADE_TEST_RUN)
-         for s, p in itertools.product(topology_specs, VALID_UPGRADE_PAIRS)]
+         for s, p in itertools.product(topology_specs, build_upgrade_pairs())]
 
 for klaus in BasePagingTester.__subclasses__():
     for spec in specs:

--- a/upgrade_tests/regression_test.py
+++ b/upgrade_tests/regression_test.py
@@ -4,7 +4,8 @@ Home for upgrade-related tests that don't fit in with the core upgrade testing i
 from cassandra import ConsistencyLevel as CL
 
 from tools import known_failure
-from upgrade_base import UPGRADE_TEST_RUN, VALID_UPGRADE_PAIRS, UpgradeTester
+from upgrade_base import UPGRADE_TEST_RUN, UpgradeTester
+from upgrade_manifest import build_upgrade_pairs
 
 
 class TestForRegressions(UpgradeTester):
@@ -60,7 +61,7 @@ class TestForRegressions(UpgradeTester):
                 self.assertEqual(count, expected_rows, "actual {} did not match expected {}".format(count, expected_rows))
 
 
-for path in VALID_UPGRADE_PAIRS:
+for path in build_upgrade_pairs():
     gen_class_name = TestForRegressions.__name__ + path.name
     assert gen_class_name not in globals(), gen_class_name
     spec = {'UPGRADE_PATH': path,

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -3,7 +3,6 @@ import re
 import sys
 import time
 from abc import ABCMeta
-from collections import namedtuple
 from distutils.version import LooseVersion
 from unittest import skipIf
 
@@ -14,48 +13,6 @@ from dtest import DEBUG, Tester, debug
 UPGRADE_TEST_RUN = os.environ.get('UPGRADE_TEST_RUN', '').lower() in {'true', 'yes'}
 
 
-UpgradePath = namedtuple('UpgradePath', ('name', 'starting_version', 'upgrade_version'))
-
-
-# these should be latest tentative tags, falling back to the most recent release if no pending tentative
-latest_2dot0 = '2.0.17'
-latest_2dot1 = '2.1.13'
-latest_2dot2 = '2.2.5'
-latest_3dot0 = '3.0.3'
-latest_3dot1 = '3.1.1'
-latest_3dot2 = '3.2.1'
-latest_3dot3 = '3.3'
-
-head_2dot0 = 'git:cassandra-2.0'
-head_2dot1 = 'git:cassandra-2.1'
-head_2dot2 = 'git:cassandra-2.2'
-head_3dot0 = 'git:cassandra-3.0'
-head_3dot1 = 'git:cassandra-3.1'
-head_3dot2 = 'git:cassandra-3.2'
-head_3dot3 = 'git:cassandra-3.3'
-head_trunk = 'git:trunk'
-
-
-VALID_UPGRADE_PAIRS = (
-    # commented out until we have a solution for specifying java versions in upgrade tests
-    # UpgradePath(name='2_0_UpTo_2_1_HEAD', starting_version=latest_2dot0, upgrade_version='git:cassandra-2.1'),
-    UpgradePath(name='2_1_UpTo_2_2_HEAD', starting_version=latest_2dot1, upgrade_version=head_2dot2),
-    UpgradePath(name='2_1_UpTo_3_0_HEAD', starting_version=latest_2dot1, upgrade_version=head_3dot0),
-    UpgradePath(name='2_1_UpTo_3_3_HEAD', starting_version=latest_2dot1, upgrade_version=head_3dot3),
-    UpgradePath(name='2_1_UpTo_Trunk', starting_version=latest_2dot1, upgrade_version=head_trunk),
-    UpgradePath(name='2_2_UpTo_3_0_HEAD', starting_version=latest_2dot2, upgrade_version=head_3dot0),
-    UpgradePath(name='2_2_UpTo_3_3_HEAD', starting_version=latest_2dot2, upgrade_version=head_3dot3),
-    UpgradePath(name='2_2_UpTo_Trunk', starting_version=latest_2dot2, upgrade_version=head_trunk),
-    UpgradePath(name='2_1_HEAD_UpTo_2_2', starting_version=head_2dot1, upgrade_version=latest_2dot2),
-    UpgradePath(name='2_1_HEAD_UpTo_3_0', starting_version=head_2dot1, upgrade_version=latest_3dot0),
-    UpgradePath(name='2_2_HEAD_UpTo_3_0', starting_version=head_2dot2, upgrade_version=latest_3dot0),
-    UpgradePath(name='2_1_HEAD_UpTo_Trunk', starting_version=head_2dot1, upgrade_version=head_trunk),
-    UpgradePath(name='2_2_HEAD_UpTo_Trunk', starting_version=head_2dot2, upgrade_version=head_trunk),
-    UpgradePath(name='3_0_UpTo_Trunk', starting_version=latest_3dot0, upgrade_version=head_trunk),
-    UpgradePath(name='3_2_UpTo_Trunk', starting_version=latest_3dot2, upgrade_version=head_trunk),
-)
-
-
 def sanitize_version(version, allow_ambiguous=True):
     """
     Takes version of the form cassandra-1.2, 2.0.10, or trunk.
@@ -64,7 +21,7 @@ def sanitize_version(version, allow_ambiguous=True):
     If allow_ambiguous is False, will raise RuntimeError if no version is found.
     """
     if (version == 'git:trunk') or (version == 'trunk'):
-        return LooseVersion(head_trunk)
+        return LooseVersion('git:trunk')
 
     match = re.match('^.*(\d+\.+\d+\.*\d*).*$', unicode(version))
     if match:

--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -1,0 +1,116 @@
+from collections import namedtuple
+
+from dtest import debug
+
+# UpgradePath's contain data about upgrade paths we wish to test
+# They also contain VersionMeta's for each version the path is testing
+UpgradePath = namedtuple('UpgradePath', ('name', 'starting_version', 'upgrade_version', 'starting_meta', 'upgrade_meta'))
+
+# VersionMeta's capture data about version lines, protocols supported, and current version identifiers
+# they should have a 'variant' value of 'current', 'indev', or 'next':
+#    'current' means most recent released version, 'indev' means where changing code is found, 'next' means a tentative tag
+VersionMeta = namedtuple('VersionMeta', ('name', 'variant', 'version', 'min_proto_v', 'max_proto_v'))
+
+indev_2_0_x = None  # None if release not likely
+current_2_0_x = VersionMeta(name='current_2_0_x', variant='current', version='2.0.17', min_proto_v=1, max_proto_v=2)
+next_2_0_x = None  # None if not yet tagged
+
+indev_2_1_x = VersionMeta(name='indev_2_1_x', variant='indev', version='git:cassandra-2.1', min_proto_v=1, max_proto_v=3)
+current_2_1_x = VersionMeta(name='current_2_1_x', variant='current', version='2.1.14', min_proto_v=1, max_proto_v=3)
+next_2_1_x = None  # None if not yet tagged
+
+indev_2_2_x = VersionMeta(name='indev_2_2_x', variant='indev', version='git:cassandra-2.2', min_proto_v=1, max_proto_v=4)
+current_2_2_x = VersionMeta(name='current_2_2_x', variant='current', version='2.2.6', min_proto_v=1, max_proto_v=4)
+next_2_2_x = None  # None if not yet tagged
+
+indev_3_0_x = VersionMeta(name='indev_3_0_x', variant='indev', version='git:cassandra-3.0', min_proto_v=3, max_proto_v=4)
+current_3_0_x = VersionMeta(name='current_3_0_x', variant='current', version='3.0.5', min_proto_v=3, max_proto_v=4)
+next_3_0_x = None  # None if not yet tagged
+
+indev_3_x = VersionMeta(name='indev_3_x', variant='indev', version='git:cassandra-3.7', min_proto_v=3, max_proto_v=4)
+current_3_x = VersionMeta(name='current_3_x', variant='current', version='3.5', min_proto_v=3, max_proto_v=4)
+next_3_x = None  # None if not yet tagged
+
+head_trunk = VersionMeta(name='head_trunk', variant='indev', version='git:trunk', min_proto_v=3, max_proto_v=4)
+
+
+# maps an VersionMeta representing a line/variant to a list of other VersionMeta's representing supported upgrades
+MANIFEST = {
+    # commented out until we have a solution for specifying java versions in upgrade tests
+    # indev_2_0_x:                [indev_2_1_x, current_2_1_x, next_2_1_x],
+    # current_2_0_x: [indev_2_0_x, indev_2_1_x, current_2_1_x, next_2_1_x],
+    # next_2_0_x:                 [indev_2_1_x, current_2_1_x, next_2_1_x],
+
+    indev_2_1_x:                [indev_2_2_x, current_2_2_x, next_2_2_x, indev_3_0_x, current_3_0_x, next_3_0_x, indev_3_x, current_3_x, next_3_x, head_trunk],
+    current_2_1_x: [indev_2_1_x, indev_2_2_x, current_2_2_x, next_2_2_x, indev_3_0_x, current_3_0_x, next_3_0_x, indev_3_x, current_3_x, next_3_x, head_trunk],
+    next_2_1_x:                 [indev_2_2_x, current_2_2_x, next_2_2_x, indev_3_0_x, current_3_0_x, next_3_0_x, indev_3_x, current_3_x, next_3_x, head_trunk],
+
+    indev_2_2_x:                [indev_3_0_x, current_3_0_x, next_3_0_x, indev_3_x, current_3_x, next_3_x, head_trunk],
+    current_2_2_x: [indev_2_2_x, indev_3_0_x, current_3_0_x, next_3_0_x, indev_3_x, current_3_x, next_3_x, head_trunk],
+    next_2_2_x:                 [indev_3_0_x, current_3_0_x, next_3_0_x, indev_3_x, current_3_x, next_3_x, head_trunk],
+
+    indev_3_0_x:                [indev_3_x, current_3_x, next_3_x, head_trunk],
+    current_3_0_x: [indev_3_0_x, indev_3_x, current_3_x, next_3_x, head_trunk],
+    next_3_0_x:                 [indev_3_x, current_3_x, next_3_x, head_trunk],
+
+    indev_3_x:              [head_trunk],
+    current_3_x: [indev_3_x, head_trunk],
+    next_3_x:               [head_trunk],
+}
+
+
+def _have_common_proto(origin_meta, destination_meta):
+    """
+    Takes two VersionMeta objects, in order of test from start version to next version.
+    Returns a boolean indicating if the given VersionMetas have a common protocol version.
+    """
+    return origin_meta.max_proto_v >= destination_meta.min_proto_v
+
+
+def _is_targeted_variant_combo(origin_meta, destination_meta):
+    """
+    Takes two VersionMeta objects, in order of test from start version to next version.
+    Returns a boolean indicating if this is a test pair we care about.
+
+    for now we only test upgrades of these types:
+      current -> in-dev (aka: released -> branch)
+      current -> next (aka: released -> proposed release point)
+      next -> in-dev (aka: proposed release point -> branch)
+    """
+    return (origin_meta.variant == 'current' and destination_meta.variant == 'indev')\
+        or (origin_meta.variant == 'current' and destination_meta.variant == 'next')\
+        or (origin_meta.variant == 'next' and destination_meta.variant == 'indev')
+
+
+def build_upgrade_pairs():
+    """
+    Using the manifest (above), builds a set of valid upgrades, according to current testing practices.
+
+    Returns a list of UpgradePath's.
+    """
+    valid_upgrade_pairs = []
+    for origin_meta, destination_metas in MANIFEST.items():
+        for destination_meta in destination_metas:
+            if not (origin_meta and destination_meta):  # None means we don't care about that version, which means we don't care about iterations involving it either
+                debug("skipping class creation as a version is undefined (this is normal), versions: {} and {}".format(origin_meta, destination_meta))
+                continue
+
+            if not _is_targeted_variant_combo(origin_meta, destination_meta):
+                debug("skipping class creation, no testing of '{}' to '{}' (for {} upgrade to {})".format(origin_meta.variant, destination_meta.variant, origin_meta.name, destination_meta.name))
+                continue
+
+            if not _have_common_proto(origin_meta, destination_meta):
+                debug("skipping class creation, no compatible protocol version between {} and {}".format(origin_meta.name, destination_meta.name))
+                continue
+
+            valid_upgrade_pairs.append(
+                    UpgradePath(
+                        name='Upgrade_' + origin_meta.name + '_To_' + destination_meta.name,
+                        starting_version=origin_meta.version,
+                        upgrade_version=destination_meta.version,
+                        starting_meta=origin_meta,
+                        upgrade_meta=destination_meta
+                    )
+            )
+
+    return valid_upgrade_pairs

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -795,14 +795,14 @@ MULTI_UPGRADES = (
     MultiUpgrade(name='ProtoV1Upgrade_AllVersions_RandomPartitioner_EndsAt_indev_2_2_x',
                  version_metas=[current_2_0_x, current_2_1_x, indev_2_2_x], protocol_version=1,
                  extra_config=(
-                    ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
+                     ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
                  )),
     MultiUpgrade(name='ProtoV1Upgrade_AllVersions_EndsAt_next_2_2_x',
                  version_metas=[current_2_0_x, current_2_1_x, next_2_2_x], protocol_version=1, extra_config=None),
     MultiUpgrade(name='ProtoV1Upgrade_AllVersions_RandomPartitioner_EndsAt_indev_2_2_x',
                  version_metas=[current_2_0_x, current_2_1_x, next_2_2_x], protocol_version=1,
                  extra_config=(
-                    ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
+                     ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
                  )),
 
     # Proto v2 upgrades (v2 is supported on 2.0, 2.1, 2.2)
@@ -811,7 +811,7 @@ MULTI_UPGRADES = (
     MultiUpgrade(name='ProtoV2Upgrade_AllVersions_RandomPartitioner_EndsAt_indev_2_2_x',
                  version_metas=[current_2_0_x, current_2_1_x, indev_2_2_x], protocol_version=2,
                  extra_config=(
-                    ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
+                     ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
                  )),
     MultiUpgrade(name='ProtoV2Upgrade_AllVersions_EndsAt_next_2_2x',
                  version_metas=[current_2_0_x, current_2_1_x, next_2_2_x], protocol_version=2, extra_config=None),
@@ -836,7 +836,7 @@ MULTI_UPGRADES = (
     MultiUpgrade(name='ProtoV4Upgrade_AllVersions_RandomPartitioner_EndsAt_Trunk_HEAD',
                  version_metas=[current_2_2_x, current_3_0_x, head_trunk], protocol_version=4,
                  extra_config=(
-                    ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
+                     ('partitioner', 'org.apache.cassandra.dht.RandomPartitioner'),
                  )),
 )
 


### PR DESCRIPTION
(mostly) unites test class generation between
the upgrade_through_version tests and the other upgrade
tests of mixed version clusters.

introduces clearer metaphors and makes test coverage
more explicit with the concept of indev, current, and next
for each version.

generative approach to tests using a manifest or starting
versions to all possible upgraded-to versions