### PR TITLE
upgrades: add java version awareness

### DIFF
--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -16,15 +16,18 @@ def switch_jdks(major_version_int):
     Changes the jdk version globally, by setting JAVA_HOME = JAVA[N]_HOME.
     This means the environment must have JAVA[N]_HOME set to switch to jdk version N.
     """
+    new_java_home = 'JAVA{}_HOME'.format(major_version_int)
+
     try:
-        os.environ['JAVA{}_HOME'.format(major_version_int)]
+        os.environ[new_java_home]
     except KeyError:
-        raise RuntimeError("You need to set JAVA{}_HOME to run these tests!".format(major_version_int))
+        raise RuntimeError("You need to set {} to run these tests!".format(new_java_home))
 
     # don't change if the same version was requested
-    if os.environ.get('JAVA_HOME') != os.environ['JAVA{}_HOME'.format(major_version_int)]:
-        debug("Switching jdk to {}".format(major_version_int))
-        os.environ['JAVA_HOME'] = os.environ['JAVA{}_HOME'.format(major_version_int)]
+    current_java_home = os.environ.get('JAVA_HOME')
+    if current_java_home != os.environ[new_java_home]:
+        debug("Switching jdk to version {} (JAVA_HOME is changing from {} to {})".format(major_version_int, current_java_home or 'undefined', os.environ[new_java_home]))
+        os.environ['JAVA_HOME'] = os.environ[new_java_home]
 
 
 @skipIf(not UPGRADE_TEST_RUN, 'set UPGRADE_TEST_RUN=true to run upgrade tests')

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -242,10 +242,13 @@ class UpgradeTester(Tester):
         Tester.__init__(self, *args, **kwargs)
 
     def setUp(self):
+        debug("Upgrade test beginning, setting CASSANDRA_VERSION to {}, and jdk to {}. (Prior values will be restored after test)."
+              .format(self.test_version_metas[0].version, self.test_version_metas[0].java_version))
+        os.environ['CASSANDRA_VERSION'] = self.test_version_metas[0].version
+        switch_jdks(self.test_version_metas[0].java_version)
+
         super(UpgradeTester, self).setUp()
         debug("Versions to test (%s): %s" % (type(self), str([v.version for v in self.test_version_metas])))
-        switch_jdks(self.test_version_metas[0].java_version)
-        self.cluster.set_install_dir(version=self.test_version_metas[0].version)
 
     def init_config(self):
         self.init_default_config()

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -221,9 +221,9 @@ def counter_checker(tester, to_verify_queue, verification_done_queue):
 
 class UpgradeTester(Tester):
     """
-    Upgrades a 3-node Murmur3Partitioner cluster through versions specified in test_versions.
+    Upgrades a 3-node Murmur3Partitioner cluster through versions specified in test_version_metas.
     """
-    test_versions = None  # set on init to know which versions to use
+    test_version_metas = None  # set on init to know which versions to use
     subprocs = None  # holds any subprocesses, for status checking and cleanup
     extra_config = None  # holds a non-mutable structure that can be cast as dict()
     __test__ = False  # this is a base class only
@@ -243,9 +243,9 @@ class UpgradeTester(Tester):
 
     def setUp(self):
         super(UpgradeTester, self).setUp()
-        debug("Versions to test (%s): %s" % (type(self), str([v for v in self.test_versions])))
-        switch_jdks(self.test_versions[0])
-        self.cluster.set_install_dir(version=self.test_versions[0])
+        debug("Versions to test (%s): %s" % (type(self), str([v.version for v in self.test_version_metas])))
+        switch_jdks(self.test_version_metas[0].java_version)
+        self.cluster.set_install_dir(version=self.test_version_metas[0].version)
 
     def init_config(self):
         self.init_default_config()
@@ -314,7 +314,7 @@ class UpgradeTester(Tester):
 
         if populate:
             # Start with 3 node cluster
-            debug('Creating cluster (%s)' % self.test_versions[0])
+            debug('Creating cluster (%s)' % self.test_version_metas[0].version)
             cluster.populate(3)
             [node.start(use_jna=True, wait_for_binary_proto=True) for node in cluster.nodelist()]
         else:
@@ -334,7 +334,7 @@ class UpgradeTester(Tester):
             debug("Skipping schema creation (should already be built)")
         time.sleep(5)  # sigh...
 
-        self._log_current_ver(self.test_versions[0])
+        self._log_current_ver(self.test_version_metas[0])
 
         if rolling:
             # start up processes to write and verify data
@@ -342,7 +342,7 @@ class UpgradeTester(Tester):
             increment_proc, incr_verify_proc, incr_verify_queue = self._start_continuous_counter_increment_and_verify(wait_for_rowcount=5000)
 
             # upgrade through versions
-            for tag in self.test_versions[1:]:
+            for version_meta in self.test_version_metas[1:]:
                 for num, node in enumerate(self.cluster.nodelist()):
                     # sleep (sigh) because driver needs extra time to keep up with topo and make quorum possible
                     # this is ok, because a real world upgrade would proceed much slower than this programmatic one
@@ -350,13 +350,13 @@ class UpgradeTester(Tester):
                     # possibly "speed past" in an overly fast upgrade test
                     time.sleep(60)
 
-                    self.upgrade_to_version(tag, partial=True, nodes=(node,))
+                    self.upgrade_to_version(version_meta, partial=True, nodes=(node,))
 
                     self._check_on_subprocs(self.subprocs)
                     debug('Successfully upgraded %d of %d nodes to %s' %
-                          (num + 1, len(self.cluster.nodelist()), tag))
+                          (num + 1, len(self.cluster.nodelist()), version_meta.version))
 
-                self.cluster.set_install_dir(version=tag)
+                self.cluster.set_install_dir(version=version_meta.version)
 
             # Stop write processes
             write_proc.terminate()
@@ -370,12 +370,12 @@ class UpgradeTester(Tester):
         # not a rolling upgrade, do everything in parallel:
         else:
             # upgrade through versions
-            for tag in self.test_versions[1:]:
+            for version_meta in self.test_version_metas[1:]:
                 self._write_values()
                 self._increment_counters()
 
-                self.upgrade_to_version(tag)
-                self.cluster.set_install_dir(version=tag)
+                self.upgrade_to_version(version_meta)
+                self.cluster.set_install_dir(version=version_meta.version)
 
                 self._check_values()
                 self._check_counters()
@@ -385,8 +385,8 @@ class UpgradeTester(Tester):
         for call in after_upgrade_call:
             call()
 
-            debug('All nodes successfully upgraded to %s' % tag)
-            self._log_current_ver(tag)
+            debug('All nodes successfully upgraded to %s' % version_meta)
+            self._log_current_ver(version_meta)
 
         cluster.stop()
 
@@ -420,14 +420,14 @@ class UpgradeTester(Tester):
                     debug("Error terminating subprocess. There could be a lingering process.")
                     pass
 
-    def upgrade_to_version(self, tag, partial=False, nodes=None):
+    def upgrade_to_version(self, version_meta, partial=False, nodes=None):
         """
         Upgrade Nodes - if *partial* is True, only upgrade those nodes
         that are specified by *nodes*, otherwise ignore *nodes* specified
         and upgrade all nodes.
         """
-        debug('Upgrading {nodes} to {tag}'.format(nodes=[n.name for n in nodes] if nodes is not None else 'all nodes', tag=tag))
-        switch_jdks(tag)
+        debug('Upgrading {nodes} to {version}'.format(nodes=[n.name for n in nodes] if nodes is not None else 'all nodes', version=version_meta.version))
+        switch_jdks(version_meta.java_version)
         debug("JAVA_HOME: " + os.environ.get('JAVA_HOME'))
         if not partial:
             nodes = self.cluster.nodelist()
@@ -439,7 +439,7 @@ class UpgradeTester(Tester):
             node.stop(wait_other_notice=False)
 
         for node in nodes:
-            node.set_install_dir(version=tag)
+            node.set_install_dir(version=version_meta.version)
             debug("Set new cassandra dir for %s: %s" % (node.name, node.get_install_dir()))
 
         # hacky? yes. We could probably extend ccm to allow this publicly.
@@ -449,21 +449,21 @@ class UpgradeTester(Tester):
 
         # Restart nodes on new version
         for node in nodes:
-            debug('Starting %s on new version (%s)' % (node.name, tag))
+            debug('Starting %s on new version (%s)' % (node.name, version_meta.version))
             # Setup log4j / logback again (necessary moving from 2.0 -> 2.1):
             node.set_log_level("INFO")
             node.start(wait_other_notice=True, wait_for_binary_proto=True)
             node.nodetool('upgradesstables -a')
 
-    def _log_current_ver(self, current_tag):
+    def _log_current_ver(self, current_version_meta):
         """
         Logs where we currently are in the upgrade path, surrounding the current branch/tag, like ***sometag***
         """
-        vers = self.test_versions
-        curr_index = vers.index(current_tag)
+        vers = [m.version for m in self.test_version_metas]
+        curr_index = vers.index(current_version_meta.version)
         debug(
             "Current upgrade path: {}".format(
-                vers[:curr_index] + ['***' + current_tag + '***'] + vers[curr_index + 1:]))
+                vers[:curr_index] + ['***' + current_version_meta.version + '***'] + vers[curr_index + 1:]))
 
     def _create_schema_for_rolling(self):
         """
@@ -753,7 +753,7 @@ class BootstrapMixin(object):
                 );""")
 
 
-def create_upgrade_class(clsname, version_list, protocol_version,
+def create_upgrade_class(clsname, version_metas, protocol_version,
                          bootstrap_test=False, extra_config=None):
     """
     Dynamically creates a test subclass for testing the given versions.
@@ -777,14 +777,14 @@ def create_upgrade_class(clsname, version_list, protocol_version,
     parent_class_names = [cls.__name__ for cls in parent_classes]
 
     print_("Creating test class {} ".format(clsname))
-    print_("  for C* versions: {} ".format(version_list))
+    print_("  for C* versions: {} ".format(version_metas))
     print_("  using protocol: v{}, and parent classes: {}".format(protocol_version, parent_class_names))
     print_("  to run these tests alone, use `nosetests {}.py:{}`".format(__name__, clsname))
 
     newcls = type(
         clsname,
         parent_classes,
-        {'test_versions': version_list, '__test__': UPGRADE_TEST_RUN, 'protocol_version': protocol_version, 'extra_config': extra_config}
+        {'test_version_metas': version_metas, '__test__': UPGRADE_TEST_RUN, 'protocol_version': protocol_version, 'extra_config': extra_config}
     )
 
     if clsname in globals():
@@ -851,13 +851,13 @@ MULTI_UPGRADES = (
 for upgrade in MULTI_UPGRADES:
     # if any version_metas are None, this means they are verions not to be tested currently
     if all(upgrade.version_metas):
-        create_upgrade_class(upgrade.name, [m.version for m in upgrade.version_metas], protocol_version=upgrade.protocol_version, extra_config=upgrade.extra_config)
+        create_upgrade_class(upgrade.name, [m for m in upgrade.version_metas], protocol_version=upgrade.protocol_version, extra_config=upgrade.extra_config)
 
 
 for pair in build_upgrade_pairs():
     create_upgrade_class(
         'Test' + pair.name,
-        [pair.starting_version, pair.upgrade_version],
+        [pair.starting_meta, pair.upgrade_meta],
         protocol_version=pair.starting_meta.max_proto_v,
         bootstrap_test=True
     )


### PR DESCRIPTION
allows us to re-enable 2.0->2.1 upgrade testing