### PR TITLE
Fix auth test import

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -1,4 +1,3 @@
-import os
 import re
 import time
 from collections import namedtuple
@@ -6,11 +5,10 @@ from collections import namedtuple
 from cassandra import AuthenticationFailed, InvalidRequest, Unauthorized
 from cassandra.cluster import NoHostAvailable
 from cassandra.protocol import SyntaxException
-from ccmlib.common import get_version_from_build
 
 from assertions import (assert_all, assert_invalid, assert_one,
                         assert_unauthorized)
-from dtest import Tester, debug
+from dtest import CASSANDRA_VERSION_FROM_BUILD, Tester, debug
 from tools import since
 
 
@@ -996,8 +994,7 @@ class TestAuthRoles(Tester):
     """
 
     def __init__(self, *args, **kwargs):
-        CASSANDRA_DIR = os.environ.get('CASSANDRA_DIR')
-        if get_version_from_build(CASSANDRA_DIR) >= '3.0':
+        if CASSANDRA_VERSION_FROM_BUILD >= '3.0':
             kwargs['cluster_options'] = {'enable_user_defined_functions': 'true',
                                          'enable_scripted_user_defined_functions': 'true'}
         else:

--- a/auth_test.py
+++ b/auth_test.py
@@ -2518,14 +2518,8 @@ class TestAuthRoles(Tester):
 
 
 def role_creator_permissions(creator, role):
-    permissions = []
-    for perm in 'ALTER', 'DROP', 'AUTHORIZE':
-        permissions.append((creator, role, perm))
-    return permissions
+    return [(creator, role, perm) for perm in ('ALTER', 'DROP', 'AUTHORIZE')]
 
 
 def function_resource_creator_permissions(creator, resource):
-    permissions = []
-    for perm in 'ALTER', 'DROP', 'AUTHORIZE', 'EXECUTE':
-        permissions.append((creator, resource, perm))
-    return permissions
+    return [(creator, resource, perm) for perm in ('ALTER', 'DROP', 'AUTHORIZE', 'EXECUTE')]

--- a/user_functions_test.py
+++ b/user_functions_test.py
@@ -1,14 +1,11 @@
 import math
-import os
 import time
+from distutils.version import LooseVersion
 
 from cassandra import FunctionFailure
 
-from distutils.version import LooseVersion
-
-from ccmlib.common import get_version_from_build
-from dtest import Tester, debug
-from assertions import assert_invalid, assert_one, assert_none
+from assertions import assert_invalid, assert_none, assert_one
+from dtest import CASSANDRA_VERSION_FROM_BUILD, Tester, debug
 from tools import since
 
 
@@ -16,8 +13,7 @@ from tools import since
 class TestUserFunctions(Tester):
 
     def __init__(self, *args, **kwargs):
-        CASSANDRA_DIR = os.environ.get('CASSANDRA_DIR')
-        if get_version_from_build(CASSANDRA_DIR) >= '3.0':
+        if CASSANDRA_VERSION_FROM_BUILD >= '3.0':
             kwargs['cluster_options'] = {'enable_user_defined_functions': 'true',
                                          'enable_scripted_user_defined_functions': 'true'}
         else:


### PR DESCRIPTION
The first commit here (`don't use env vars for getting C* version`) is intended to fix #976, but does not on my machine. Regardless, I think it's a good thing to do. To demonstrate the problem in #976, run `auth_test.py:TestAuthRoles` with the `CASSANDRA_DIR` env var unset, and the `CASSANDRA_VERSION` var set.

I'm not sure why this doesn't fix the issue. Any thoughts? @ptnapoleon @knifewine