### PR TITLE
Fix CASSANDRA-11890

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -9,7 +9,7 @@ from cassandra.protocol import SyntaxException
 from assertions import (assert_all, assert_invalid, assert_one,
                         assert_unauthorized)
 from dtest import CASSANDRA_VERSION_FROM_BUILD, Tester, debug
-from tools import known_failure, since
+from tools import since
 
 
 class TestAuth(Tester):
@@ -1070,9 +1070,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE role1")
         assert_invalid(cassandra, "DROP ROLE role1", "role1 doesn't exist")
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11890',
-                   flaky=False)
     def role_admin_validation_test(self):
         """
         * Launch a one node cluster
@@ -1781,9 +1778,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("CREATE USER super_user WITH PASSWORD '12345' SUPERUSER")
         assert_one(cassandra, "LIST ROLES OF super_user", ["super_user", True, True, {}])
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11890',
-                   flaky=False)
     def role_name_test(self):
         """
         Simple test to verify the behaviour of quoting when creating roles & users
@@ -1824,9 +1818,6 @@ class TestAuthRoles(Tester):
         self.get_session(user='USER2', password='12345')
         self.assert_unauthenticated("Username and/or password are incorrect", 'User2', '12345')
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11890',
-                   flaky=False)
     def role_requires_login_privilege_to_authenticate_test(self):
         """
         * Launch a one node cluster
@@ -1850,9 +1841,6 @@ class TestAuthRoles(Tester):
         assert_one(cassandra, "LIST ROLES OF mike", ["mike", False, True, {}])
         self.get_session(user='mike', password='12345')
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11890',
-                   flaky=False)
     def roles_do_not_inherit_login_privilege_test(self):
         """
         * Launch a one node cluster
@@ -1873,9 +1861,6 @@ class TestAuthRoles(Tester):
 
         self.assert_unauthenticated("mike is not permitted to log in", "mike", "12345")
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11890',
-                   flaky=False)
     def role_requires_password_to_login_test(self):
         """
         * Launch a one node cluster
@@ -2493,9 +2478,9 @@ class TestAuthRoles(Tester):
             node = self.cluster.nodelist()[0]
             self.cql_connection(node, user=user, password=password)
         host, error = response.exception.errors.popitem()
-        pattern = 'Failed to authenticate to %s: code=0100 \[Bad credentials\] message="%s"' % (host, message)
+        pattern = 'Failed to authenticate to %s: Error from server: code=0100 \[Bad credentials\] message="%s"' % (host, message)
         assert isinstance(error, AuthenticationFailed), "Expected AuthenticationFailed, got %s" % error
-        assert re.search(pattern, error.message), "Expected: %s" % pattern
+        assert re.search(pattern, error.message), "Expected: %s, actual: %s" % (pattern, error.message)
 
     def get_session(self, node_idx=0, user=None, password=None):
         """

--- a/user_types_test.py
+++ b/user_types_test.py
@@ -7,7 +7,7 @@ from cassandra.query import SimpleStatement
 
 from assertions import assert_invalid
 from dtest import Tester
-from tools import known_failure, since
+from tools import since
 
 
 def listify(item):
@@ -512,9 +512,6 @@ class TestUserTypes(Tester):
         self.assertEqual(first_name, u'Abraham')
         self.assertEqual(like, u'preserving unions')
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11890',
-                   flaky=False)
     def test_type_keyspace_permission_isolation(self):
         """
         Confirm permissions are respected for types in different keyspaces
@@ -574,8 +571,8 @@ class TestUserTypes(Tester):
         user2_session.execute("ALTER TYPE ks2.simple_type RENAME user_number TO user_num;")
 
         # finally, drop the types using the correct user w/permissions to do so, consistency all avoids using a sleep
-        user1_session.execute(SimpleStatement("DROP TYPE ks1.simple_type;", ConsistencyLevel.ALL))
-        user2_session.execute(SimpleStatement("DROP TYPE ks2.simple_type;", ConsistencyLevel.ALL))
+        user1_session.execute(SimpleStatement("DROP TYPE ks1.simple_type;", consistency_level=ConsistencyLevel.ALL))
+        user2_session.execute(SimpleStatement("DROP TYPE ks2.simple_type;", consistency_level=ConsistencyLevel.ALL))
 
         time.sleep(5)
 


### PR DESCRIPTION
CASSANDRA-11890 covers recent auth failures in tests on 2.2, 3.0, and 3.x. They appeared recently because the cassandra-test branch of the Python driver was updated for the 3.4.0 driver release.

These failures come from two commits in [datastax/python-driver](https://github.com/datastax/python-driver/commits/cassandra-test).

The failures in user_types_test came from this [commit](https://github.com/datastax/python-driver/commit/88b013daac765cec04626cc3d5fdad804fd0b19b), which adds error checking for positional retry_policy parameters. A consistency level was instead being passed; we now pass this as a labeled argument.

The failures in auth_test came from this [commit](https://github.com/datastax/python-driver/commit/da994dcd3ad76f3eacae367b87f345f2ccc7a1c4), which explicitly states when errors come from the server in error messages. I've updated the regex to match this new error format and added logging of the actual message when the regex doesn't match.

EDIT: Edited to add that I've confirmed failures prior to these fixes locally and ran the tests after these fixes to confirm they pass. I have not ran the fixes on CassCI.
