### PR TITLE
Force single data dir for scrub tests

### DIFF
--- a/scrub_test.py
+++ b/scrub_test.py
@@ -14,6 +14,17 @@ KEYSPACE = 'ks'
 
 
 class TestHelper(Tester):
+
+    def setUp(self):
+        """
+        disable JBOD configuration for scrub tests.
+        range-aware JBOD can skip generation in SSTable,
+        and some tests rely on generation numbers/
+        (see CASSANDRA-11693 and increase_sstable_generations)
+        """
+        super(TestHelper, self).setUp(self)
+        self.cluster.set_datadir_count(1)
+
     def get_table_paths(self, table):
         """
         Return the path where the table sstables are located


### PR DESCRIPTION
This is for [CASSANDRA-11693](https://issues.apache.org/jira/browse/CASSANDRA-11693).

Since range-aware JBOD is introduced, there is a chance that zero byte SSTable is created (not actually on the disk, just internally) and generation number goes out of sync with what tests expect.

I propose to simply disable JBOD configuration for scrub tests, since it is not the target of the tests anyway.