### PR TITLE
Readability nits

### DIFF
--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -205,8 +205,7 @@ class TestCommitLog(Tester):
         node1.mark_log_for_errors()
 
         debug("Verify commitlog was written before abrupt stop")
-        commitlog_dir = os.path.join(node1.get_path(), 'commitlogs')
-        commitlog_files = os.listdir(commitlog_dir)
+        commitlog_files = os.listdir(os.path.join(node1.get_path(), 'commitlogs'))
         self.assertNotEqual([], commitlog_files, commitlog_files)
 
         # set a short timeout to ensure lock contention will generally exceed this

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -199,7 +199,7 @@ class TestCommitLog(Tester):
         debug("Insert data")
         num_rows = 1024  # maximum number of mutations replayed at once by the commit log
         for i in xrange(num_rows):
-            session.execute("INSERT INTO Test.mytable (a, b, c) VALUES (0, %d, %d)" % (i, i))
+            session.execute("INSERT INTO Test.mytable (a, b, c) VALUES (0, {i}, {i})".format(i=i))
 
         node1.stop(gently=False)
         node1.mark_log_for_errors()

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -206,7 +206,7 @@ class TestCommitLog(Tester):
 
         debug("Verify commitlog was written before abrupt stop")
         commitlog_files = os.listdir(os.path.join(node1.get_path(), 'commitlogs'))
-        self.assertNotEqual([], commitlog_files, commitlog_files)
+        self.assertNotEqual([], commitlog_files)
 
         # set a short timeout to ensure lock contention will generally exceed this
         node1.set_configuration_options({'write_request_timeout_in_ms': 30})
@@ -217,7 +217,7 @@ class TestCommitLog(Tester):
         start_time = time.time()
         while (time.time() - start_time) < 120.0:
             matches = node1.grep_log(r".*WriteTimeoutException.*")
-            self.assertEqual([], matches, matches)
+            self.assertEqual([], matches)
 
             replay_complete = node1.grep_log("Log replay complete")
             if replay_complete:

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -214,16 +214,15 @@ class TestCommitLog(Tester):
         node1.start()
 
         debug("Verify commit log was replayed on startup")
-        start_time = time.time()
-        while (time.time() - start_time) < 120.0:
+        start_time, replay_complete = time.time(), False
+        while not replay_complete and (time.time() - start_time) < 120.0:
             matches = node1.grep_log(r".*WriteTimeoutException.*")
             self.assertEqual([], matches)
 
             replay_complete = node1.grep_log("Log replay complete")
-            if replay_complete:
-                break
         else:
-            self.fail("Did not finish commitlog replay within 120 seconds")
+            if not replay_complete:
+                self.fail("Did not finish commitlog replay within 120 seconds")
 
         debug("Reconnecting to node")
         session = self.patient_cql_connection(node1)

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -215,14 +215,12 @@ class TestCommitLog(Tester):
 
         debug("Verify commit log was replayed on startup")
         start_time, replay_complete = time.time(), False
-        while not replay_complete and (time.time() - start_time) < 120.0:
+        while not replay_complete:
             matches = node1.grep_log(r".*WriteTimeoutException.*")
             self.assertEqual([], matches)
 
             replay_complete = node1.grep_log("Log replay complete")
-        else:
-            if not replay_complete:
-                self.fail("Did not finish commitlog replay within 120 seconds")
+            self.assertLess(time.time() - start_time, 120, "Did not finish commitlog replay within 120 seconds")
 
         debug("Reconnecting to node")
         session = self.patient_cql_connection(node1)


### PR DESCRIPTION
Had a few style and readability nits to pick with [a recent PR](https://github.com/riptano/cassandra-dtest/pull/998) that I didn't see until after it was merged.

Locally, my changes pass on `trunk` and `cassandra-3.0`, and fail as expected (with a bunch of `org.apache.cassandra.exceptions.WriteTimeoutException: Operation timed out - received only 0 responses.` messages) on `3.0.5`, which is consistent with the bug describtion in [CASSANDRA-11891](https://issues.apache.org/jira/browse/CASSANDRA-11891).