### PR TITLE
The API for node run_sstableemetadata has changed

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -86,8 +86,10 @@ class TestOfflineTools(Tester):
 
     def get_levels(self, data):
         levels = []
-        for sstable in data:
-            (metadata, error, rc) = sstable
+        # The beginning of each new sstable is \'nSSTable: '
+        # This is true across all c* versions
+        for sstable in data[0].split('\nSSTable: '):
+            metadata = sstable
             level = int(re.findall("SSTable Level: [0-9]", metadata)[0][-1])
             levels.append(level)
         return levels


### PR DESCRIPTION
Make the corresponding changes to the dtest code. Previously
we were getting back a list of tuples, now we just have
one tuple

@knifewine to review

