### PR TITLE
bump released vers to 3.7/3.0.7

### DIFF
--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -31,11 +31,11 @@ current_2_2_x = VersionMeta(name='current_2_2_x', variant='current', version='2.
 next_2_2_x = None  # None if not yet tagged
 
 indev_3_0_x = VersionMeta(name='indev_3_0_x', variant='indev', version='git:cassandra-3.0', min_proto_v=3, max_proto_v=4, java_versions=(8,))
-current_3_0_x = VersionMeta(name='current_3_0_x', variant='current', version='3.0.6', min_proto_v=3, max_proto_v=4, java_versions=(8,))
+current_3_0_x = VersionMeta(name='current_3_0_x', variant='current', version='3.0.7', min_proto_v=3, max_proto_v=4, java_versions=(8,))
 next_3_0_x = None  # None if not yet tagged
 
 indev_3_x = VersionMeta(name='indev_3_x', variant='indev', version='git:cassandra-3.7', min_proto_v=3, max_proto_v=4, java_versions=(8,))
-current_3_x = VersionMeta(name='current_3_x', variant='current', version='3.6', min_proto_v=3, max_proto_v=4, java_versions=(8,))
+current_3_x = VersionMeta(name='current_3_x', variant='current', version='3.7', min_proto_v=3, max_proto_v=4, java_versions=(8,))
 next_3_x = None  # None if not yet tagged
 
 head_trunk = VersionMeta(name='head_trunk', variant='indev', version='git:trunk', min_proto_v=3, max_proto_v=4, java_versions=(8,))


### PR DESCRIPTION
Not to be merged until 3.7/3.0.7 are fully released!

Probably will need one more commit to update indev_3_x as well, since that's currently pointing to the 3.7 branch (which after release isn't likely to see more commits).