### PR TITLE
Stop checking line length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ script:
   - git fetch riptano # fetch master for the next diff
   # feed changed lines with no context around them to pep8
   # I know we don't enforce line length but if you introduce
-  # 200-char lines you are doing something terribly wrong
-  - git diff riptano/master...HEAD -U0 | pep8 --ignore=E501 json_test.py --diff --max-line-length=200
+  # 200-char lines you are doing something terribly wrong.
+  # lint all files for everything but line length errors
+  - git diff riptano/master...HEAD -U0 | pep8 --ignore=E501 --diff
+  # lint all files except json_test.py for line length errors
+  - git diff riptano/master...HEAD -U0 | pep8 --diff --exclude='json_test.py' --max-line-length=200
 sudo: false

--- a/linter_check.sh
+++ b/linter_check.sh
@@ -6,13 +6,18 @@
 flake8 --ignore=E501,F811,F812,F821,F822,F823,F831,F841,N8,C9 --exclude=thrift_bindings,cassandra-thrift .
 flake8_result=$?
 
-git diff master...HEAD -U0 | pep8 --diff --max-line-length=200
-pep8_result=$?
+# lint all files for everything but line length errors
+git diff riptano/master...HEAD -U0 | pep8 --ignore=E501 --diff
+pep8_style_check=$?
+
+# lint all files except json_test.py for line length errors
+git diff riptano/master...HEAD -U0 | pep8 --diff --exclude='json_test.py' --max-line-length=200
+pep8_line_length=$?
 
 echo -e "\nflake8 exited with ${flake8_result}."
-echo "pep8 exited with ${pep8_result}."
+echo "pep8 line length check exited with ${pep8_line_length} and style check exited with ${pep8_style_check}."
 
-if [ $flake8_result -ne 0 -o $pep8_result -ne 0 ];
+if [ $flake8_result -ne 0 -o $pep8_line_length -ne 0 -o $pep8_style_check -ne 0 ];
 then
     echo "Your changes contain linter errors."
     echo "You can fix these manually or with autopep8, which can be installed with pip."


### PR DESCRIPTION
@mambocab to review

I strongly believe the current pep8 arguments are incorrect. For example, see these nits from a recent travis build:

```
json_test.py/assertions.py:1:1: E902 IOError: [Errno 20] Not a directory: 'json_test.py/assertions.py'
json_test.py/meta_tests/assertion_test.py:1:1: E902 IOError: [Errno 20] Not a directory:'json_test.py/meta_tests/assertion_test.py'
```

Looking at the output of `pep8 --help`, I don't think we can exclusively ignore errors on only one file. So either we stop linting E501, or we stop linting json_test.py. I don't think there's a union of those two goals, so I chose the former. That choice is up for debate, as well as my assumption that there is no way to do what we really want.