### PR TITLE
Don't wrap csv results in an extra list layer

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -303,7 +303,7 @@ class CqlshCopyTest(Tester):
 
         self.maxDiff = None
         try:
-            self.assertItemsEqual(csv_results, processed_results)
+            self.assertItemsEqual(csv_results[0], processed_results[0])
         except Exception as e:
             if len(csv_results) != len(processed_results):
                 warning("Different # of entries. CSV: " + str(len(csv_results)) +


### PR DESCRIPTION
This makes the assert useless, as comparing Items is less
granular

Compare this error message with my changes
```
AssertionError: Element counts were not equal:
First has 1, Second has 0:  '2005-07-14 12:30:00+0000'
First has 1, Second has 0:  "{'2005-07-14 12:30:00+0000': '1', '2005-07-14 13:30:00+0000': '2'}"
First has 0, Second has 1:  '2005-07-14 12:30:00.000+0000'
First has 0, Second has 1:  "{'2005-07-14 12:30:00.000+0000': '1', '2005-07-14 13:30:00.000+0000': '2'}"
```

to this error without them
```
AssertionError: Element counts were not equal:
First has 1, Second has 0:  ['ascii', '1099511627776', '0xbeef', 'True', '3.140000000000000124344978758017532527446746826171875', '2.444', '1.1', '127.0.0.1', '25', '\xe3\x83\xbd(\xc2\xb4\xe3\x83\xbc\xef\xbd\x80)\xe3\x83\x8e', '2005-07-14 12:30:00+0000', '329d97cc-33d8-11e6-9c5a-7831c1cc2294', '67e71068-ea2f-43e4-b30a-3808fae10ecf', 'asdf', '36893488147419103232', '[1, 2, 3]', "{'1', '2', '3'}", "{'2005-07-14 12:30:00+0000': '1', '2005-07-14 13:30:00+0000': '2'}", "(1, '1', True)", "{name: {firstname: 'name1', lastname: 'last1'}, number: 1, street: 'street 1', phones: {'1111 2222', '3333 4444'}}", "[[{name: {firstname: 'name1', lastname: 'last1'}, number: 1, street: 'street 1', phones: {'1111 2222', '3333 4444'}}, {name: {firstname: 'name2', lastname: 'last2'}, number: 2, street: 'street 2', phones: {'5555 6666', '7777 8888'}}], [{name: {firstname: 'name3', lastname: 'last3'}, number: 3, street: 'street 3', phones: {'1111 2222', '3333 4444'}}, {name: {firstname: 'name4', lastname: 'last4'}, number: 4, street: 'street 4', phones: {'5555 6666', '7777 8888'}}]]", "{{1: 1, 2: 2}: {'1', '2', '3'}}", "{{'127.0.0.1'}, {'127.0.0.1', '127.0.0.2'}}"]
First has 0, Second has 1:  ['ascii', '1099511627776', '0xbeef', 'True', '3.140000000000000124344978758017532527446746826171875', '2.444', '1.1', '127.0.0.1', '25', '\xe3\x83\xbd(\xc2\xb4\xe3\x83\xbc\xef\xbd\x80)\xe3\x83\x8e', '2005-07-14 12:30:00.000+0000', '329d97cc-33d8-11e6-9c5a-7831c1cc2294', '67e71068-ea2f-43e4-b30a-3808fae10ecf', 'asdf', '36893488147419103232', '[1, 2, 3]', "{'1', '2', '3'}", "{'2005-07-14 12:30:00.000+0000': '1', '2005-07-14 13:30:00.000+0000': '2'}", "(1, '1', True)", "{name: {firstname: 'name1', lastname: 'last1'}, number: 1, street: 'street 1', phones: {'1111 2222', '3333 4444'}}", "[[{name: {firstname: 'name1', lastname: 'last1'}, number: 1, street: 'street 1', phones: {'1111 2222', '3333 4444'}}, {name: {firstname: 'name2', lastname: 'last2'}, number: 2, street: 'street 2', phones: {'5555 6666', '7777 8888'}}], [{name: {firstname: 'name3', lastname: 'last3'}, number: 3, street: 'street 3', phones: {'1111 2222', '3333 4444'}}, {name: {firstname: 'name4', lastname: 'last4'}, number: 4, street: 'street 4', phones: {'5555 6666', '7777 8888'}}]]", "{{1: 1, 2: 2}: {'1', '2', '3'}}", "{{'127.0.0.1'}, {'127.0.0.1', '127.0.0.2'}}"]
```

@mambocab and @knifewine to review

http://cassci.datastax.com/view/Dev/view/ptnapoleon/job/ptnapoleon-2.1-cqlsh-cqlsh-tests/