### PR TITLE
use self.cluster

### DIFF
--- a/repair_tests/repair_test.py
+++ b/repair_tests/repair_test.py
@@ -273,7 +273,7 @@ class TestRepair(Tester):
         @jira_ticket CASSANDRA-4373
         """
         if order_preserving_partitioner:
-            cluster.set_partitioner('org.apache.cassandra.dht.ByteOrderedPartitioner')
+            self.cluster.set_partitioner('org.apache.cassandra.dht.ByteOrderedPartitioner')
 
         self._populate_cluster()
         self._repair_and_verify(sequential)


### PR DESCRIPTION
@ptnapoleon, please review.

Fix being tested here: http://cassci.datastax.com/view/Parameterized/job/parameterized_dtest_multiplexer/132