### PR TITLE
Only run test from CASSANDRA-11038 on 2.2+

### DIFF
--- a/pushed_notifications_test.py
+++ b/pushed_notifications_test.py
@@ -217,6 +217,7 @@ class TestPushedNotifications(Tester):
         notifications = waiter.wait_for_notifications(timeout=30.0, num_notifications=2)
         self.assertEquals(0, len(notifications), notifications)
 
+    @since("2.2")
     def add_and_remove_node_test(self):
         """
         Test that NEW_NODE and REMOVED_NODE are sent correctly as nodes join and leave.


### PR DESCRIPTION
Since 2.1 is critical fixes only, the patch to ensure correct behaviour for 11038 was only added from 2.2 onwards, so it's probably wise to only run it's test on those versions.

(see also: CASSANDRA-12056)