### PR TITLE
Fix for CASSANDRA-12024: pick a real token range to signal copy child processes to fail

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -2612,10 +2612,17 @@ class CqlshCopyTest(Tester):
             start = tokens[1]
             end = tokens[2]
         else:
-            start = 0
-            end = 5000000000000000000
             self.prepare(nodes=1)
+            metadata = self.session.cluster.metadata
+            metadata.token_map.rebuild_keyspace(self.ks, build_if_absent=True)
+            ring = [t.value for t in metadata.token_map.tokens_to_hosts_by_ks[self.ks].keys()]
+            self.assertTrue(len(ring) >= 3, 'Not enough ranges in the ring for this test')
+            ring.sort()
+            idx = len(ring) / 2
+            start = ring[idx]
+            end = ring[idx + 1]
 
+        debug("Using failure range: {}, {}".format(start, end))
         return start, end
 
     @freshCluster()


### PR DESCRIPTION
Here is a tentative fix for  CASSANDRA-12024, don't merge until it has been tested with a repeated batch of tests.