### PR TITLE
Fix broken trunk dtests due to version change to 3.10

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -9,6 +9,7 @@ import time
 from assertions import assert_none, assert_one
 from ccmlib import common
 from dtest import Tester, debug
+from distutils.version import LooseVersion
 from nose.tools import assert_equal
 from tools import known_failure, since
 
@@ -199,7 +200,7 @@ class TestCompaction(Tester):
         time.sleep(40)
         expired_sstables = node1.get_sstables('ks', 'cf')
         expected_sstable_count = 1
-        if self.cluster.version() > '3.1':
+        if LooseVersion(self.cluster.version()) > LooseVersion('3.1'):
             expected_sstable_count = cluster.data_dir_count
         self.assertEqual(len(expired_sstables), expected_sstable_count)
         # write a new sstable to make DTCS check for expired sstables:
@@ -241,7 +242,7 @@ class TestCompaction(Tester):
 
         matches = block_on_compaction_log(node1)
         stringline = matches[0]
-        units = 'MB/s' if cluster.version() < '3.6' else '(K|M|G)iB/s'
+        units = 'MB/s' if LooseVersion(cluster.version()) < LooseVersion('3.6') else '(K|M|G)iB/s'
         throughput_pattern = re.compile('''.*           # it doesn't matter what the line starts with
                                            =            # wait for an equals sign
                                            ([\s\d\.]*)  # capture a decimal number, possibly surrounded by whitespace
@@ -326,7 +327,7 @@ class TestCompaction(Tester):
 
         node.nodetool('compact ks large')
         verb = 'Writing' if self.cluster.version() > '2.2' else 'Compacting'
-        sizematcher = '\d+ bytes' if self.cluster.version() < '3.6' else '\d+\.\d{3}(K|M|G)iB'
+        sizematcher = '\d+ bytes' if LooseVersion(self.cluster.version()) < LooseVersion('3.6') else '\d+\.\d{3}(K|M|G)iB'
         node.watch_log_for('{} large partition ks/large:user \({}\)'.format(verb, sizematcher), from_mark=mark, timeout=180)
 
         ret = list(session.execute("SELECT properties from ks.large where userid = 'user'"))

--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -9,6 +9,7 @@ import time
 from collections import namedtuple
 from contextlib import contextmanager
 from decimal import Decimal
+from distutils.version import LooseVersion
 from functools import partial
 from tempfile import NamedTemporaryFile, gettempdir, template
 from uuid import uuid1, uuid4
@@ -353,7 +354,7 @@ class CqlshCopyTest(Tester):
                 return format_value_default(nullval, colormap=NO_COLOR_MAP)
 
             # CASSANDRA-11255 increased COPY TO DOUBLE PRECISION TO 12
-            if cql_type_name == 'double' and self.cluster.version() >= '3.6':
+            if cql_type_name == 'double' and LooseVersion(self.cluster.version()) >= LooseVersion('3.6'):
                 float_precision = 12
             else:
                 float_precision = 5
@@ -1928,8 +1929,8 @@ class CqlshCopyTest(Tester):
 
             # comma as thousands sep and dot as decimal sep
             # the precision for double values was increased from 5 to 12 in 3.6, see CASSANDRA-11255
-            double_val_1 = '5.12346' if self.cluster.version() < '3.6' else '5.12345678'
-            double_val_2 = '123,456,789.56' if self.cluster.version() < '3.6' else '123,456,789.560000002384'
+            double_val_1 = '5.12346' if LooseVersion(self.cluster.version()) < LooseVersion('3.6') else '5.12345678'
+            double_val_2 = '123,456,789.56' if LooseVersion(self.cluster.version()) < LooseVersion('3.6') else '123,456,789.560000002384'
             expected_vals_usual = [
                 ['0', '10', '10', '10', '10', '10', '10', '10', '10'],
                 ['1', '127', '255', '1,000', '1,000', '1,000', '5.5', '5.5', double_val_1],
@@ -1942,8 +1943,8 @@ class CqlshCopyTest(Tester):
             ]
 
             # dot as thousands sep and comma as decimal sep
-            double_val_1 = '5,12346' if self.cluster.version() < '3.6' else '5,12345678'
-            double_val_2 = '123.456.789,56' if self.cluster.version() < '3.6' else '123.456.789,560000002384'
+            double_val_1 = '5,12346' if LooseVersion(self.cluster.version()) < LooseVersion('3.6') else '5,12345678'
+            double_val_2 = '123.456.789,56' if LooseVersion(self.cluster.version()) < LooseVersion('3.6') else '123.456.789,560000002384'
             expected_vals_inverted = [
                 ['0', '10', '10', '10', '10', '10', '10', '10', '10'],
                 ['1', '127', '255', '1.000', '1.000', '1.000', '5,5', '5,5', double_val_1],
@@ -2580,7 +2581,7 @@ class CqlshCopyTest(Tester):
         """
         os.environ['CQLSH_COPY_TEST_NUM_CORES'] = '1'
         ret = self._test_bulk_round_trip(nodes=3, partitioner="murmur3", num_operations=100000)
-        if self.cluster.version() >= '3.6':
+        if LooseVersion(self.cluster.version()) >= LooseVersion('3.6'):
             debug('Checking that number of cores detected is correct')
             for out, _ in ret:
                 self.assertIn("Detected 1 core", out)

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -142,7 +142,7 @@ class TestCqlsh(Tester):
 
         output, err = self.run_cqlsh(node1, 'use simple; SELECT * FROM simpledate')
 
-        if self.cluster.version() >= '3.4':
+        if LooseVersion(self.cluster.version()) >= LooseVersion('3.4'):
             self.assertIn("2143-04-19 11:21:01.000000+0000", output)
             self.assertIn("1943-04-19 11:21:01.000000+0000", output)
         else:

--- a/jmxutils.py
+++ b/jmxutils.py
@@ -6,6 +6,7 @@ from urllib2 import urlopen
 import ccmlib.common as common
 
 from dtest import warning
+from distutils.version import LooseVersion
 
 JOLOKIA_JAR = os.path.join('lib', 'jolokia-jvm-1.2.3-agent.jar')
 CLASSPATH_SEP = ';' if common.is_win() else ':'
@@ -75,7 +76,7 @@ def remove_perf_disable_shared_mem(node):
     option (see https://github.com/rhuss/jolokia/issues/198 for details).  This
     edits cassandra-env.sh (or the Windows equivalent), or jvm.options file on 3.2+ to remove that option.
     """
-    if node.cluster.version() >= '3.2':
+    if LooseVersion(node.cluster.version()) >= LooseVersion('3.2'):
         conf_file = os.path.join(node.get_conf_dir(), JVM_OPTIONS)
         pattern = '\-XX:\+PerfDisableSharedMem'
         replacement = '#-XX:+PerfDisableSharedMem'


### PR DESCRIPTION
We'll probably need to fix the ccm/dtest versioning scheme to be more resilient and use `distutils.version.LooseVersion` exclusively, but this is a more immediate fix to fix trunk dtests more promptly.

Submitted dtest run: http://cassci.datastax.com/view/Dev/view/paulomotta/job/pauloricardomg-trunkcopy2-dtest/4/