### PR TITLE
Write at CL.ALL for paging tests

### DIFF
--- a/paging_test.py
+++ b/paging_test.py
@@ -183,10 +183,11 @@ class BasePagingTester(Tester):
 
     def prepare(self):
         cluster = self.cluster
-        cluster.populate(3).start()
+        cluster.populate(3).start(wait_for_binary_proto=True)
         node1 = cluster.nodelist()[0]
         session = self.patient_cql_connection(node1)
         session.row_factory = dict_factory
+        session.default_consistency_level = CL.QUORUM
         return session
 
 
@@ -711,7 +712,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
         PAGE_SIZES = (2, 3, 4, 5, 15, 16, 17, 100)
 
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test" % selector))
@@ -726,7 +727,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # IN over the partitions
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a IN (0, 1, 2, 3)" % selector))
@@ -744,7 +745,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             session.execute("INSERT INTO test (a, b, c, s1, s2) VALUES (%d, %d, %d, %d, %d)" % (99, i, i, 17, 42))
 
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99" % selector))
@@ -759,7 +760,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # reversed
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 ORDER BY b DESC" % selector))
@@ -774,7 +775,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # IN on clustering column
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 AND b IN (3, 4, 8, 14, 15)" % selector))
@@ -789,7 +790,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # reversed IN on clustering column
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 AND b IN (3, 4, 8, 14, 15) ORDER BY b DESC" % selector))
@@ -804,7 +805,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # slice on clustering column with set start
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 AND b > 3" % selector))
@@ -819,7 +820,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # reversed slice on clustering column with set finish
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 AND b > 3 ORDER BY b DESC" % selector))
@@ -834,7 +835,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # slice on clustering column with set finish
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 AND b < 14" % selector))
@@ -849,7 +850,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # reversed slice on clustering column with set start
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 AND b < 14 ORDER BY b DESC" % selector))
@@ -864,7 +865,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # slice on clustering column with start and finish
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 AND b > 3 AND b < 14" % selector))
@@ -879,7 +880,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
         # reversed slice on clustering column with start and finish
         for page_size in PAGE_SIZES:
-            debug("Current page size is %s".format(page_size))
+            debug("Current page size is {}".format(page_size))
             session.default_fetch_size = page_size
             for selector in selectors:
                 results = list(session.execute("SELECT %s FROM test WHERE a = 99 AND b > 3 AND b < 14 ORDER BY b DESC" % selector))
@@ -1092,7 +1093,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
 
             # single partition
             res = rows_to_list(session.execute("SELECT * FROM test WHERE a = 4 AND b > 3 AND c > 3 AND cnt > 8 ALLOW FILTERING"))
-            self.assertEqual(res, [[4, 7, 8, 91],
+            self.assertEqual(res, [[4, 7, 8, 9],
                                    [4, 8, 9, 10],
                                    [4, 9, 10, 11]],
                              page_size_error_msg)


### PR DESCRIPTION
Shouldn't we insert at CL.ALL if by default we read at CL.ONE? I managed to get a failure locally by forcing an exclusive connection to one node, which I was using for debugging some paging problems in CASSANDRA-11521.

I also fixed a typo.