### PR TITLE
Remove annotations from tests that failed due to recent netty bug

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -1179,9 +1179,6 @@ class TestAuthRoles(Tester):
                                        cassandra,
                                        "LIST ALL PERMISSIONS")
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def create_and_grant_roles_with_superuser_status_test(self):
         """
         * Launch a one node cluster
@@ -1680,9 +1677,6 @@ class TestAuthRoles(Tester):
                             "LIST ALL PERMISSIONS OF john",
                             "You are not authorized to view john's permissions")
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def role_caching_authenticated_user_test(self):
         """
         This test is to show that the role caching in AuthenticatedUser
@@ -2235,9 +2229,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP FUNCTION ks.plus_one(int)")
         self.assert_no_permissions(cassandra, "LIST ALL PERMISSIONS OF mike")
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def drop_keyspace_cleans_up_function_level_permissions_test(self):
         """
         * Launch a one node cluster
@@ -2261,9 +2252,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP KEYSPACE ks")
         self.assert_no_permissions(cassandra, "LIST ALL PERMISSIONS OF mike")
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def udf_permissions_in_selection_test(self):
         """
         Verify EXECUTE permission works in a SELECT when UDF is one of the columns requested
@@ -2318,9 +2306,6 @@ class TestAuthRoles(Tester):
         cassandra.execute("GRANT EXECUTE ON FUNCTION ks.plus_one(int) TO mike")
         return mike.execute(cql)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def inheritence_of_udf_permissions_test(self):
         """
         * Launch a one node cluster
@@ -2384,9 +2369,6 @@ class TestAuthRoles(Tester):
                        "Altering permissions on builtin functions is not supported",
                        InvalidRequest)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def disallow_grant_execute_on_non_function_resources_test(self):
         """
         * Launch a one node cluster

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -392,9 +392,6 @@ class TestCompaction(Tester):
         time.sleep(2)
         self.assertTrue(len(node.grep_log('Compacting.+to_disable', filename=log_file)) > 0, 'Found no log items for {0}'.format(self.strategy))
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def disable_autocompaction_alter_test(self):
         """
         Make sure we can enable compaction using an alter-statement

--- a/cql_tracing_test.py
+++ b/cql_tracing_test.py
@@ -92,9 +92,6 @@ class TestCqlTracing(Tester):
         self.assertIn('Request complete ', out)
         self.assertIn(" Frodo |  Baggins", out)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def tracing_simple_test(self):
         """
         Test tracing using the default tracing class. See trace().

--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -431,9 +431,6 @@ class CqlshCopyTest(Tester):
 
         self.assertCsvResultEqual(tempfile.name, results, 'testlist')
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def test_tuple_data(self):
         """
         Tests the COPY TO command with the tuple datatype by:
@@ -820,9 +817,6 @@ class CqlshCopyTest(Tester):
         self.assertItemsEqual(self.result_to_csv_rows(exported_results, cql_type_names, time_format=format),
                               self.result_to_csv_rows(imported_results, cql_type_names, time_format=format))
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12059',
-                   flaky=True)
     @since('3.2')
     def test_reading_with_ttl(self):
         """
@@ -1063,9 +1057,6 @@ class CqlshCopyTest(Tester):
 
         self.assertItemsEqual(csv_values, result)
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def test_reading_max_parse_errors(self):
         """
         Test that importing a csv file is aborted when we reach the maximum number of parse errors:
@@ -1425,9 +1416,6 @@ class CqlshCopyTest(Tester):
 
         assert_csvs_items_equal(tempfile.name, reference_file.name)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12067',
-                   flaky=True)
     def test_explicit_column_order_reading(self):
         """
         Test that COPY can write to a CSV file when the order of columns is
@@ -1625,9 +1613,6 @@ class CqlshCopyTest(Tester):
                 self.assertFalse(err)
                 self.assertCsvResultEqual(tempfile.name, results, 'testvalidate')
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     @since('2.2')
     def test_read_wrong_column_names(self):
         """
@@ -1773,9 +1758,6 @@ class CqlshCopyTest(Tester):
         _test(True)
         _test(False)
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def test_boolstyle_round_trip(self):
         """
         Test that a CSV file with booleans in a different style successfully round-trips
@@ -2019,9 +2001,6 @@ class CqlshCopyTest(Tester):
                                ['3', '1943-06-19 11:21:01.124+0000']],
                               csv_results)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12061',
-                   flaky=True)
     @since('3.6')
     def test_round_trip_with_different_number_precision(self):
         """
@@ -2076,9 +2055,6 @@ class CqlshCopyTest(Tester):
         do_test(5, 12)
         do_test(5, 15)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     def test_round_trip_with_num_processes(self):
         """
         Test exporting a large number of rows into a csv file with a fixed number of child processes.

--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -689,12 +689,6 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
 (6 rows)
 """)
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12058',
-                   flaky=True)
     def test_describe(self):
         """
         @jira_ticket CASSANDRA-7814
@@ -809,9 +803,6 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
         self.assertEqual("", err)
         self.assertIn("CREATE TABLE ks.map (", out)
 
-    @known_failure(failure_source='cassandra',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12072',
-                   flaky=True)
     @since('3.0')
     def test_describe_mv(self):
         """


### PR DESCRIPTION
In [CASSANDRA-12032](https://issues.apache.org/jira/browse/CASSANDRA-12032), we bumped the netty version in Cassandra to 4.0.37. This contained a bug that caused a variety of dtest failures, including CASSANDRA-12072, CASSANDRA-12067, CASSANDRA-12058, CASSANDRA-12059, and CASSANDRA-12061. 

With commit 78f077de079d0b3760a06a7f944be070772b0c83 in Cassandra, the netty version was reverted to 4.0.36. None of these failures have repeated after the revert.