### PR TITLE
make `nodetool rebuild` calls use same logic

### DIFF
--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -84,6 +84,8 @@ class TestRebuild(Tester):
             except NodetoolError as e:
                 if 'Node is still rebuilding' in e.message:
                     self.rebuild_errors += 1
+                else:
+                    raise e
 
         cmd1 = Thread(target=rebuild)
         cmd1.start()

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -91,10 +91,7 @@ class TestRebuild(Tester):
         # concurrent rebuild should not be allowed (CASSANDRA-9119)
         # (following sleep is needed to avoid conflict in 'nodetool()' method setting up env.)
         time.sleep(.1)
-        try:
-            node2.nodetool('rebuild dc1')
-        except NodetoolError:
-            self.rebuild_errors += 1
+        rebuild()
 
         cmd1.join()
 


### PR DESCRIPTION
Noticed this while looking into

https://issues.apache.org/jira/browse/CASSANDRA-11687

This code wasn't using the same logic between `rebuild` and the code at the top level in the test -- the to-level code would increment `self.rebuild_errors` on any `NodetoolError`, rather than just the one we expect.

I've also re-raised the error when we find an unexpected `NodetoolErrors` -- these should fail the test, yes?