### PR TITLE
make get_test_path a non-test

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -792,6 +792,8 @@ def get_test_path():
         test_path = process.communicate()[0].rstrip()
 
     return test_path
+# nose will discover this as a test, so we manually make it not a test
+get_test_path.__test__ = False
 
 
 def create_ccm_cluster(test_path, name):


### PR DESCRIPTION
`get_test_path` is discovered by `nosetests` as a test in all test modules where it's imported, because it has `test` in the name. This PR manually prevents that:

```sh
~/cstar_src/cassandra-dtest master
(dtest) ❯ CASSANDRA_VERSION=git:trunk nosetests --collect-only -vv --pasteable 2>&1 snapshot_test.py | grep get_test_path
snapshot_test.py:get_test_path ... ok

~/cstar_src/cassandra-dtest master
(dtest) ❯ g co dont-run-get_test_path
Switched to branch 'dont-run-get_test_path'

~/cstar_src/cassandra-dtest dont-run-get_test_path
(dtest) ❯ CASSANDRA_VERSION=git:trunk nosetests --collect-only -vv --pasteable 2>&1 snapshot_test.py | grep get_test_path

~/cstar_src/cassandra-dtest dont-run-get_test_path
(dtest) ❯
```