### PR TITLE
Fixes for CASSANDRA-11850

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -2404,11 +2404,11 @@ class CqlshCopyTest(Tester):
         def create_records():
             if not profile:
                 debug('Running stress without any user profile')
-                self.node1.stress(['write', 'n={}'.format(num_operations), 'no-warmup', '-rate', 'threads=50'])
+                self.node1.stress(['write', 'n={} cl=ALL'.format(num_operations), 'no-warmup', '-rate', 'threads=50'])
             else:
                 debug('Running stress with user profile {}'.format(profile))
                 self.node1.stress(['user', 'profile={}'.format(profile), 'ops(insert=1)',
-                                   'n={}'.format(num_operations), 'no-warmup', '-rate', 'threads=50'])
+                                   'n={} cl=ALL'.format(num_operations), 'no-warmup', '-rate', 'threads=50'])
 
             if skip_count_checks:
                 return num_operations
@@ -2501,9 +2501,9 @@ class CqlshCopyTest(Tester):
     def test_bulk_round_trip_blogposts_with_max_connections(self):
         """
         Same as test_bulk_round_trip_blogposts but limit the maximum number of concurrent connections a host will
-        accept to simulate a failed connection to a replica that is up. Here we are interested in testing COPY TO
-        where we should have at most worker_processes * nodes connections plus 1 (the cqlsh connection). For COPY
-        FROM the driver handles retries. We use only 2 worker processes to make sure it suceeds.
+        accept to simulate a failed connection to a replica that is up. Here we are interested in testing COPY TO,
+        where we should have at most worker_processes * nodes connections + 1 connections, the +1 is the cqlsh
+        connection. For COPY FROM the driver handles retries, we use only 2 worker processes to make sure it succeeds.
 
         @jira_ticket CASSANDRA-10938
         """

--- a/json_test.py
+++ b/json_test.py
@@ -1260,7 +1260,7 @@ class JsonFullRowInsertSelect(Tester):
         Try to create a JSON row with the pkey omitted from the column list, and omitted from the JSON data:
 
             >>> cqlsh_err_print('''INSERT INTO primitive_type_test JSON '{"col1": "bar"}' ''')
-            <stdin>:2:InvalidRequest: code=2200 [Invalid query] message="Invalid null value in condition for column key1"
+            <stdin>:2:InvalidRequest: Error from server: code=2200 [Invalid query] message="Invalid null value in condition for column key1"
             <BLANKLINE>
         """
         run_func_docstring(tester=self, test_func=self.pkey_requirement_test)


### PR DESCRIPTION
These are the companion changes for [CASSANDRA-11850](https://issues.apache.org/jira/browse/CASSANDRA-11850), which upgrades the python driver version embedded with cqlsh. 

This PR must be merge at the same time as the c* patch. 