### PR TITLE
CASSANDRA-12287: Fix sstablelevelreset_test

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -17,10 +17,6 @@ class TestOfflineTools(Tester):
     ignore_log_patterns = ["Unable to initialize MemoryMeter"]
 
     @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12287',
-                   flaky=False,
-                   notes='3.9')
-    @known_failure(failure_source='test',
                    jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11235',
                    flaky=False,
                    notes='windows')
@@ -70,7 +66,7 @@ class TestOfflineTools(Tester):
 
         # test by loading large amount data so we have multiple levels and checking all levels are 0 at end
         cluster.start(wait_for_binary_proto=True)
-        node1.stress(['write', 'n=50K', 'no-warmup', '-rate', 'threads=20', '-schema', 'replication(factor=1)',
+        node1.stress(['write', 'n=50K', 'no-warmup', '-schema', 'replication(factor=1)',
                       '-rate', 'threads=8'])
         cluster.flush()
         self.wait_for_compactions(node1)


### PR DESCRIPTION
This should fix the test by removing a duplicate **-rate ...** parameter, which was passed to **stress**.