### PR TITLE
add ALTER KEYSPACE to make rebuild commands work

### DIFF
--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -73,6 +73,9 @@ class TestRebuild(Tester):
         # alter keyspace to replicate to dc2
         session = self.patient_exclusive_cql_connection(node2)
         session.execute("ALTER KEYSPACE ks WITH REPLICATION = {'class':'NetworkTopologyStrategy', 'dc1':1, 'dc2':1};")
+        # alter system_auth -- rebuilding it no longer possible after
+        # CASSANDRA-11848 prevented local node from being considered a source
+        session.execute("ALTER KEYSPACE system_auth WITH REPLICATION = {'class':'NetworkTopologyStrategy', 'dc1':1, 'dc2':1};")
         session.execute('USE ks')
 
         self.rebuild_errors = 0


### PR DESCRIPTION
This is a fix for the immediate problem in [CASSANDRA-11687](https://issues.apache.org/jira/browse/CASSANDRA-11687). This will not close the ticket, as the tests fails.

I'm not sure this is a long-term solution, so I've filed [CASSANDRA-12296](https://issues.apache.org/jira/browse/CASSANDRA-12296).