### PR TITLE
default to empty notes field

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -366,7 +366,7 @@ def require(require_pattern, broken_in=None):
         return tagging_decorator
 
 
-def known_failure(failure_source, jira_url, flaky=False, notes=None):
+def known_failure(failure_source, jira_url, flaky=False, notes=''):
     """
     Tag a test as a known failure. Associate it with the URL for a JIRA
     ticket and tag it as flaky or not.
@@ -401,8 +401,8 @@ def known_failure(failure_source, jira_url, flaky=False, notes=None):
                            jira_url=jira_url)(f)
         if flaky:
             tagged_func = attr('known_flaky')(tagged_func)
-        if notes:
-            tagged_func = attr(failure_notes=notes)(tagged_func)
+
+        tagged_func = attr(failure_notes=notes)(tagged_func)
         return tagged_func
     return wrapper
 


### PR DESCRIPTION
This will make double-annotation with known_failure work as expected with the notes parameter - if you tag it twice, but omit notes in the outer decorator, the notes will be an empty string.

@knifewine can you review please?