### PR TITLE
exclude OSX specific error/warning from assertion

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -407,7 +407,7 @@ class TestOfflineTools(Tester):
     def _check_stderr_error(self, error):
         if len(error) > 0:
             for line in error.splitlines():
-                self.assertTrue("Max sstable size of" in line or "Consider adding more capacity" in line,
+                self.assertTrue("Max sstable size of" in line or "Consider adding more capacity" in line or "Class JavaLaunchHelper is implemented in both" in line or "JNA link failure" in line,
                                 'Found line \n\n"{line}"\n\n in error\n\n{error}'.format(line=line, error=error))
 
     def _get_final_sstables(self, node, ks, table):


### PR DESCRIPTION
`offline_tools_test` fails on Mac because it does not expect "normal" warnings (`JNA link failure` and `Class JavaLaunchHelper is implemented in both`) in the assertion.

PR adds these to the exclusions.

```
FAIL: sstablelevelreset_test (offline_tools_test.TestOfflineTools)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/snazy/devel/cassandra/dtest/offline_tools_test.py", line 49, in sstablelevelreset_test
    self._check_stderr_error(error)
  File "/Users/snazy/devel/cassandra/dtest/offline_tools_test.py", line 411, in _check_stderr_error
    'Found line \n\n"{line}"\n\n in error\n\n{error}'.format(line=line, error=error))
AssertionError: Found line 

"objc[51491]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/bin/java and /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/jre/lib/libinstrument.dylib. One of the two will be used. Which one is undefined."

 in error

objc[51491]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/bin/java and /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/jre/lib/libinstrument.dylib. One of the two will be used. Which one is undefined.
WARN  14:46:11,545 JNA link failure, one or more native method will be unavailable.

-------------------- >> begin captured stdout << ---------------------
[node1 ERROR] objc[51445]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/bin/java and /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/jre/lib/libinstrument.dylib. One of the two will be used. Which one is undefined.
[node1 ERROR] objc[51483]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/bin/java and /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/jre/lib/libinstrument.dylib. One of the two will be used. Which one is undefined.

--------------------- >> end captured stdout << ----------------------
```