### PR TITLE
Ignore log error cassandra 12340

### DIFF
--- a/upgrade_supercolumns_test.py
+++ b/upgrade_supercolumns_test.py
@@ -11,7 +11,7 @@ from thrift_bindings.v22.ttypes import (CfDef, Column, ColumnOrSuperColumn,
                                         Mutation, SlicePredicate, SliceRange,
                                         SuperColumn, TimedOutException)
 from thrift_tests import get_thrift_client
-from tools import RerunTestException, requires_rerun, since, known_failure
+from tools import RerunTestException, known_failure, requires_rerun, since
 
 
 @since('2.0', max_version='2.1.x')


### PR DESCRIPTION
@knifewine Could I get a quick review? This should successfully ignore the error in [CASSANDRA-12340](https://issues.apache.org/jira/browse/CASSANDRA-12340), yeah?

I forgot to remove the `known_failure` annotation, so I'll need to do that before merge, if we merge this.