### PR TITLE
CASSANDRA-11687

### DIFF
--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -92,19 +92,24 @@ class TestRebuild(Tester):
                 else:
                     raise e
 
-        def call_and_register_exc_info_on_exception(func):
-            """
-            Closes over self to catch any exceptions raised by func and
-            register them at self.thread_exc_info
-            Based on http://stackoverflow.com/a/1854263
-            """
-            try:
-                func()
-            except Exception:
-                import sys
-                self.thread_exc_info = sys.exc_info()
+        class Runner(Thread):
+            def __init__(self, func):
+                Thread.__init__(self)
+                self.func = func
 
-        cmd1 = Thread(target=call_and_register_exc_info_on_exception(rebuild))
+            def run(self):
+                """
+                Closes over self to catch any exceptions raised by func and
+                register them at self.thread_exc_info
+                Based on http://stackoverflow.com/a/1854263
+                """
+                try:
+                    self.func()
+                except Exception:
+                    import sys
+                    self.thread_exc_info = sys.exc_info()
+
+        cmd1 = Runner(rebuild)
         cmd1.start()
 
         # concurrent rebuild should not be allowed (CASSANDRA-9119)

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -87,7 +87,6 @@ class TestRebuild(Tester):
         # exactly 1 of the two nodetool calls should fail
         try:
             node2.nodetool('rebuild dc1')
-            self.fail("second rebuild should fail")
         except NodetoolError as e:
             self.assertTrue('Node is still rebuilding' in e.message)
 

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -5,7 +5,7 @@ from cassandra import ConsistencyLevel
 from ccmlib.node import NodetoolError
 
 from dtest import Tester
-from tools import insert_c1c2, known_failure, query_c1c2, since
+from tools import insert_c1c2, query_c1c2, since
 
 
 class TestRebuild(Tester):

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -1,4 +1,5 @@
 import time
+from threading import Thread
 
 from cassandra import ConsistencyLevel
 from ccmlib.node import NodetoolError

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -79,8 +79,6 @@ class TestRebuild(Tester):
         session.execute('USE ks')
 
         self.rebuild_errors = 0
-        # make it possible for thread to raise errors
-        self.thread_exc_info = None
 
         # rebuild dc2 from dc1
         def rebuild():
@@ -96,6 +94,7 @@ class TestRebuild(Tester):
             def __init__(self, func):
                 Thread.__init__(self)
                 self.func = func
+                self.thread_exc_info = None
 
             def run(self):
                 """
@@ -122,8 +121,8 @@ class TestRebuild(Tester):
 
         # manually raise exception from cmd1 thread
         # see http://stackoverflow.com/a/1854263
-        if self.thread_exc_info is not None:
-            raise self.thread_exc_info[1], None, self.thread_exc_info[2]
+        if cmd1.thread_exc_info is not None:
+            raise cmd1.thread_exc_info[1], None, cmd1.thread_exc_info[2]
 
         # exactly 1 of the two nodetool calls should fail
         # usually it will be the one in the main thread,

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -24,9 +24,6 @@ class TestRebuild(Tester):
         ]
         Tester.__init__(self, *args, **kwargs)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11687',
-                   flaky=True)
     def simple_rebuild_test(self):
         """
         @jira_ticket CASSANDRA-9119
@@ -52,11 +49,11 @@ class TestRebuild(Tester):
         session = self.patient_exclusive_cql_connection(node1)
         self.create_ks(session, 'ks', {'dc1': 1})
         self.create_cf(session, 'cf', columns={'c1': 'text', 'c2': 'text'})
-        insert_c1c2(session, n=keys, consistency=ConsistencyLevel.ALL)
+        insert_c1c2(session, n=keys, consistency=ConsistencyLevel.LOCAL_ONE)
 
         # check data
         for i in xrange(0, keys):
-            query_c1c2(session, i, ConsistencyLevel.ALL)
+            query_c1c2(session, i, ConsistencyLevel.LOCAL_ONE)
         session.shutdown()
 
         # Bootstrapping a new node in dc2 with auto_bootstrap: false
@@ -133,7 +130,7 @@ class TestRebuild(Tester):
 
         # check data
         for i in xrange(0, keys):
-            query_c1c2(session, i, ConsistencyLevel.ALL)
+            query_c1c2(session, i, ConsistencyLevel.LOCAL_ONE)
 
     @since('3.6')
     def rebuild_ranges_test(self):


### PR DESCRIPTION
First of all, my fix in #1146 was not doing the job. Even though nodetool is invoked in background first, the second call can be invoked first. So I reverted the changes made.

Now, I noticed that we were trying to spawn Thread to run rebuild in parallel, but actually it wasn't. The first rebuild is called before the thread is created, resulting sequential rebuild call instead of parallel.

@mambocab @pauloricardomg can you run multiplexer on this one?