### PR TITLE
add more helpful message to upgrade base class

### DIFF
--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -49,6 +49,7 @@ class UpgradeTester(Tester):
         super(UpgradeTester, self).__init__(*args, **kwargs)
 
     def setUp(self):
+        self.validate_class_config()
         debug("Upgrade test beginning, setting CASSANDRA_VERSION to {}, and jdk to {}. (Prior values will be restored after test)."
               .format(self.UPGRADE_PATH.starting_version, self.UPGRADE_PATH.starting_meta.java_version))
         switch_jdks(self.UPGRADE_PATH.starting_meta.java_version)
@@ -197,3 +198,14 @@ class UpgradeTester(Tester):
         if is_win() and self.cluster.version() <= '2.2':
             self.cluster.nodelist()[1].mark_log_for_errors()
         super(UpgradeTester, self).tearDown()
+
+    def validate_class_config(self):
+        # check that an upgrade path is specified
+        subclasses = self.__class__.__subclasses__()
+        no_upgrade_path_error = (
+            'No upgrade path specified. {klaus} may not be configured to run as a test.'.format(klaus=self.__class__) +
+            (' Did you mean to run one of its subclasses, such as {sub}?'.format(sub=subclasses[0])
+             if subclasses else
+             '')
+        )
+        self.assertIsNotNone(self.UPGRADE_PATH, no_upgrade_path_error)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-11126?focusedCommentId=15404041&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15404041

If you try to run tests in one of the base test classes, the error message is just incidental and doesn't help much if you don't understand the way the tests are generated:

```
RUN_STATIC_UPGRADE_MATRIX=true CASSANDRA_VERSION=git:trunk JAVA8_HOME=/usr/lib/jvm/java-8-openjdk JAVA7_HOME=/usr/lib/jvm/java-7-openjdk python2.7 ./run_dtests.py --vnodes false  --nose-options='-v' upgrade_tests/cql_tests.py:TestCQL.select_distinct_with_deletions_test
[...]
======================================================================
ERROR: select_distinct_with_deletions_test (upgrade_tests.cql_tests.TestCQL)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pcmanus/Git/cassandra-dtest/upgrade_tests/upgrade_base.py", line 53, in setUp
    .format(self.UPGRADE_PATH.starting_version, self.UPGRADE_PATH.starting_meta.java_version))
AttributeError: 'NoneType' object has no attribute 'starting_version'
-------------------- >> begin captured logging << --------------------
```

So, this improves that error message:

```
CASSANDRA_VERSION=git:trunk ./run_dtests.py --vnodes false --nose-options= --with-id --verbosity=2 --nocapture upgrade_tests/cql_tests.py:TestCQL.select_distinct_with_deletions_test
[...]
======================================================================
ERROR: upgrade_tests/cql_tests.py:TestCQL.select_distinct_with_deletions_test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mambocab/cstar_src/cassandra-dtest/upgrade_tests/upgrade_base.py", line 52, in setUp
    self.validate_class_config()
  File "/home/mambocab/cstar_src/cassandra-dtest/upgrade_tests/upgrade_base.py", line 211, in validate_class_config
    self.assertIsNotNone(self.UPGRADE_PATH, no_upgrade_path_error)
AssertionError: No upgrade path specified. <class 'upgrade_tests.cql_tests.TestCQL'> may not be configured to run as a test. Did you mean to run one of its subclasses, such as <class 'abc.TestCQLNodes3RF3_Upgrade_current_2_2_x_To_in
dev_2_2_x'>?
```

@knifewine could you review please?