### PR TITLE
close session before shutting down nodes

### DIFF
--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -987,6 +987,8 @@ class TestMaterializedViews(Tester):
                 [i, i, 'a', 3.0]
             )
 
+        debug('Close connection to node1')
+        session.cluster.shutdown()
         debug('Shutdown node1, node4 and node5')
         node1.stop()
         node4.stop()


### PR DESCRIPTION
I saw some failures on a multiplexer run:

http://cassci.datastax.com/view/Parameterized/job/parameterized_dtest_multiplexer/169/testReport/junit/node_0_iter_246.materialized_views_test/TestMaterializedViews/complex_repair_test/

that look like the session trying to connect to (correctly) downed nodes. Running `materialized_views_test.py:TestMaterializedViews.complex_repair_test` succeeds on my machine.