### PR TITLE
Fix enabling of jmx auth on windows

### DIFF
--- a/jmx_auth_test.py
+++ b/jmx_auth_test.py
@@ -4,15 +4,12 @@ from ccmlib.node import ToolError
 
 from dtest import Tester
 from jmxutils import apply_jmx_authentication
-from tools import known_failure, since
+from tools import since
 
 
 @since('3.6')
 class TestJMXAuth(Tester):
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-11730',
-                   flaky=False, notes='windows')
     def basic_auth_test(self):
         """
         Some basic smoke testing of JMX authentication and authorization.

--- a/jmxutils.py
+++ b/jmxutils.py
@@ -128,6 +128,15 @@ def enable_jmx_ssl(node,
 
 def apply_jmx_authentication(node):
     replacement_list = [
+        ('#\$env:JVM_OPTS="\$env:JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"',
+         '$env:JVM_OPTS="$env:JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"'),
+        ('#\$env:JVM_OPTS="\$JVM_OPTS -Dcassandra.jmx.remote.login.config=CassandraLogin"',
+         '$env:JVM_OPTS="$env:JVM_OPTS -Dcassandra.jmx.remote.login.config=CassandraLogin"'),
+        ('#\$env:JVM_OPTS="\$JVM_OPTS -Djava.security.auth.login.config=C:/cassandra-jaas.config"',
+         '$env:JVM_OPTS="$env:JVM_OPTS -Djava.security.auth.login.config=$env:CASSANDRA_HOME\conf\cassandra-jaas.config"'),
+        ('#\$env:JVM_OPTS="\$JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"',
+         '$env:JVM_OPTS="$env:JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"')
+    ] if common.is_win() else [
         ('JVM_OPTS="\$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false"',
          'JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"'),
         ('JVM_OPTS="\$JVM_OPTS -Dcom.sun.management.jmxremote.password.file=/etc/cassandra/jmxremote.password"',
@@ -139,6 +148,7 @@ def apply_jmx_authentication(node):
         ('#JVM_OPTS="\$JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"',
          'JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"')
     ]
+
     common.replaces_in_file(node.envfilename(), replacement_list)
 
 


### PR DESCRIPTION
PR for issue at [CASSANDRA-11730](https://issues.apache.org/jira/browse/CASSANDRA-11730). This edits the Windows config files appropriately to set up JMX auth.