### PR TITLE
special case for 2.2/3.0 mixed version cluster paging

### DIFF
--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -187,6 +187,13 @@ class PageAssertionMixin(object):
 class BasePagingTester(UpgradeTester):
 
     def prepare(self, *args, **kwargs):
+        start_on, upgrade_to = self.UPGRADE_PATH.starting_meta, self.UPGRADE_PATH.upgrade_meta
+        if 'protocol_version' not in kwargs.keys():
+            # Due to CASSANDRA-10880, we need to use proto v3 (instead of v4) when it's a mixed cluster of 2.2.x and 3.0.x nodes.
+            if start_on.family == '2.2.x' and upgrade_to.family == '3.0.x':
+                debug("Protocol version set to v3, due to 2.2.x and 3.0.x mixed version cluster.")
+                kwargs['protocol_version'] = 3
+
         cursor = UpgradeTester.prepare(self, *args, **kwargs)
         cursor.row_factory = dict_factory
         return cursor


### PR DESCRIPTION
Due to CASSANDRA-10880 there's a special case that needs to be handled with protocol version.

This mixed cluster combination of 2.2/3.0 needs to work over proto v3, rather than v4 (despite that fact that both support v4).