### PR TITLE
page wait() small improvements

### DIFF
--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -126,8 +126,12 @@ class PageFetcher(object):
         while time.time() < expiry:
             if self.requested_pages == (self.retrieved_pages + self.retrieved_empty_pages):
                 return self
+            # small wait so we don't need excess cpu to keep checking
+            time.sleep(0.1)
 
-        raise RuntimeError("Requested pages were not delivered before timeout.")
+        raise RuntimeError(
+            "Requested pages were not delivered before timeout." +
+            "Requested: {}; retrieved: {}; empty retrieved: {}".format(self.requested_pages, self.retrieved_pages, self.retrieved_empty_pages))
 
     def pagecount(self):
         """


### PR DESCRIPTION
Add a small loop sleep, and improve debug message when paging times out.

I spotted these small differences comparing the regular paging tests to the upgrade paging tests, and thought they could be useful in the upgrade suite.

At some point we should extract the paging utility classes to a single place, so that both paging suites can pull it in without code duplication, so this is a small band-aid for now.