### PR TITLE
remove redundant argument

### DIFF
--- a/repair_tests/repair_test.py
+++ b/repair_tests/repair_test.py
@@ -769,7 +769,7 @@ class TestRepair(BaseRepairTest):
         t3.join()
         node1.stop(wait_other_notice=True)
         node3.stop(wait_other_notice=True)
-        _, stderr, _ = node2.stress(['read', 'n=1M', 'no-warmup', '-rate', 'threads=30', '-node', node2.address()])
+        _, stderr, _ = node2.stress(['read', 'n=1M', 'no-warmup', '-rate', 'threads=30'])
         self.assertTrue(len(stderr) == 0, stderr)
 
 RepairTableContents = namedtuple('RepairTableContents',


### PR DESCRIPTION
@ptnapoleon or @mambocab or @knifewine, for your consideration.

The `--node` argument is redundant here, as it is specified inside of ccmlib/node.py here:
https://github.com/pcmanus/ccm/blob/master/ccmlib/node.py#L1226-L1229

Running a quick multiplex here: http://cassci.datastax.com/view/Parameterized/job/parameterized_dtest_multiplexer/218/