### PR TITLE
Added missing known_failure import

### DIFF
--- a/cql_tracing_test.py
+++ b/cql_tracing_test.py
@@ -3,7 +3,7 @@
 from distutils.version import LooseVersion
 
 from dtest import Tester, debug
-from tools import since
+from tools import known_failure, since
 
 
 class TestCqlTracing(Tester):


### PR DESCRIPTION
`cql_tracing_test.py` currently doesn't run because `known_failure` was added without an import for it.