### PR TITLE
Update jmx_auth_test on Windows for config file changes

### DIFF
--- a/jmxutils.py
+++ b/jmxutils.py
@@ -130,11 +130,11 @@ def apply_jmx_authentication(node):
     replacement_list = [
         ('#\$env:JVM_OPTS="\$env:JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"',
          '$env:JVM_OPTS="$env:JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"'),
-        ('#\$env:JVM_OPTS="\$JVM_OPTS -Dcassandra.jmx.remote.login.config=CassandraLogin"',
+        ('#\$env:JVM_OPTS="\$env:JVM_OPTS -Dcassandra.jmx.remote.login.config=CassandraLogin"',
          '$env:JVM_OPTS="$env:JVM_OPTS -Dcassandra.jmx.remote.login.config=CassandraLogin"'),
-        ('#\$env:JVM_OPTS="\$JVM_OPTS -Djava.security.auth.login.config=C:/cassandra-jaas.config"',
+        ('#\$env:JVM_OPTS="\$env:JVM_OPTS -Djava.security.auth.login.config=C:/cassandra-jaas.config"',
          '$env:JVM_OPTS="$env:JVM_OPTS -Djava.security.auth.login.config=$env:CASSANDRA_HOME\conf\cassandra-jaas.config"'),
-        ('#\$env:JVM_OPTS="\$JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"',
+        ('#\$env:JVM_OPTS="\$env:JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"',
          '$env:JVM_OPTS="$env:JVM_OPTS -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy"')
     ] if common.is_win() else [
         ('JVM_OPTS="\$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false"',


### PR DESCRIPTION
This pull request is intended to fix [CASSANDRA-11730](https://issues.apache.org/jira/browse/CASSANDRA-11730).

I originally PRed a fix to this issue as PR #1175 but the config file contents concurrently changed in [CASSANDRA-12109](https://issues.apache.org/jira/browse/CASSANDRA-12109), so the replace was no longer working correctly. This now passes correctly on trunk.

@mambocab to review probably, since he reviewed the original.