### PR TITLE
install driver & ccm as editable eggs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/datastax/python-driver.git@cassandra-test
-git+https://github.com/pcmanus/ccm.git
+-e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
+-e git+https://github.com/pcmanus/ccm.git@master#egg=ccm
 cql
 decorator
 docopt


### PR DESCRIPTION
This is not very useful now, because our CI doesn't yet use this `requirements.txt`. However, once it does, this will be helpful: it makes `pip freeze` report the hash of the installed commit for the driver and CCM:

```sh
~/cstar_src/cassandra-dtest master*  11s
(dtest-test-sha-reporting) ❯ pip install -r requirements.txt 
Obtaining cassandra-driver from git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver (from -r requirements.txt (line 1))
  Cloning https://github.com/datastax/python-driver.git (to cassandra-test) to /home/mambocab/.pyenv/versions/2.7.12/envs/dtest-test-sha-reporting/src/cassandra-driver
Obtaining ccm from git+https://github.com/pcmanus/ccm.git@master#egg=ccm (from -r requirements.txt (line 2))
  Updating /home/mambocab/.pyenv/versions/2.7.12/envs/dtest-test-sha-reporting/src/ccm clone (to master)
Collecting cql (from -r requirements.txt (line 3))
Collecting decorator (from -r requirements.txt (line 4))
  Using cached decorator-4.0.10-py2.py3-none-any.whl
Collecting docopt (from -r requirements.txt (line 5))
Collecting enum34 (from -r requirements.txt (line 6))
  Using cached enum34-1.1.6-py2-none-any.whl
Collecting flaky (from -r requirements.txt (line 7))
  Using cached flaky-3.3.0-py2.py3-none-any.whl
Collecting futures (from -r requirements.txt (line 8))
  Using cached futures-3.0.5-py2-none-any.whl
Collecting mock (from -r requirements.txt (line 9))
  Using cached mock-2.0.0-py2.py3-none-any.whl
Collecting nose (from -r requirements.txt (line 10))
  Using cached nose-1.3.7-py2-none-any.whl
Collecting nose-test-select (from -r requirements.txt (line 11))
Collecting parse (from -r requirements.txt (line 12))
  Using cached parse-1.6.6-py2-none-any.whl
Collecting psutil (from -r requirements.txt (line 13))
Collecting pycassa (from -r requirements.txt (line 14))
Collecting six (from -r requirements.txt (line 15))
  Using cached six-1.10.0-py2.py3-none-any.whl
Collecting thrift (from -r requirements.txt (line 16))
Collecting pyYaml (from ccm->-r requirements.txt (line 2))
Collecting funcsigs>=1; python_version < "3.3" (from mock->-r requirements.txt (line 9))
  Using cached funcsigs-1.0.2-py2.py3-none-any.whl
Collecting pbr>=0.11 (from mock->-r requirements.txt (line 9))
  Using cached pbr-1.10.0-py2.py3-none-any.whl
Installing collected packages: six, futures, cassandra-driver, pyYaml, ccm, thrift, cql, decorator, docopt, enum34, flaky, funcsigs, pbr, mock, nose, nose-test-select, parse, psutil, pycassa
  Running setup.py develop for cassandra-driver
  Running setup.py develop for ccm
Successfully installed cassandra-driver ccm cql-1.4.0 decorator-4.0.10 docopt-0.6.2 enum34-1.1.6 flaky-3.3.0 funcsigs-1.0.2 futures-3.0.5 mock-2.0.0 nose-1.3.7 nose-test-select-0.3 parse-1.6.6 pbr-1.10.0 psutil-4.3.0 pyYaml-3.11 pyc
assa-1.11.1 six-1.10.0 thrift-0.9.3

~/cstar_src/cassandra-dtest master*  4m 25s
(dtest-test-sha-reporting) ❯ pip freeze
-e git+https://github.com/datastax/python-driver.git@f433a80cb0d8d691b25a4d826866fda7916cd2f1#egg=cassandra_driver
-e git+https://github.com/pcmanus/ccm.git@3c09695b6b22aa6dfd24f83b964b1299351a4572#egg=ccm
cql==1.4.0
decorator==4.0.10
docopt==0.6.2
enum34==1.1.6
flaky==3.3.0
funcsigs==1.0.2
futures==3.0.5
mock==2.0.0
nose==1.3.7
nose-test-select==0.3
parse==1.6.6
pbr==1.10.0
psutil==4.3.0
pycassa==1.11.1
PyYAML==3.11
six==1.10.0
thrift==0.9.3
```