### PR TITLE
Add pull repair test for CASSANDRA-9876

### DIFF
--- a/repair_tests/deprecated_repair_test.py
+++ b/repair_tests/deprecated_repair_test.py
@@ -30,6 +30,7 @@ class TestDeprecatedRepairAPI(Tester):
         self.assertEqual(opt["data_centers"], "[]", opt)
         self.assertEqual(opt["hosts"], "[]", opt)
         self.assertEqual(opt["column_families"], "[cf]", opt)
+        self.assertEqual(opt["pull_repair"], "false", opt)
 
     def force_repair_async_2_test(self):
         """
@@ -47,6 +48,7 @@ class TestDeprecatedRepairAPI(Tester):
         self.assertEqual(opt["data_centers"], "[]", opt)
         self.assertEqual(opt["hosts"], "[]", opt)
         self.assertEqual(opt["column_families"], "[]", opt)
+        self.assertEqual(opt["pull_repair"], "false", opt)
 
     def force_repair_async_3_test(self):
         """
@@ -63,6 +65,7 @@ class TestDeprecatedRepairAPI(Tester):
         self.assertEqual(opt["data_centers"], "[]", opt)
         self.assertEqual(opt["hosts"], "[]", opt)
         self.assertEqual(opt["column_families"], "[cf]", opt)
+        self.assertEqual(opt["pull_repair"], "false", opt)
 
     def force_repair_range_async_1_test(self):
         """
@@ -82,6 +85,7 @@ class TestDeprecatedRepairAPI(Tester):
         self.assertEqual(opt["hosts"], "[]", opt)
         self.assertEqual(opt["ranges"], "1", opt)
         self.assertEqual(opt["column_families"], "[cf]", opt)
+        self.assertEqual(opt["pull_repair"], "false", opt)
 
     def force_repair_range_async_2_test(self):
         """
@@ -101,6 +105,7 @@ class TestDeprecatedRepairAPI(Tester):
         self.assertEqual(opt["hosts"], "[]", opt)
         self.assertEqual(opt["ranges"], "1", opt)
         self.assertEqual(opt["column_families"], "[cf]", opt)
+        self.assertEqual(opt["pull_repair"], "false", opt)
 
     def force_repair_range_async_3_test(self):
         """
@@ -119,6 +124,7 @@ class TestDeprecatedRepairAPI(Tester):
         self.assertEqual(opt["hosts"], "[]", opt)
         self.assertEqual(opt["ranges"], "1", opt)
         self.assertEqual(opt["column_families"], "[cf]", opt)
+        self.assertEqual(opt["pull_repair"], "false", opt)
 
     def _deprecated_repair_jmx(self, method, arguments):
         """
@@ -152,7 +158,7 @@ class TestDeprecatedRepairAPI(Tester):
         # get repair parameters from the log
         l = node1.grep_log(("Starting repair command #1, repairing keyspace ks with repair options \(parallelism: (?P<parallelism>\w+), primary range: (?P<pr>\w+), "
                             "incremental: (?P<incremental>\w+), job threads: (?P<jobs>\d+), ColumnFamilies: (?P<cfs>.+), dataCenters: (?P<dc>.+), "
-                            "hosts: (?P<hosts>.+), # of ranges: (?P<ranges>\d+)\)"))
+                            "hosts: (?P<hosts>.+), # of ranges: (?P<ranges>\d+), pull repair: (?P<pullrepair>true|false)\)"))
         self.assertEqual(len(l), 1)
         line, m = l[0]
         return {"parallelism": m.group("parallelism"),
@@ -162,4 +168,5 @@ class TestDeprecatedRepairAPI(Tester):
                 "column_families": m.group("cfs"),
                 "data_centers": m.group("dc"),
                 "hosts": m.group("hosts"),
-                "ranges": m.group("ranges")}
+                "ranges": m.group("ranges"),
+                "pull_repair": m.group("pullrepair")}

--- a/repair_tests/repair_test.py
+++ b/repair_tests/repair_test.py
@@ -721,6 +721,42 @@ class TestRepair(BaseRepairTest):
 
         self._parameterized_range_repair(repair_opts=['-pr'])
 
+    @no_vnodes()
+    def pull_repair_test(self):
+        """
+        Test repair using the --pull option
+        @jira_ticket CASSANDRA-9876
+        * Launch a three node cluster
+        * Insert some data at RF 2
+        * Shut down node2, insert more data, restore node2
+        * Issue a pull repair on a range that only belongs to node1
+        * Verify that nodes 1 and 2, and only nodes 1+2, are repaired
+        * Verify that node1 only received data
+        * Verify that node2 only sent data
+        """
+        cluster = self.cluster
+        cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
+        cluster.set_batch_commitlog(enabled=True)
+        debug("Starting cluster..")
+        cluster.populate(3).start(wait_for_binary_proto=True)
+
+        node1, node2, node3 = cluster.nodelist()
+
+        node1_address = node1.network_interfaces['binary'][0]
+        node2_address = node2.network_interfaces['binary'][0]
+
+        self._parameterized_range_repair(repair_opts=['--pull', '--in-hosts', node1_address + ',' + node2_address, '-st', str(node3.initial_token), '-et', str(node1.initial_token)])
+
+        # Node 1 should only receive files (as we ran a pull repair on node1)
+        self.assertTrue(len(node1.grep_log("Receiving [1-9][0-9]* files")) > 0)
+        self.assertEqual(len(node1.grep_log("sending [1-9][0-9]* files")), 0)
+        self.assertTrue(len(node1.grep_log("sending 0 files")) > 0)
+
+        # Node 2 should only send files (as we ran a pull repair on node1)
+        self.assertEqual(len(node2.grep_log("Receiving [1-9][0-9]* files")), 0)
+        self.assertTrue(len(node2.grep_log("Receiving 0 files")) > 0)
+        self.assertTrue(len(node2.grep_log("sending [1-9][0-9]* files")) > 0)
+
     def _parameterized_range_repair(self, repair_opts):
         """
         @param repair_opts A list of strings which represent cli args to nodetool repair

--- a/repair_tests/repair_test.py
+++ b/repair_tests/repair_test.py
@@ -721,6 +721,7 @@ class TestRepair(BaseRepairTest):
 
         self._parameterized_range_repair(repair_opts=['-pr'])
 
+    @since('3.10')
     @no_vnodes()
     def pull_repair_test(self):
         """


### PR DESCRIPTION
This adds a dtest for pull repairs, which are introduced in [CASSANDRA-9876](https://issues.apache.org/jira/browse/CASSANDRA-9876).