### PR TITLE
Stabilize resumable_bootstrap_test by using byteman

### DIFF
--- a/stream_failure.btm
+++ b/stream_failure.btm
@@ -1,0 +1,17 @@
+#
+# Inject streaming failure
+#
+# Before start streaming files in `StreamSession#prepare()` method,
+# interrupt streaming by throwing RuntimeException.
+#
+RULE inject stream failure
+CLASS org.apache.cassandra.streaming.StreamSession
+METHOD prepare
+AT INVOKE startStreamingFiles
+BIND peer = $0.peer
+# set flag to only run this rule once.
+IF peer.equals(InetAddress.getByName("127.0.0.3")) AND NOT flagged("done")
+DO
+   flag("done");
+   throw new java.lang.RuntimeException("Triggering network failure")
+ENDRULE

--- a/tools.py
+++ b/tools.py
@@ -432,17 +432,6 @@ def safe_mkdtemp():
     return tmpdir.replace('\\', '/')
 
 
-class InterruptBootstrap(Thread):
-
-    def __init__(self, node):
-        Thread.__init__(self)
-        self.node = node
-
-    def run(self):
-        self.node.watch_log_for("Prepare completed")
-        self.node.stop(gently=False)
-
-
 class InterruptCompaction(Thread):
     """
     Interrupt compaction by killing a node as soon as


### PR DESCRIPTION
Although It's faily stable recently, [the most recent failure](http://cassci.datastax.com/job/cassandra-3.9_novnode_dtest/30/testReport/bootstrap_test/TestBootstrap/resumable_bootstrap_test/) indicates there still be a chance that the test fails because bootstrap streaming is not interrupted as expected.

This patch uses byteman instead of Thread and watch_for_log for killing node to fail bootstrap stream.
This is more reliable and since we can eliminate node start/stop and decrease the size of SSTable, test runs much faster (2x to 3x).

Byteman support is added to 2.2 also so this should be fine.