### PR TITLE
Wait for all pools on cluster connect

### DIFF
--- a/dtest.py
+++ b/dtest.py
@@ -503,7 +503,7 @@ class Tester(TestCase):
         cluster = PyCluster([node_ip], auth_provider=auth_provider, compression=compression,
                             protocol_version=protocol_version, load_balancing_policy=load_balancing_policy, default_retry_policy=FlakyRetryPolicy(),
                             port=port, ssl_options=ssl_opts, connect_timeout=10)
-        session = cluster.connect()
+        session = cluster.connect(wait_for_all_pools=True)
 
         # temporarily increase client-side timeout to 1m to determine
         # if the cluster is simply responding slowly to requests


### PR DESCRIPTION
This was a tweak suggested by @aholmberg that restores an old behavior of the Python driver. Previously, the driver waited for all pools on cluster connect. Now, the default behavior is to return after successfully connecting to one. Note that this change would break tests for users who have not updated their driver.

@aholmberg, what are the consequences if we don't enable this? Tests should continue to function correctly, right?