### PR TITLE
re-introduce InterruptBootstrap

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -432,6 +432,17 @@ def safe_mkdtemp():
     return tmpdir.replace('\\', '/')
 
 
+class InterruptBootstrap(Thread):
+
+    def __init__(self, node):
+        Thread.__init__(self)
+        self.node = node
+
+    def run(self):
+        self.node.watch_log_for("Prepare completed")
+        self.node.stop(gently=False)
+
+
 class InterruptCompaction(Thread):
     """
     Interrupt compaction by killing a node as soon as


### PR DESCRIPTION
This class was removed in https://github.com/riptano/cassandra-dtest/pull/1213, but I missed on review that `InterruptBoostrap` is used elsewhere.