### PR TITLE
Bump timeout for cassandra 12456

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -43,8 +43,11 @@ class TestAuth(Tester):
         debug("nodes started")
 
         session = self.get_session(user='cassandra', password='cassandra')
-        auth_metadata = UpdatingKeyspaceMetadataWrapper(cluster=session.cluster,
-                                                        ks_name='system_auth')
+        auth_metadata = UpdatingKeyspaceMetadataWrapper(
+            cluster=session.cluster,
+            ks_name='system_auth',
+            max_schema_agreement_wait=30  # 3x the default of 10
+        )
         self.assertEquals(1, auth_metadata.replication_strategy.replication_factor)
 
         session.execute("""

--- a/meta_tests/utils_test/metadata_wrapper_test.py
+++ b/meta_tests/utils_test/metadata_wrapper_test.py
@@ -66,10 +66,12 @@ class UpdatingTableMetadataWrapperTest(TestCase):
     def setUp(self):
         self.cluster_mock = MagicMock()
         self.ks_name_sentinel, self.table_name_sentinel = Mock(name='ks'), Mock(name='tab')
+        self.max_schema_agreement_wait_sentinel = Mock(name='wait')
         self.wrapper = UpdatingTableMetadataWrapper(
             cluster=self.cluster_mock,
             ks_name=self.ks_name_sentinel,
-            table_name=self.table_name_sentinel
+            table_name=self.table_name_sentinel,
+            max_schema_agreement_wait=self.max_schema_agreement_wait_sentinel
         )
 
     def wrapped_access_calls_refresh_test(self):
@@ -80,7 +82,22 @@ class UpdatingTableMetadataWrapperTest(TestCase):
         self.cluster_mock.refresh_table_metadata.assert_not_called()
         self.wrapper._wrapped
         self.cluster_mock.refresh_table_metadata.assert_called_once_with(
-            self.ks_name_sentinel, self.table_name_sentinel
+            self.ks_name_sentinel,
+            self.table_name_sentinel,
+            max_schema_agreement_wait=self.max_schema_agreement_wait_sentinel
+        )
+
+    def default_wrapper_max_schema_agreement_wait_is_None_test(self):
+        wrapper = UpdatingTableMetadataWrapper(
+            cluster=self.cluster_mock,
+            ks_name=self.ks_name_sentinel,
+            table_name=self.table_name_sentinel
+        )
+        wrapper._wrapped
+        self.cluster_mock.refresh_table_metadata.assert_called_once_with(
+            self.ks_name_sentinel,
+            self.table_name_sentinel,
+            max_schema_agreement_wait=None
         )
 
     def wrapped_returns_table_metadata_test(self):
@@ -111,8 +128,9 @@ class UpdatingTableMetadataWrapperTest(TestCase):
     def repr_test(self):
         self.assertEqual(
             repr(self.wrapper),
-            'UpdatingTableMetadataWrapper(cluster={}, ks_name={}, table_name={})'.format(
-                self.cluster_mock, self.ks_name_sentinel, self.table_name_sentinel
+            'UpdatingTableMetadataWrapper(cluster={}, ks_name={}, table_name={}, max_schema_agreement_wait={})'.format(
+                self.cluster_mock, self.ks_name_sentinel,
+                self.table_name_sentinel, self.max_schema_agreement_wait_sentinel
             )
         )
 
@@ -121,8 +139,10 @@ class UpdatingKeyspaceMetadataWrapperTest(TestCase):
 
     def setUp(self):
         self.cluster_mock, self.ks_name_sentinel = MagicMock(), Mock(name='ks')
+        self.max_schema_agreement_wait_sentinel = Mock(name='wait')
         self.wrapper = UpdatingKeyspaceMetadataWrapper(
-            cluster=self.cluster_mock, ks_name=self.ks_name_sentinel
+            cluster=self.cluster_mock, ks_name=self.ks_name_sentinel,
+            max_schema_agreement_wait=self.max_schema_agreement_wait_sentinel
         )
 
     def wrapped_access_calls_refresh_test(self):
@@ -133,7 +153,19 @@ class UpdatingKeyspaceMetadataWrapperTest(TestCase):
         self.cluster_mock.refresh_keyspace_metadata.assert_not_called()
         self.wrapper._wrapped
         self.cluster_mock.refresh_keyspace_metadata.assert_called_once_with(
-            self.ks_name_sentinel
+            self.ks_name_sentinel,
+            max_schema_agreement_wait=self.max_schema_agreement_wait_sentinel
+        )
+
+    def default_wrapper_max_schema_agreement_wait_is_None_test(self):
+        wrapper = UpdatingKeyspaceMetadataWrapper(
+            cluster=self.cluster_mock,
+            ks_name=self.ks_name_sentinel
+        )
+        wrapper._wrapped
+        self.cluster_mock.refresh_keyspace_metadata.assert_called_once_with(
+            self.ks_name_sentinel,
+            max_schema_agreement_wait=None
         )
 
     def wrapped_returns_keyspace_metadata_test(self):
@@ -150,8 +182,8 @@ class UpdatingKeyspaceMetadataWrapperTest(TestCase):
     def repr_test(self):
         self.assertEqual(
             repr(self.wrapper),
-            'UpdatingKeyspaceMetadataWrapper(cluster={}, ks_name={})'.format(
-                self.cluster_mock, self.ks_name_sentinel
+            'UpdatingKeyspaceMetadataWrapper(cluster={}, ks_name={}, max_schema_agreement_wait={})'.format(
+                self.cluster_mock, self.ks_name_sentinel, self.max_schema_agreement_wait_sentinel
             )
         )
 
@@ -160,7 +192,11 @@ class UpdatingClusterMetadataWrapperTest(TestCase):
 
     def setUp(self):
         self.cluster_mock = MagicMock()
-        self.wrapper = UpdatingClusterMetadataWrapper(cluster=self.cluster_mock)
+        self.max_schema_agreement_wait_sentinel = Mock(name='wait')
+        self.wrapper = UpdatingClusterMetadataWrapper(
+            cluster=self.cluster_mock,
+            max_schema_agreement_wait=self.max_schema_agreement_wait_sentinel
+        )
 
     def wrapped_access_calls_refresh_test(self):
         """
@@ -169,7 +205,16 @@ class UpdatingClusterMetadataWrapperTest(TestCase):
         """
         self.cluster_mock.refresh_schema_metadata.assert_not_called()
         self.wrapper._wrapped
-        self.cluster_mock.refresh_schema_metadata.assert_called_once_with()
+        self.cluster_mock.refresh_schema_metadata.assert_called_once_with(
+            max_schema_agreement_wait=self.max_schema_agreement_wait_sentinel
+        )
+
+    def default_wrapper_max_schema_agreement_wait_is_None_test(self):
+        wrapper = UpdatingClusterMetadataWrapper(cluster=self.cluster_mock)
+        wrapper._wrapped
+        self.cluster_mock.refresh_schema_metadata.assert_called_once_with(
+            max_schema_agreement_wait=None
+        )
 
     def wrapped_returns_cluster_metadata_test(self):
         """
@@ -180,5 +225,8 @@ class UpdatingClusterMetadataWrapperTest(TestCase):
     def repr_test(self):
         self.assertEqual(
             repr(self.wrapper),
-            'UpdatingClusterMetadataWrapper(cluster={})'.format(self.cluster_mock)
+            'UpdatingClusterMetadataWrapper(cluster={}, max_schema_agreement_wait={})'.format(
+                self.cluster_mock,
+                self.max_schema_agreement_wait_sentinel
+            )
         )

--- a/tools/metadata_wrapper.py
+++ b/tools/metadata_wrapper.py
@@ -20,22 +20,28 @@ class UpdatingTableMetadataWrapper(UpdatingMetadataWrapperBase):
     A class that provides an interface to a table's metadata that is refreshed
     on access.
     """
-    def __init__(self, cluster, ks_name, table_name):
+    def __init__(self, cluster, ks_name, table_name, max_schema_agreement_wait=None):
         self._cluster = cluster
         self._ks_name = ks_name
         self._table_name = table_name
+        self.max_schema_agreement_wait = max_schema_agreement_wait
 
     @property
     def _wrapped(self):
-        self._cluster.refresh_table_metadata(self._ks_name, self._table_name)
+        self._cluster.refresh_table_metadata(
+            self._ks_name,
+            self._table_name,
+            max_schema_agreement_wait=self.max_schema_agreement_wait
+        )
         return self._cluster.metadata.keyspaces[self._ks_name].tables[self._table_name]
 
     def __repr__(self):
-        return '{cls_name}(cluster={cluster}, ks_name={ks_name}, table_name={table_name})'.format(
+        return '{cls_name}(cluster={cluster}, ks_name={ks_name}, table_name={table_name}, max_schema_agreement_wait={max_wait})'.format(
             cls_name=self.__class__.__name__,
             cluster=repr(self._cluster),
             ks_name=self._ks_name,
-            table_name=self._table_name)
+            table_name=self._table_name,
+            max_wait=self.max_schema_agreement_wait)
 
 
 class UpdatingKeyspaceMetadataWrapper(UpdatingMetadataWrapperBase):
@@ -43,20 +49,25 @@ class UpdatingKeyspaceMetadataWrapper(UpdatingMetadataWrapperBase):
     A class that provides an interface to a keyspace's metadata that is
     refreshed on access.
     """
-    def __init__(self, cluster, ks_name):
+    def __init__(self, cluster, ks_name, max_schema_agreement_wait=None):
         self._cluster = cluster
         self._ks_name = ks_name
+        self.max_schema_agreement_wait = max_schema_agreement_wait
 
     @property
     def _wrapped(self):
-        self._cluster.refresh_keyspace_metadata(self._ks_name)
+        self._cluster.refresh_keyspace_metadata(
+            self._ks_name,
+            max_schema_agreement_wait=self.max_schema_agreement_wait
+        )
         return self._cluster.metadata.keyspaces[self._ks_name]
 
     def __repr__(self):
-        return '{cls_name}(cluster={cluster}, ks_name={ks_name})'.format(
+        return '{cls_name}(cluster={cluster}, ks_name={ks_name}, max_schema_agreement_wait={max_wait})'.format(
             cls_name=self.__class__.__name__,
             cluster=repr(self._cluster),
-            ks_name=self._ks_name)
+            ks_name=self._ks_name,
+            max_wait=self.max_schema_agreement_wait)
 
 
 class UpdatingClusterMetadataWrapper(UpdatingMetadataWrapperBase):
@@ -64,17 +75,20 @@ class UpdatingClusterMetadataWrapper(UpdatingMetadataWrapperBase):
     A class that provides an interface to a cluster's metadata that is
     refreshed on access.
     """
-    def __init__(self, cluster):
+    def __init__(self, cluster, max_schema_agreement_wait=None):
         """
         @param cluster The cassandra.cluster.Cluster object to wrap.
         """
         self._cluster = cluster
+        self.max_schema_agreement_wait = max_schema_agreement_wait
 
     @property
     def _wrapped(self):
-        self._cluster.refresh_schema_metadata()
+        self._cluster.refresh_schema_metadata(max_schema_agreement_wait=self.max_schema_agreement_wait)
         return self._cluster.metadata
 
     def __repr__(self):
-        return '{cls_name}(cluster={cluster})'.format(
-            cls_name=self.__class__.__name__, cluster=repr(self._cluster))
+        return '{cls_name}(cluster={cluster}, max_schema_agreement_wait={max_wait})'.format(
+            cls_name=self.__class__.__name__,
+            cluster=repr(self._cluster),
+            max_wait=self.max_schema_agreement_wait)


### PR DESCRIPTION
Adds and tests a `max_schema_agreement_wait` to the metadata wrappers, uses one of those wrappers in the auth test that failed in [CASSANDRA-12456](https://issues.apache.org/jira/browse/CASSANDRA-12456), then bumps the wait in that test.