### PR TITLE
Start the node in logged_batch_doesnt_throw_uae_test

### DIFF
--- a/batch_test.py
+++ b/batch_test.py
@@ -190,6 +190,8 @@ class TestBatch(Tester):
             APPLY BATCH
         """, consistency_level=ConsistencyLevel.ANY)
         session.execute(query)
+
+        self.cluster.nodelist()[-1].start(wait_other_notice=True)
         assert_all(session, "SELECT * FROM users", [[1, u'Will', u'Turner'], [0, u'Jack', u'Sparrow']])
 
     @known_failure(failure_source='test',


### PR DESCRIPTION
Start the node in logged_batch_doesnt_throw_uae_test in order to make sure that repair happens during the write to avoid reading partial data, as write is done with CL ANY.

Cassandra ticket: https://issues.apache.org/jira/browse/CASSANDRA-12383 (waiting for CI results)

