### PR TITLE
custom upgrade path example (do not merge!)

### DIFF
--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -107,14 +107,13 @@ MANIFEST = {
 # 3) If using ccm local: slugs, make sure you have LOCAL_GIT_REPO defined in your env. This is the path to your git repo.
 # 4) Run the tests!
 #      To run all, use 'nosetests -v upgrade_tests/'. To run specific tests, use 'nosetests -vs --collect-only' to preview the test names, then run nosetests using the desired test name.
-custom_1 = VersionMeta(name='custom_branch_1', family='2.1.x', variant='indev', version='local:some_branch', min_proto_v=3, max_proto_v=4, java_versions=(7, 8))
-custom_2 = VersionMeta(name='custom_branch_2', family='2.2.x', variant='indev', version='git:trunk', min_proto_v=3, max_proto_v=4, java_versions=(7, 8))
-custom_3 = VersionMeta(name='custom_branch_3', family='3.0.x', variant='indev', version='git:cassandra-3.5', min_proto_v=3, max_proto_v=4, java_versions=(7, 8))
-custom_4 = VersionMeta(name='custom_branch_4', family='3.x', variant='indev', version='git:cassandra-3.6', min_proto_v=3, max_proto_v=4, java_versions=(7, 8))
+custom_1 = VersionMeta(name='custom_branch_1', family='2.1.x', variant='indev', version='github:username/some_branch', min_proto_v=3, max_proto_v=4, java_versions=(7, 8))
+custom_2 = VersionMeta(name='custom_branch_2', family='2.2.x', variant='indev', version='github:username/some_branch2', min_proto_v=3, max_proto_v=4, java_versions=(7, 8))
 OVERRIDE_MANIFEST = {
     # EXAMPLE:
     # custom_1: [custom_2, custom_3],  # creates a test of custom_1 -> custom_2, and another test from custom_1 -> custom_3
     # custom_3: [custom_4]             # creates a test of custom_3 -> custom_4
+    custom_1: [custom_2]
 }
 
 


### PR DESCRIPTION
update OVERRIDE_MANIFEST setting the version property to the location of source, see example code below. if needed, update the protocol versions and java versions.

set env var (see example code below)
> export RUN_STATIC_UPGRADE_MANIFEST=true

preview generates tests, this lets you see what test names are without running:
> nosetests --collect-only -v upgrade_tests/

run a specific test:
> nosetests -v upgrade_tests/cql_tests.py:TestCQLNodes3RF3_Upgrade_custom_branch_1_To_custom_branch_2.select_key_in_test
