### PR TITLE
check stderr has no errors

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -10,7 +10,7 @@ from cassandra import ConsistencyLevel
 from cassandra.concurrent import execute_concurrent_with_args
 from ccmlib.node import NodeError
 
-from tools.assertions import assert_almost_equal, assert_not_running, assert_one
+from tools.assertions import assert_almost_equal, assert_not_running, assert_one, assert_stderr_clean
 from dtest import DISABLE_VNODES, Tester, debug
 from tools.data import query_c1c2
 from tools.decorators import known_failure, no_vnodes, since
@@ -401,6 +401,7 @@ class TestBootstrap(Tester):
                                         '-errors', 'retries=2'])
 
         debug(out)
+        assert_stderr_clean(err)
         regex = re.compile("Operation.+error inserting key.+Exception")
         failure = regex.search(out)
         self.assertIsNone(failure, "Error during stress while bootstrapping")


### PR DESCRIPTION
@ptnapoleon, for your review.

We first questioned the validity of the error message in line 405 during cstar-97. I am unable to find it in the cassandra source code. Now that `stress` should return the correct return code, this test will automatically fail if stress fails, but as an extra precaution, I've checked stderr is clean, and left in the original error message check.