### PR TITLE
add pep8 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ mock
 nose
 nose-test-select
 parse
+pep8
 psutil
 pycassa
 thrift


### PR DESCRIPTION
When we migrated to using `requirements.txt`, missing this dependency made this test fail:

http://cassci.datastax.com/job/trunk_dtest/1359/testReport/junit/cqlsh_tests.cqlsh_tests/TestCqlsh/test_pep8_compliance/