### PR TITLE
known_failure decorator tracks annotations as a list of dicts.

### DIFF
--- a/bin/collect_known_failures.py
+++ b/bin/collect_known_failures.py
@@ -36,18 +36,12 @@ class PrintJiraURLPlugin(nose.plugins.Plugin):
             cls=test.test,
         )
 
-        jira_url = get_attr_for_current_method(attr_name='jira_url')
-        flaky = get_attr_for_current_method(attr_name='known_flaky')
-        failure_source = get_attr_for_current_method(attr_name='known_failure')
-        notes = get_attr_for_current_method(attr_name='failure_notes')
+        failure_annotations = get_attr_for_current_method(attr_name='known_failure')
 
         return json.dumps({
             'module': test_module,
             'name': test_name,
-            'jira_url': jira_url,
-            'known_flaky': flaky,
-            'failure_source': failure_source,
-            'notes': notes
+            'failure_annotations': failure_annotations
         })
 
 


### PR DESCRIPTION
Update `collect_known_failure.py` to reflect this.

@mambocab, please review.

Tests with two annotations will be represented by `collect_known_failure.py` as:

```bash
{"failure_annotations": [{"failure_source": "test", "notes": "", "known_flaky": true, "jira_url": 
"https://issues.apache.org/jira/browse/CASSANDRA-12444"}, {"failure_source": "cassandra", "notes": "", "known_flaky": true, "jira_url": "https://issues.apache.org/jira/browse/CASSANDRA-12457"}], "name": "TestUpgrade_current_3_x_To_indev_3_x.rolling_upgrade_test", "module": "upgrade_tests.upgrade_through_versions_test"} ... ok
```

Something we should think about is any place where we access the `known_failure` attribute thinking there will be the `failure_source` value. I'm not aware of anything like this in dtest, but maybe it is used in Jenkins?