### PR TITLE
Version gate changes from 11706

### DIFF
--- a/cql_tracing_test.py
+++ b/cql_tracing_test.py
@@ -1,7 +1,8 @@
 # coding: utf-8
+from distutils.version import LooseVersion
 
 from dtest import Tester, debug
-from tools.decorators import since, known_failure
+from tools.decorators import since
 
 
 class TestCqlTracing(Tester):
@@ -123,13 +124,14 @@ class TestCqlTracing(Tester):
         errs = self.cluster.nodelist()[0].grep_log_for_errors()
         debug('Errors after attempted trace with unknown tracing class: {errs}'.format(errs=errs))
         self.assertEqual(len(errs), 1)
-        self.assertTrue(len(errs[0]) > 0)
+        if LooseVersion(self.cluster.version()) >= LooseVersion('3.10'):
+            # See CASSANDRA-11706 and PR #1281
+            self.assertTrue(len(errs[0]) > 0)
+        else:
+            self.assertEqual(len(errs[0]), 1)
         err = errs[0][0]
         self.assertIn(expected_error, err)
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12579',
-                   flaky=True)
     @since('3.4')
     def tracing_default_impl_test(self):
         """
@@ -155,12 +157,22 @@ class TestCqlTracing(Tester):
         errs = self.cluster.nodelist()[0].grep_log_for_errors()
         debug('Errors after attempted trace with default tracing class: {errs}'.format(errs=errs))
         self.assertEqual(len(errs), 1)
-        self.assertTrue(len(errs[0]) > 0)
+        if LooseVersion(self.cluster.version()) >= LooseVersion('3.10'):
+            # See CASSANDRA-11706 and PR #1281
+            self.assertTrue(len(errs[0]) > 0)
+        else:
+            self.assertEqual(len(errs[0]), 1)
         err = errs[0][0]
         self.assertIn(expected_error, err)
         # make sure it logged the error for the correct reason. this isn't
         # part of the expected error to avoid having to escape parens and
         # periods for regexes.
+
+        if LooseVersion(self.cluster.version()) >= LooseVersion('3.10'):
+            # See CASSANDRA-11706 and PR #1281
+            check_for_errs_in = errs[0][1]
+        else:
+            check_for_errs_in = err
         self.assertIn("Default constructor for Tracing class "
                       "'org.apache.cassandra.tracing.TracingImpl' is inaccessible.",
-                      errs[0][1])
+                      check_for_errs_in)


### PR DESCRIPTION
Breakage is from https://github.com/riptano/cassandra-dtest/pull/1281/files
Fixes https://issues.apache.org/jira/browse/CASSANDRA-12579
@knifewine to review, please