### PR TITLE
Fix log pattern append in replace_address_test

### DIFF
--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -460,7 +460,7 @@ class TestReplaceAddress(BaseReplaceAddressTest):
         self._test_restart_failed_replace(mode='wipe')
 
     def _test_restart_failed_replace(self, mode):
-        self.ignore_log_patterns.append(r'Error while waiting on bootstrap to complete')
+        self.ignore_log_patterns = list(self.ignore_log_patterns) + [r'Error while waiting on bootstrap to complete']
         self._setup(n=3, enable_byteman=True)
         self._insert_data(n="1k")
 


### PR DESCRIPTION
Fixes this error

```
======================================================================
ERROR: resume_failed_replace_test (replace_address_test.TestReplaceAddress)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mshuler/git/cassandra-dtest/tools/decorators.py", line 46, in wrapped
    f(obj)
  File "/home/mshuler/git/cassandra-dtest/replace_address_test.py", line 444, in resume_failed_replace_test
    self._test_restart_failed_replace(mode='resume')
  File "/home/mshuler/git/cassandra-dtest/replace_address_test.py", line 463, in _test_restart_failed_replace
    self.ignore_log_patterns.append(r'Error while waiting on bootstrap to complete')
AttributeError: 'tuple' object has no attribute 'append'
-------------------- >> begin captured logging << --------------------
dtest: DEBUG: Python driver version in use: 3.6.0.post0
dtest: DEBUG: cluster ccm directory: /tmp/dtest-QXoqGd
dtest: DEBUG: Done setting configuration options:
{   'initial_token': None,
    'num_tokens': '256',
    'phi_convict_threshold': 5,
    'start_rpc': 'true'}
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 0.080s

FAILED (errors=1)
```