### PR TITLE
Parameterize error message in snitch_test after typo fix in C*

### DIFF
--- a/snitch_test.py
+++ b/snitch_test.py
@@ -69,10 +69,11 @@ class TestGossipingPropertyFileSnitch(Tester):
         self._test_connect(NODE2_LISTEN_ADDRESS, STORAGE_PORT)
         self._test_connect(NODE2_BROADCAST_ADDRESS, STORAGE_PORT)
 
-        node1.watch_log_for("Intiated reconnect to an Internal IP /{} for the /{}".format(NODE2_LISTEN_ADDRESS,
-                                                                                          NODE2_BROADCAST_ADDRESS), filename='debug.log', timeout=60)
-        node2.watch_log_for("Intiated reconnect to an Internal IP /{} for the /{}".format(NODE1_LISTEN_ADDRESS,
-                                                                                          NODE1_BROADCAST_ADDRESS), filename='debug.log', timeout=60)
+        # Intiated -> Initiated typo was fixed in 3.10
+        node1.watch_log_for("Ini?tiated reconnect to an Internal IP /{} for the /{}".format(NODE2_LISTEN_ADDRESS,
+                                                                                            NODE2_BROADCAST_ADDRESS), filename='debug.log', timeout=60)
+        node2.watch_log_for("Ini?tiated reconnect to an Internal IP /{} for the /{}".format(NODE1_LISTEN_ADDRESS,
+                                                                                            NODE1_BROADCAST_ADDRESS), filename='debug.log', timeout=60)
 
         # read data from node2 just to make sure data and connectivity is OK
         session = self.patient_exclusive_cql_connection(node2)


### PR DESCRIPTION
This typo was fixed in https://github.com/apache/cassandra/commit/2dc2bb808634be9aaf5ee1d65eb968f8c5514305, but the test was never updated accordingly.