### PR TITLE
bounce cluster post-startup on cl-replaying tests

### DIFF
--- a/cdc_test.py
+++ b/cdc_test.py
@@ -253,6 +253,13 @@ class TestCDC(Tester):
         self.cluster.populate(1)
         self.cluster.set_configuration_options(dict(config_defaults, **configuration_overrides))
         self.cluster.start(wait_for_binary_proto=True)
+        # drain and bounce to get clean CLs. We do this to address
+        # CASSANDRA-11811, where mutations generated on startup get replayed
+        # when we replay commitlogs
+        self.cluster.drain()
+        self.cluster.stop()
+        self.cluster.start(wait_for_binary_proto=True)
+
         node = self.cluster.nodelist()[0]
         session = self.patient_cql_connection(node)
         self.create_ks(session, ks_name, rf=1)

--- a/snapshot_test.py
+++ b/snapshot_test.py
@@ -219,7 +219,13 @@ class TestArchiveCommitlog(SnapshotTester):
                         [(r'^archive_command=.*$', 'archive_command={archive_command} %path {tmp_commitlog}/%name'.format(
                             tmp_commitlog=tmp_commitlog, archive_command=archive_command))])
 
-        cluster.start()
+        cluster.start(wait_for_binary_proto=True)
+        # drain and bounce to get clean CLs. We do this to address
+        # CASSANDRA-11811, where mutations generated on startup get replayed
+        # when we restore from a snapshot
+        cluster.drain()
+        cluster.stop()
+        cluster.start(wait_for_binary_proto=True)
 
         session = self.patient_cql_connection(node1)
         self.create_ks(session, 'ks', 1)


### PR DESCRIPTION
Should address [CASSANDRA-11811](https://issues.apache.org/jira/browse/CASSANDRA-11811). I'll run CI, if it runs clean I'll get Joel to review.