### PR TITLE
Update CQL tests to use proper DC name for CASSANDRA-12681

### DIFF
--- a/cql_tests.py
+++ b/cql_tests.py
@@ -95,7 +95,7 @@ class StorageProxyCQLTester(CQLTester):
         self.assertIsInstance(ks_meta.replication_strategy, SimpleStrategy)
 
         session.execute("ALTER KEYSPACE ks WITH replication = "
-                        "{ 'class' : 'NetworkTopologyStrategy', 'dc1' : 1 } "
+                        "{ 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 } "
                         "AND DURABLE_WRITES = false")
         self.assertFalse(ks_meta.durable_writes)
         self.assertIsInstance(ks_meta.replication_strategy, NetworkTopologyStrategy)


### PR DESCRIPTION
CCM uses 'datacenter1'. The dtest uses 'dc1'. CASSANDRA-12681 validates the datacenter name. 

Whether or not CASSANDRA-12681 gets merged, we should use the real datacenter name. 