### PR TITLE
Removes outdated known_failure annotations

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -1391,9 +1391,6 @@ class TestCQL(UpgradeTester):
             cursor.execute(q % "tags = tags - [ 'bar' ]")
             assert_one(cursor, "SELECT tags FROM user WHERE fn='Bilbo' AND ln='Baggins'", [['m', 'n', 'c', 'c']])
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12399',
-                   flaky=False)
     def multi_collection_test(self):
         cursor = self.prepare()
 
@@ -2273,9 +2270,6 @@ class TestCQL(UpgradeTester):
             query = "SELECT * FROM test WHERE k = 0 LIMIT 1;"
             assert_one(cursor, query, [0, 0, 2, 2])
 
-    @known_failure(failure_source='test',
-                   jira_url='https://issues.apache.org/jira/browse/CASSANDRA-12401',
-                   flaky=False)
     def multi_list_set_test(self):
         cursor = self.prepare()
 


### PR DESCRIPTION
Removing the `known_failure` annotations for `multi_collection_test` and `multi_list_set_test` as the problem behind those tests seems to have been fixed.