### PR TITLE
Make show_output=True the default for all cqlsh copy tests

### DIFF
--- a/cqlsh_tests/cqlsh_copy_tests.py
+++ b/cqlsh_tests/cqlsh_copy_tests.py
@@ -155,7 +155,7 @@ class CqlshCopyTest(Tester):
         return cqlshrc
 
     def run_cqlsh(self, cmds=None, cqlsh_options=None, use_debug=True, skip_cqlshrc=False,
-                  auth_enabled=False, show_output=False):
+                  auth_enabled=False, show_output=True):
         """
         Run cqlsh on node1 adding the debug and cqlshrc to the clqsh options, unless the caller
         has specified its own options.
@@ -2165,8 +2165,7 @@ class CqlshCopyTest(Tester):
 
         debug('Exporting to csv file: {}'.format(tempfile.name))
         self.run_cqlsh(cmds="COPY {} TO '{}' WITH RATEFILE='{}' AND REPORTFREQUENCY='{}'"
-                       .format(stress_table, tempfile.name, ratefile.name, report_frequency),
-                       show_output=True)
+                       .format(stress_table, tempfile.name, ratefile.name, report_frequency))
 
         # check all records were exported
         self.assertEqual(num_rows, len(open(tempfile.name).readlines()))
@@ -2179,8 +2178,7 @@ class CqlshCopyTest(Tester):
 
         debug('Importing from csv file: {}'.format(tempfile.name))
         self.run_cqlsh(cmds="COPY {} FROM '{}' WITH RATEFILE='{}' AND REPORTFREQUENCY='{}'"
-                       .format(stress_table, tempfile.name, ratefile.name, report_frequency),
-                       show_output=True)
+                       .format(stress_table, tempfile.name, ratefile.name, report_frequency))
 
         # check all records were imported
         self.assertEqual([[num_rows]], rows_to_list(self.session.execute("SELECT COUNT(*) FROM {}"
@@ -2472,7 +2470,7 @@ class CqlshCopyTest(Tester):
             if copy_to_options:
                 copy_to_cmd += ' WITH ' + ' AND '.join('{} = {}'.format(k, v) for k, v in copy_to_options.iteritems())
             debug('Running {}'.format(copy_to_cmd))
-            result = self.run_cqlsh(cmds=copy_to_cmd, show_output=True)
+            result = self.run_cqlsh(cmds=copy_to_cmd)
             ret.append(result)
             debug("COPY TO took {} to export {} records".format(datetime.datetime.now() - start, num_records))
 
@@ -2483,7 +2481,7 @@ class CqlshCopyTest(Tester):
             if copy_from_options:
                 copy_from_cmd += ' WITH ' + ' AND '.join('{} = {}'.format(k, v) for k, v in copy_from_options.iteritems())
             debug('Running {}'.format(copy_from_cmd))
-            result = self.run_cqlsh(cmds=copy_from_cmd, show_output=True)
+            result = self.run_cqlsh(cmds=copy_from_cmd)
             ret.append(result)
             debug("COPY FROM took {} to import {} records".format(datetime.datetime.now() - start, num_records))
 


### PR DESCRIPTION
In view of some recent failures in cqlsh copy tests that are very hard to reproduce, I propose to show the output of the cqlsh copy commands for all tests, so that in future we may be able to understand why a copy command has failed. 

I've already run the patch [here](https://cassci.datastax.com/view/Dev/view/stef1927/job/stef1927-dtest-multiplex/73/).