### PR TITLE
Add dtest for CASSANDRA-12813

### DIFF
--- a/upgrade_internal_auth_test.py
+++ b/upgrade_internal_auth_test.py
@@ -60,7 +60,7 @@ class TestAuthUpgrade(Tester):
         cluster.add(node3, False)
         node3.start()
 
-        time.sleep(15)
+        node3.watch_log_for('Created default superuser')
 
         node3.drain()
         node3.watch_log_for("DRAINED")
@@ -84,9 +84,10 @@ class TestAuthUpgrade(Tester):
         node2.start(wait_for_binary_proto=True)
         node3.start()
 
-        node1.watch_log_for('Initializing system_auth.credentials')
-        node1.watch_log_for('Initializing system_auth.permissions')
-        node1.watch_log_for('Initializing system_auth.users')
+        for node in [node1, node2]:
+            node.watch_log_for('Initializing system_auth.credentials')
+            node.watch_log_for('Initializing system_auth.permissions')
+            node.watch_log_for('Initializing system_auth.users')
 
         # Should succeed. Will throw an NPE on pre-12813 code.
         self.patient_cql_connection(node1, user='cassandra', password='cassandra')


### PR DESCRIPTION
[CASSANDRA-12813](https://issues.apache.org/jira/browse/CASSANDRA-12813)

Follow up after the #1381 

Unfortunately, the previous version contained a bug that made it look like C* patch was correct, so the test was failing when we needed it to and succeeding in other case. I've simplified and rewritten the tests. 

After the bug I mentioned was fixed, the other problem appeared: test was flaky because system_auth was not always available on the clean node. I've fixed it in this version by increasing a CL of `system_auth` and making sure the node sees it.

I haven't squashed commits if anyone wanted to see history.

CI results:

[2.2](https://cassci.datastax.com/job/ifesdjeen-2.2-dtest/) 
[3.0](https://cassci.datastax.com/job/ifesdjeen-3.0-dtest/) 
[3.X](https://cassci.datastax.com/job/ifesdjeen-cassandra-3.X-dtest/) 
[trunk](https://cassci.datastax.com/job/ifesdjeen-_trunk-dtest/) 
[broken](https://cassci.datastax.com/job/ifesdjeen-broken-dtest/) (pre #12813)
