### PR TITLE
Update bootstrap test following pcmanus/ccm#557

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -647,7 +647,7 @@ class TestBootstrap(BaseBootstrapTest):
         time.sleep(.5)
         node2.watch_log_for("Starting listening for CQL clients")
 
-        node3.grep_log(bootstrap_error)
+        node3.watch_log_for(bootstrap_error)
 
         session = self.patient_exclusive_cql_connection(node2)
 


### PR DESCRIPTION
The changes to subprocess' stdout/stderr when starting a ccm node seem to have broken simultaneous_bootstrap_test. The changes I've made fix the test, but there may be better ways to acheive that. 