### PR TITLE
add plugin with selector to check __test__

### DIFF
--- a/plugins/test_attrib_checker/setup.py
+++ b/plugins/test_attrib_checker/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='test_attrib_checker',
+    version='0.1',
+    packages=find_packages(),
+    entry_points={
+        'nose.plugins': ['test_attrib_checker = '
+                         'plugins.test_attrib_checker.test_attrib_checker:TestAttribChecker']
+    },
+    install_requires=['nose'],
+)

--- a/plugins/test_attrib_checker/test_attrib_checker.py
+++ b/plugins/test_attrib_checker/test_attrib_checker.py
@@ -1,0 +1,41 @@
+from nose import plugins, selector
+
+
+class _ClassCheckingSelector(selector.Selector):
+
+    def wantClass(self, cls):
+        default_result = super(_ClassCheckingSelector, self).wantClass(cls)
+
+        if not default_result:
+            falsy_test = hasattr(cls, '__test__') and not cls.__test__
+            test_set_on_cls = '__test__' in cls.__dict__
+            if falsy_test and not test_set_on_cls:
+                raise RuntimeError(
+                    "__test__ is falsey on {cls}'s superclass, but unset "
+                    "on {cls}. The installed {module_name} module requires "
+                    "__test__ to be explicitly set on classes removed from "
+                    "discovery in this way.".format(
+                        cls=cls.__name__, module_name=__name__
+                    )
+                )
+
+        return default_result
+
+
+class TestAttribChecker(plugins.Plugin):
+    """
+    Checks that any test classes skipped with `__test__ = False` are done so on
+    the class itself.
+    """
+
+    enabled = True  # always use this plugin if it's installed
+    name = 'test_attrib_checker'
+
+    def configure(self, options, conf):
+        """
+        Noop conifigure method -- this plugin is always on.
+        """
+        pass
+
+    def prepareTestLoader(self, loader):
+        loader.selector = _ClassCheckingSelector(loader.config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
 
+./plugins/test_attrib_checker
+
 ccm==2.4.9
 cql
 decorator


### PR DESCRIPTION
This addresses the problem from #1386 -- if you run the tests with this plugin installed, it'll make sure every test class where `bool(cls.__test__) == False` has `__test__` set on `cls` itself, rather than inheriting it from a superclass.

I've set up a test on CassCI:

https://cassci.datastax.com/view/Dev/view/mambocab/job/mambocab-trunk-copy-dtest/10/

This test uses this branch, but with a commit removing `__test__` from some subclasses.

This should fail -- I'm not sure whether I expect it to fail in bucketization or during the test run.

Anyone to review code-wise, @ptnapoleon to review behavior. Is this what we want?