### PR TITLE
Remove potential reconnection error from auth_test

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -62,6 +62,9 @@ class TestAuth(Tester):
         debug("Repairing before altering RF")
         self.cluster.repair()
 
+        debug("Shutting down client session")
+        session.shutdown()
+
         # make sure schema change is persistent
         debug("Stopping cluster..")
         self.cluster.stop()


### PR DESCRIPTION
auth_test:TestAuth.system_auth_ks_is_alterable_test can be flaky due to
the client session attempting to reconnect while the cluster is being
restarted. Because it uses the 'cassandra' user, reads to the auth
tables are made a QUORUM & so may fail if nodes are marked down.