### PR TITLE
Add max version for tests which shouldn't run for 4.0+

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -306,6 +306,11 @@ class TestOfflineTools(Tester):
         out, error, _ = node1.run_sstableexpiredblockers(keyspace="ks", column_family="cf")
         self.assertIn("blocks 2 expired sstables from getting dropped", out)
 
+    # 4.0 removes back compatibility with pre-3.0 versions, so testing upgradesstables for
+    # paths from those versions to 4.0 is invalid (and can only fail). There isn't currently
+    # any difference between the 3.0 and 4.0 sstable format though, but when the version is
+    # bumped for 4.0, remove the max_version & add a case for testing a 3.0 -> 4.0 upgrade
+    @since('2.2', max_version='3.X')
     def sstableupgrade_test(self):
         """
         Test that sstableupgrade functions properly offline on a same-version Cassandra sstable, a

--- a/upgrade_internal_auth_test.py
+++ b/upgrade_internal_auth_test.py
@@ -30,6 +30,7 @@ class TestAuthUpgrade(Tester):
     def upgrade_to_30_test(self):
         self.do_upgrade_with_internal_auth("git:cassandra-3.0")
 
+    @since('2.2', max_version='3.X')
     def test_upgrade_legacy_table(self):
         """
         Upgrade with bringing up the legacy tables after the newer nodes (without legacy tables)


### PR DESCRIPTION
The annotation in `upgrade_internal_auth_test` fixes CASSANDRA-12986, as upgrading from 2.1 -> 4.0 is not supported.
 `offline_tools_test` has also been failing recently for similar reasons, but I couldn't find a JIRA for that.