### PR TITLE
Don't run storage upgrade tests on 4.0+

### DIFF
--- a/upgrade_tests/storage_engine_upgrade_test.py
+++ b/upgrade_tests/storage_engine_upgrade_test.py
@@ -435,14 +435,14 @@ class TestBootstrapAfterUpgrade(TestStorageEngineUpgrade):
         super(TestBootstrapAfterUpgrade, self).setUp(bootstrap=True, jvm_args=LEGACY_SSTABLES_JVM_ARGS)
 
 
-@since('3.0')
+@since('3.0', max_version='4')
 class TestLoadKaSStables(BaseSStableLoaderTest):
     __test__ = True
     upgrade_from = '2.1.6'
     jvm_args = LEGACY_SSTABLES_JVM_ARGS
 
 
-@since('3.0')
+@since('3.0', max_version='4')
 class TestLoadKaCompactSStables(BaseSStableLoaderTest):
     __test__ = True
     upgrade_from = '2.1.6'
@@ -450,14 +450,14 @@ class TestLoadKaCompactSStables(BaseSStableLoaderTest):
     compact = True
 
 
-@since('3.0')
+@since('3.0', max_version='4')
 class TestLoadLaSStables(BaseSStableLoaderTest):
     __test__ = True
     upgrade_from = '2.2.4'
     jvm_args = LEGACY_SSTABLES_JVM_ARGS
 
 
-@since('3.0')
+@since('3.0', max_version='4')
 class TestLoadLaCompactSStables(BaseSStableLoaderTest):
     __test__ = True
     upgrade_from = '2.2.4'

--- a/upgrade_tests/storage_engine_upgrade_test.py
+++ b/upgrade_tests/storage_engine_upgrade_test.py
@@ -36,7 +36,10 @@ class TestStorageEngineUpgrade(Tester):
             cluster.set_configuration_options(cluster_options)
 
         # Forcing cluster version on purpose
-        cluster.set_install_dir(version="2.1.9")
+        if CASSANDRA_VERSION_FROM_BUILD >= '4':
+            cluster.set_install_dir(version="git:cassandra-3.0")
+        else:
+            cluster.set_install_dir(version="git:cassandra-2.1")
         cluster.populate(1).start()
 
         node1 = cluster.nodelist()[0]


### PR DESCRIPTION
These are for testing 2.1 -> post-8099, and thus there's no need
to run on 4.0. We don't support upgrades to 4.x from 2.1

@beobal or @pauloricardomg  to review