### PR TITLE
Thrift removal tests

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -24,7 +24,6 @@ class BaseBootstrapTest(Tester):
     __test__ = False
 
     allow_log_errors = True
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
     ignore_log_patterns = (
         # This one occurs when trying to send the migration to a
         # node that hasn't started yet, and when it does, it gets
@@ -364,7 +363,7 @@ class TestBootstrap(BaseBootstrapTest):
         # check if we reset bootstrap state
         node3.watch_log_for("Resetting bootstrap progress to start fresh", from_mark=mark)
         # wait for node3 ready to query
-        node3.wait_for_thrift_interface(from_mark=mark)
+        node3.wait_for_binary_interface(from_mark=mark)
 
         # check if 2nd bootstrap succeeded
         assert_bootstrap_state(self, node3, 'COMPLETED')

--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -16,7 +16,7 @@ from tools.assertions import (assert_almost_equal, assert_bootstrap_state, asser
 from tools.data import query_c1c2
 from tools.decorators import no_vnodes, since
 from tools.intervention import InterruptBootstrap, KillOnBootstrap
-from tools.misc import ImmutableMapping, new_node
+from tools.misc import new_node
 from tools.misc import generate_ssl_stores
 
 

--- a/cdc_test.py
+++ b/cdc_test.py
@@ -445,12 +445,12 @@ class TestCDC(Tester):
         session.cluster.shutdown()
         self.assertEqual(pre_non_cdc_write_cdc_raw_segments, _get_cdc_raw_files(node.get_path()))
 
-    def _init_new_loading_node(self, ks_name, create_stmt):
+    def _init_new_loading_node(self, ks_name, create_stmt, use_thrift=False):
         loading_node = Node(
             name='node2',
             cluster=self.cluster,
             auto_bootstrap=False,
-            thrift_interface=('127.0.0.2', 9160),
+            thrift_interface=('127.0.0.2', 9160) if use_thrift else None,
             storage_interface=('127.0.0.2', 7000),
             jmx_port='7400',
             remote_debug_port='0',
@@ -510,7 +510,7 @@ class TestCDC(Tester):
         generation_session.cluster.shutdown()
 
         # create a new node to use for cdc_raw cl segment replay
-        loading_node = self._init_new_loading_node(ks_name, cdc_table_info.create_stmt)
+        loading_node = self._init_new_loading_node(ks_name, cdc_table_info.create_stmt, self.cluster.version() < '4')
 
         # move cdc_raw contents to commitlog directories, then start the
         # node again to trigger commitlog replay, which should replay the

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -23,7 +23,6 @@ class TestCommitLog(Tester):
     """
     CommitLog Tests
     """
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
     allow_log_errors = True
 
     def setUp(self):

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -16,7 +16,6 @@ from dtest import Tester, debug, create_ks
 from tools.assertions import assert_almost_equal, assert_none, assert_one
 from tools.data import rows_to_list
 from tools.decorators import since
-from tools.misc import ImmutableMapping
 
 
 class TestCommitLog(Tester):

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -17,7 +17,6 @@ from tools.misc import ImmutableMapping
 class TestCompaction(Tester):
 
     __test__ = False
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
 
     def setUp(self):
         Tester.setUp(self)

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -11,7 +11,6 @@ import parse
 from dtest import Tester, debug, create_ks
 from tools.assertions import assert_length_equal, assert_none, assert_one
 from tools.decorators import since
-from tools.misc import ImmutableMapping
 
 
 class TestCompaction(Tester):

--- a/concurrent_schema_changes_test.py
+++ b/concurrent_schema_changes_test.py
@@ -24,7 +24,6 @@ def wait(delay=2):
 
 @skip('awaiting CASSANDRA-10699')
 class TestConcurrentSchemaChanges(Tester):
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
     allow_log_errors = True
 
     def prepare_for_changes(self, session, namespace='ns1'):

--- a/concurrent_schema_changes_test.py
+++ b/concurrent_schema_changes_test.py
@@ -12,7 +12,6 @@ from ccmlib.node import Node
 
 from dtest import Tester, debug, create_ks
 from tools.decorators import since
-from tools.misc import ImmutableMapping
 
 
 def wait(delay=2):

--- a/cql_tests.py
+++ b/cql_tests.py
@@ -494,6 +494,7 @@ class MiscellaneousCQLTester(CQLTester):
                             "Only the first 65535 elements will be returned to the client. Please see "
                             "http://cassandra.apache.org/doc/cql3/CQL.html#collections for more details.")
 
+    @since('2.0', max_version='4')
     def cql3_insert_thrift_test(self):
         """
         Check that we can insert from thrift into a CQL3 table:
@@ -531,6 +532,7 @@ class MiscellaneousCQLTester(CQLTester):
 
         assert_one(session, "SELECT * FROM test", [2, 4, 8])
 
+    @since('2.0', max_version='4')
     def rename_test(self):
         """
         Check that a thrift-created table can be renamed via CQL:

--- a/dtest.py
+++ b/dtest.py
@@ -915,6 +915,11 @@ def init_default_config(cluster, cluster_options):
             'request_timeout_in_ms': timeout
         })
 
+
+    # No more thrift in 4.0, and start_rpc doesn't exists anymore
+    if cluster.version() >= '4' and 'start_rpc' in values:
+        del values['start_rpc']
+
     cluster.set_configuration_options(values)
     debug("Done setting configuration options:\n" + pprint.pformat(cluster._config_options, indent=4))
 

--- a/dtest.py
+++ b/dtest.py
@@ -915,7 +915,6 @@ def init_default_config(cluster, cluster_options):
             'request_timeout_in_ms': timeout
         })
 
-
     # No more thrift in 4.0, and start_rpc doesn't exists anymore
     if cluster.version() >= '4' and 'start_rpc' in values:
         del values['start_rpc']

--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -1727,7 +1727,6 @@ class TestMaterializedViewsLockcontention(Tester):
         self.cluster.populate(1)
 
         self.cluster.set_configuration_options(values={
-            'start_rpc': True,
             'concurrent_materialized_view_writes': 1,
             'concurrent_writes': 1,
         })

--- a/metadata_tests.py
+++ b/metadata_tests.py
@@ -3,7 +3,6 @@ import time
 from unittest import skip
 
 from dtest import Tester
-from tools.misc import ImmutableMapping
 
 
 class TestMetadata(Tester):

--- a/metadata_tests.py
+++ b/metadata_tests.py
@@ -7,7 +7,6 @@ from tools.misc import ImmutableMapping
 
 
 class TestMetadata(Tester):
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
 
     def force_compact(self):
         cluster = self.cluster

--- a/pushed_notifications_test.py
+++ b/pushed_notifications_test.py
@@ -236,7 +236,7 @@ class TestPushedNotifications(Tester):
         waiter.clear_notifications()
 
         debug("Adding second node...")
-        node2 = Node('node2', self.cluster, True, ('127.0.0.2', 9160), ('127.0.0.2', 7000), '7200', '0', None, ('127.0.0.2', 9042))
+        node2 = Node('node2', self.cluster, True, None, ('127.0.0.2', 7000), '7200', '0', None, binary_interface=('127.0.0.2', 9042))
         self.cluster.add(node2, False)
         node2.start(wait_other_notice=True)
         debug("Waiting for notifications from {}".format(waiter.address))
@@ -268,8 +268,9 @@ class TestPushedNotifications(Tester):
         i = 0
         for node in cluster.nodelist():
             debug('Set 127.0.0.1 to prevent IPv6 java prefs, set rpc_address: localhost in cassandra.yaml')
-            node.network_interfaces['thrift'] = ('127.0.0.1', node.network_interfaces['thrift'][1] + i)
-            node.network_interfaces['binary'] = ('127.0.0.1', node.network_interfaces['thrift'][1] + 1)
+            if cluster.version() < '4':
+                node.network_interfaces['thrift'] = ('127.0.0.1', node.network_interfaces['thrift'][1] + i)
+            node.network_interfaces['binary'] = ('127.0.0.1', node.network_interfaces['binary'][1] + i)
             node.import_config_files()  # this regenerates the yaml file and sets 'rpc_address' to the 'thrift' address
             node.set_configuration_options(values={'rpc_address': 'localhost'})
             debug(node.show())

--- a/putget_test.py
+++ b/putget_test.py
@@ -7,7 +7,7 @@ from thrift.transport import TSocket, TTransport
 from dtest import Tester, create_ks, create_cf
 from tools.data import (create_c1c2_table, insert_c1c2, insert_columns, putget,
                         query_c1c2, query_columns, range_putget)
-from tools.decorators import no_vnodes
+from tools.decorators import no_vnodes, since
 from tools.misc import ImmutableMapping, retry_till_success
 
 
@@ -91,6 +91,7 @@ class TestPutGet(Tester):
                 query_columns(self, session, key, size, offset=x * size - 1)
 
     @no_vnodes()
+    @since('2.0', max_version='4')
     def wide_slice_test(self):
         """
         Check slicing a wide row.

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -11,7 +11,6 @@ from tools.misc import ImmutableMapping
 
 
 class TestRebuild(Tester):
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
     ignore_log_patterns = (
         # This one occurs when trying to send the migration to a
         # node that hasn't started yet, and when it does, it gets
@@ -34,7 +33,7 @@ class TestRebuild(Tester):
         cluster = self.cluster
         cluster.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.PropertyFileSnitch'})
         node1 = cluster.create_node('node1', False,
-                                    ('127.0.0.1', 9160),
+                                    None,
                                     ('127.0.0.1', 7000),
                                     '7100', '2000', None,
                                     binary_interface=('127.0.0.1', 9042))

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -7,7 +7,6 @@ from ccmlib.node import ToolError
 from dtest import Tester, debug, create_ks, create_cf
 from tools.data import insert_c1c2, query_c1c2
 from tools.decorators import since, no_vnodes
-from tools.misc import ImmutableMapping
 
 
 class TestRebuild(Tester):

--- a/repair_tests/incremental_repair_test.py
+++ b/repair_tests/incremental_repair_test.py
@@ -16,7 +16,6 @@ from tools.misc import ImmutableMapping
 
 
 class TestIncRepair(Tester):
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
     ignore_log_patterns = (r'Can\'t send migration request: node.*is down',)
 
     def sstable_marking_test(self):

--- a/repair_tests/incremental_repair_test.py
+++ b/repair_tests/incremental_repair_test.py
@@ -12,7 +12,6 @@ from dtest import Tester, debug, create_ks, create_cf
 from tools.assertions import assert_almost_equal, assert_one
 from tools.data import insert_c1c2
 from tools.decorators import since
-from tools.misc import ImmutableMapping
 
 
 class TestIncRepair(Tester):

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -13,7 +13,6 @@ from dtest import CASSANDRA_VERSION_FROM_BUILD, DISABLE_VNODES, Tester, debug
 from tools.assertions import assert_bootstrap_state, assert_all, assert_not_running
 from tools.data import rows_to_list
 from tools.decorators import since
-from tools.misc import ImmutableMapping
 
 
 class NodeUnavailable(Exception):

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -23,7 +23,6 @@ class NodeUnavailable(Exception):
 class BaseReplaceAddressTest(Tester):
     __test__ = False
     replacement_node = None
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
     ignore_log_patterns = (
         # This one occurs when trying to send the migration to a
         # node that hasn't started yet, and when it does, it gets
@@ -87,7 +86,7 @@ class BaseReplaceAddressTest(Tester):
 
             debug("Starting replacement node {} with jvm_option '{}={}'".format(replacement_address, jvm_option, replace_address))
             self.replacement_node = Node('replacement', cluster=self.cluster, auto_bootstrap=True,
-                                         thrift_interface=(replacement_address, 9160), storage_interface=(replacement_address, 7000),
+                                         thrift_interface=None, storage_interface=(replacement_address, 7000),
                                          jmx_port='7400', remote_debug_port='0', initial_token=None, binary_interface=(replacement_address, 9042))
             if opts is not None:
                 debug("Setting options on replacement node: {}".format(opts))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
 
-ccm==2.4.2
+-e git+https://github.com/pcmanus/ccm.git@thrift_removal#egg=ccm
 cql
 decorator
 docopt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
 
--e git+https://github.com/pcmanus/ccm.git@thrift_removal#egg=ccm
+ccm==2.4.2
 cql
 decorator
 docopt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
 
-ccm==2.4.2
+ccm==2.4.7
 cql
 decorator
 docopt

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -7,7 +7,6 @@ from ccmlib import common as ccmcommon
 
 from dtest import Tester, debug, create_ks, create_cf
 from tools.assertions import assert_one
-from tools.misc import ImmutableMapping
 
 
 # WARNING: sstableloader tests should be added to TestSSTableGenerationAndLoading (below),

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -22,7 +22,6 @@ class BaseSStableLoaderTest(Tester):
     compact = False
     jvm_args = ()
     allow_log_errors = True
-    cluster_options = ImmutableMapping({'start_rpc': True})
 
     def create_schema(self, session, ks, compression):
         create_ks(session, ks, rf=2)

--- a/sstablesplit_test.py
+++ b/sstablesplit_test.py
@@ -9,7 +9,6 @@ from tools.misc import ImmutableMapping
 
 
 class TestSSTableSplit(Tester):
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
 
     def split_test(self):
         """

--- a/sstablesplit_test.py
+++ b/sstablesplit_test.py
@@ -5,7 +5,6 @@ from math import floor
 from os.path import getsize
 
 from dtest import Tester, debug
-from tools.misc import ImmutableMapping
 
 
 class TestSSTableSplit(Tester):

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -8,7 +8,6 @@ from ccmlib.node import ToolError
 from dtest import Tester, debug
 from tools.decorators import since
 from tools.intervention import InterruptCompaction
-from tools.misc import ImmutableMapping
 
 # These must match the stress schema names
 KeyspaceName = 'keyspace1'

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -25,7 +25,6 @@ def _normcase_all(xs):
 
 @since('3.0')
 class SSTableUtilTest(Tester):
-    cluster_options = ImmutableMapping({'start_rpc': 'true'})
 
     def compaction_test(self):
         """

--- a/super_column_cache_test.py
+++ b/super_column_cache_test.py
@@ -7,8 +7,10 @@ from thrift_bindings.v22.ttypes import (CfDef, Column, ColumnOrSuperColumn,
                                         SuperColumn)
 from thrift_tests import get_thrift_client
 from tools.misc import ImmutableMapping
+from tools.decorators import since
 
 
+@since('2.0', max_version='4')
 class TestSCCache(Tester):
     cluster_options = ImmutableMapping({'start_rpc': 'true'})
 

--- a/super_counter_test.py
+++ b/super_counter_test.py
@@ -6,7 +6,9 @@ from dtest import Tester, debug, create_ks
 from thrift_tests import get_thrift_client
 from tools.misc import ImmutableMapping
 
+from tools.decorators import since
 
+@since('2.0', max_version='4')
 class TestSuperCounterClusterRestart(Tester):
     """
     This test is part of this issue:

--- a/super_counter_test.py
+++ b/super_counter_test.py
@@ -8,6 +8,7 @@ from tools.misc import ImmutableMapping
 
 from tools.decorators import since
 
+
 @since('2.0', max_version='4')
 class TestSuperCounterClusterRestart(Tester):
     """

--- a/thrift_hsha_test.py
+++ b/thrift_hsha_test.py
@@ -29,6 +29,7 @@ except KeyError:
         JNA_IN_LIB = glob.glob('%s/lib/jna-*.jar' % DEFAULT_DIR)
         JNA_PATH = JNA_IN_LIB[0]
 
+
 @since('2.0', max_version='4')
 class ThriftHSHATest(Tester):
 

--- a/thrift_hsha_test.py
+++ b/thrift_hsha_test.py
@@ -11,6 +11,9 @@ from dtest import DEFAULT_DIR, Tester, debug, create_ks
 from tools.jmxutils import (JolokiaAgent, make_mbean,
                             remove_perf_disable_shared_mem)
 
+from tools.decorators import since
+
+
 JNA_PATH = '/usr/share/java/jna.jar'
 ATTACK_JAR = 'lib/cassandra-attack.jar'
 
@@ -26,7 +29,7 @@ except KeyError:
         JNA_IN_LIB = glob.glob('%s/lib/jna-*.jar' % DEFAULT_DIR)
         JNA_PATH = JNA_IN_LIB[0]
 
-
+@since('2.0', max_version='4')
 class ThriftHSHATest(Tester):
 
     def test_closing_connections(self):

--- a/thrift_tests.py
+++ b/thrift_tests.py
@@ -44,6 +44,7 @@ def pid():
     return int(open(pid_fname).read())
 
 
+@since('2.0', max_version='4')
 class ThriftTester(ReusableClusterTester):
     client = None
     extra_args = []
@@ -342,6 +343,7 @@ def _big_multi_slice(key='abc'):
 _MULTI_SLICE_COLUMNS = [Column('a', '1', 0), Column('b', '2', 0), Column('c', '3', 0), Column('e', '5', 0), Column('f', '6', 0)]
 
 
+@since('2.0', max_version='4')
 class TestMutations(ThriftTester):
 
     def truncate_all(self, *table_names):

--- a/thrift_tests.py
+++ b/thrift_tests.py
@@ -57,6 +57,11 @@ class ThriftTester(ReusableClusterTester):
         super(ThriftTester, cls).setUpClass()
 
     def setUp(self):
+        # This is called before the @since annotation has had time to take
+        # effect and we don't want to even try connecting on thrift in 4.0
+        if self.cluster.version() >= '4':
+            return
+
         ReusableClusterTester.setUp(self)
 
         # this is ugly, but the whole test module is written against a global client
@@ -65,12 +70,23 @@ class ThriftTester(ReusableClusterTester):
         client.transport.open()
 
     def tearDown(self):
+        # This is called before the @since annotation has had time to take
+        # effect and we don't want to even try connecting on thrift in 4.0
+        if self.cluster.version() >= '4':
+            return
+
         client.transport.close()
         ReusableClusterTester.tearDown(self)
 
     @classmethod
     def post_initialize_cluster(cls):
         cluster = cls.cluster
+
+        # This is called before the @since annotation has had time to take
+        # effect and we don't want to even try connecting on thrift in 4.0
+        if cluster.version() >= '4':
+            return
+
         cluster.populate(1)
         node1, = cluster.nodelist()
 

--- a/write_failures_test.py
+++ b/write_failures_test.py
@@ -209,6 +209,7 @@ class TestWriteFailures(Tester):
         self.expected_expt = None
         self._perform_cql_statement("INSERT INTO mytable (key, value) VALUES ('key1', 'Value 1') IF NOT EXISTS")
 
+    @since('2.0', max_version='4')
     def test_thrift(self):
         """
         A thrift client receives a TimedOutException


### PR DESCRIPTION
This is the changes required on 4.0/trunk now that CASSANDRA-11115 has been committed and basically consists at skipping anything thrift related on 4.0. This depends on a https://github.com/pcmanus/ccm/pull/566, but once that's been committed, we should remove/revert the commit named "Point to modified ccm repo".