### PR TITLE
Update dtest to use new ccm 'wait_for_any_log' function

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -1039,7 +1039,7 @@ class TestAuth(Tester):
         self.cluster.set_configuration_options(values=config)
         self.cluster.populate(nodes).start()
 
-        n = self.wait_for_any_log(self.cluster.nodelist(), 'Created default superuser', 25)
+        n = self.cluster.wait_for_any_log('Created default superuser', 25)
         debug("Default role created by " + n.name)
 
     def get_session(self, node_idx=0, user=None, password=None):
@@ -2646,7 +2646,7 @@ class TestAuthRoles(Tester):
         self.cluster.set_configuration_options(values=config)
         self.cluster.populate(nodes).start(wait_for_binary_proto=True)
 
-        self.wait_for_any_log(self.cluster.nodelist(), 'Created default superuser', 25)
+        self.cluster.wait_for_any_log('Created default superuser', 25)
 
     def assert_permissions_listed(self, expected, session, query):
         rows = session.execute(query)

--- a/dtest.py
+++ b/dtest.py
@@ -626,29 +626,6 @@ class Tester(TestCase):
     def shortDescription(self):
         return None
 
-    def wait_for_any_log(self, nodes, pattern, timeout, filename='system.log'):
-        """
-        Look for a pattern in the system.log of any in a given list
-        of nodes.
-        @param nodes The list of nodes whose logs to scan
-        @param pattern The target pattern
-        @param timeout How long to wait for the pattern. Note that
-                        strictly speaking, timeout is not really a timeout,
-                        but a maximum number of attempts. This implies that
-                        the all the grepping takes no time at all, so it is
-                        somewhat inaccurate, but probably close enough.
-        @return The first node in whose log the pattern was found
-        """
-        for _ in range(timeout):
-            for node in nodes:
-                found = node.grep_log(pattern, filename=filename)
-                if found:
-                    return node
-            time.sleep(1)
-
-        raise TimeoutError(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()) +
-                           " Unable to find: " + repr(pattern) + " in any node log within " + str(timeout) + "s")
-
     def get_jfr_jvm_args(self):
         """
         @return The JVM arguments required for attaching flight recorder to a Java process.

--- a/dtest.py
+++ b/dtest.py
@@ -33,7 +33,6 @@ from cassandra.policies import RetryPolicy, WhiteListRoundRobinPolicy
 from ccmlib.cluster import Cluster
 from ccmlib.cluster_factory import ClusterFactory
 from ccmlib.common import get_version_from_build, is_win
-from ccmlib.node import TimeoutError
 from nose.exc import SkipTest
 from nose.tools import assert_greater_equal
 from six import print_

--- a/paging_test.py
+++ b/paging_test.py
@@ -3370,7 +3370,7 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
         else:
             failure_msg = ("Scanned over.* tombstones during query.* query aborted")
 
-        self.wait_for_any_log(self.cluster.nodelist(), failure_msg, 25)
+        self.cluster.wait_for_any_log(failure_msg, 25)
 
     @since('2.2.6')
     def test_deletion_with_distinct_paging(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
 
-ccm==2.4.7
+ccm==2.4.8
 cql
 decorator
 docopt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
 
-ccm==2.4.8
+ccm==2.4.9
 cql
 decorator
 docopt

--- a/secondary_indexes_test.py
+++ b/secondary_indexes_test.py
@@ -138,7 +138,7 @@ class TestSecondaryIndexes(Tester):
         # keyspace calls that come later. See CASSANDRA-11729.
         if self.cluster.version() > '3.0':
             self.cluster.wait_for_any_log('Completed submission of build tasks for any materialized views',
-                                  timeout=35, filename='debug.log')
+                                          timeout=35, filename='debug.log')
 
         # This only occurs when dropping and recreating with
         # the same name, so loop through this test a few times:
@@ -486,6 +486,7 @@ class TestSecondaryIndexes(Tester):
 
 
 class TestSecondaryIndexesOnCollections(Tester):
+
     def test_tuple_indexes(self):
         """
         Checks that secondary indexes on tuples work for querying

--- a/secondary_indexes_test.py
+++ b/secondary_indexes_test.py
@@ -137,7 +137,7 @@ class TestSecondaryIndexes(Tester):
         # to complete, to prevent schema concurrency issues with the drop
         # keyspace calls that come later. See CASSANDRA-11729.
         if self.cluster.version() > '3.0':
-            self.wait_for_any_log(self.cluster.nodelist(), 'Completed submission of build tasks for any materialized views',
+            self.cluster.wait_for_any_log('Completed submission of build tasks for any materialized views',
                                   timeout=35, filename='debug.log')
 
         # This only occurs when dropping and recreating with


### PR DESCRIPTION
Update requirements.txt to use version 2.4.8 of ccm, remove wait_for_any_log function definition, and replace all usages of wait_for_any_log with ccm version.