### PR TITLE
Add test that DES works in multi-datacenter situations (CASSANDRA-13074)

### DIFF
--- a/snitch_test.py
+++ b/snitch_test.py
@@ -1,8 +1,15 @@
 import os
 import socket
+import time
 
+from nose.plugins.attrib import attr
+
+from cassandra import ConsistencyLevel
 from dtest import Tester, debug
+from nose.tools import assert_true, assert_equal, assert_greater_equal
 from tools.decorators import since
+from tools.jmxutils import (JolokiaAgent, make_mbean,
+                            remove_perf_disable_shared_mem)
 
 
 @since('2.2.5')
@@ -88,3 +95,81 @@ class TestGossipingPropertyFileSnitch(Tester):
         self.assertIn("INTERNAL_IP:6:{}".format(NODE1_LISTEN_ADDRESS), out)
         self.assertIn("/{}".format(NODE2_BROADCAST_ADDRESS), out)
         self.assertIn("INTERNAL_IP:6:{}".format(NODE2_LISTEN_ADDRESS), out)
+
+
+class TestDynamicEndpointSnitch(Tester):
+    @attr('resource-intensive')
+    @since('3.10')
+    def test_multidatacenter_local_quorum(self):
+        '''
+        @jira_ticket CASSANDRA-13074
+
+        If we do only local datacenters reads in a multidatacenter DES setup,
+        DES should take effect and route around a degraded node
+        '''
+
+        def no_cross_dc(scores, cross_dc_nodes):
+            return all('/' + k.address() not in scores for k in cross_dc_nodes)
+
+        def snitchable(scores_before, scores_after, needed_nodes):
+            return all('/' + k.address() in scores_before and '/' + k.address()
+                       in scores_after for k in needed_nodes)
+
+        cluster = self.cluster
+        cluster.populate([3, 3])
+        coordinator_node, healthy_node, degraded_node, node4, node5, node6 = cluster.nodelist()
+        # increase DES reset/update interval so we clear any cross-DC startup reads faster
+        cluster.set_configuration_options(values={'dynamic_snitch_reset_interval_in_ms': 10000,
+                                                  'dynamic_snitch_update_interval_in_ms': 50,
+                                                  'phi_convict_threshold': 12})
+        remove_perf_disable_shared_mem(coordinator_node)
+        remove_perf_disable_shared_mem(degraded_node)
+        # Delay reads on the degraded node by 50 milliseconds
+        degraded_node.start(jvm_args=['-Dcassandra.test.read_iteration_delay_ms=50',
+                                      '-Dcassandra.allow_unsafe_join=true'])
+        cluster.start(wait_for_binary_proto=30, wait_other_notice=True)
+
+        des = make_mbean('db', type='DynamicEndpointSnitch')
+        read_stage = make_mbean('metrics', type='ThreadPools', path='request',
+                                scope='ReadStage', name='CompletedTasks')
+        session = self.patient_exclusive_cql_connection(coordinator_node)
+        session.execute("CREATE KEYSPACE snitchtestks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}")
+        session.execute("CREATE TABLE snitchtestks.tbl1 (key int PRIMARY KEY) WITH speculative_retry = 'NONE' AND dclocal_read_repair_chance = 0.0")
+        read_stmt = session.prepare("SELECT * FROM snitchtestks.tbl1 where key = ?")
+        read_stmt.consistency_level = ConsistencyLevel.LOCAL_QUORUM
+        with JolokiaAgent(coordinator_node) as jmx:
+            with JolokiaAgent(degraded_node) as bad_jmx:
+                cleared = False
+                # Wait for a snitch reset in case any earlier
+                # startup process populated cross-DC read timings
+                while not cleared:
+                    scores = jmx.read_attribute(des, 'Scores')
+                    cleared = ('/127.0.0.1' in scores and (len(scores) == 1)) or not scores
+
+                snitchable_count = 0
+
+                for x in range(0, 300):
+                    degraded_reads_before = bad_jmx.read_attribute(read_stage, 'Value')
+                    scores_before = jmx.read_attribute(des, 'Scores')
+                    assert_true(no_cross_dc(scores_before, [node4, node5, node6]),
+                                "Cross DC scores were present: " + str(scores_before))
+                    future = session.execute_async(read_stmt, [x])
+                    future.result()
+                    scores_after = jmx.read_attribute(des, 'Scores')
+                    assert_true(no_cross_dc(scores_after, [node4, node5, node6]),
+                                "Cross DC scores were present: " + str(scores_after))
+
+                    if snitchable(scores_before, scores_after,
+                                  [coordinator_node, healthy_node, degraded_node]):
+                        snitchable_count = snitchable_count + 1
+                        # If the DES correctly routed the read around the degraded node,
+                        # it shouldn't have another completed read request in metrics
+                        assert_equal(degraded_reads_before,
+                                     bad_jmx.read_attribute(read_stage, 'Value'))
+                    else:
+                        # sleep to give dynamic snitch time to recalculate scores
+                        time.sleep(.1)
+
+                # check that most reads were snitchable, with some
+                # room allowed in case score recalculation is slow
+                assert_greater_equal(snitchable_count, 250)


### PR DESCRIPTION
This test adds test coverage for DES in multi-datacenter situations.

It does this by populating scores for the local datacenter and ensuring that read metrics are not incremented on the degraded host when doing local quorum reads.

A [multiplexer run](http://cassci.datastax.com/job/parameterized_dtest_multiplexer/374/) shows this passing 90 times when the patches for CASSANDRA-13074 are applied. This should not be merged until CASSANDRA-13074 has been merged.