### PR TITLE
Don't try to alter system_distributed keyspace on 2.1

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -541,8 +541,11 @@ class TestBootstrap(BaseBootstrapTest):
         node2.start(wait_for_binary_proto=True, wait_other_notice=True)
 
         session = self.patient_cql_connection(node1)
-        # reduce system_distributed RF to 2 so we don't require forceful decommission
-        session.execute("ALTER KEYSPACE system_distributed WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':'1'};")
+
+        if cluster.version() >= '2.2':
+            # reduce system_distributed RF to 2 so we don't require forceful decommission
+            session.execute("ALTER KEYSPACE system_distributed WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':'1'};")
+
         session.execute("ALTER KEYSPACE system_traces WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':'1'};")
 
         # Decommision the new node and kill it

--- a/topology_test.py
+++ b/topology_test.py
@@ -42,8 +42,10 @@ class TestTopology(Tester):
         node1, node2, node3 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
-        # reduce system_distributed RF to 2 so we don't require forceful decommission
-        session.execute("ALTER KEYSPACE system_distributed WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':'2'};")
+
+        if cluster.version() >= '2.2':
+            # reduce system_distributed RF to 2 so we don't require forceful decommission
+            session.execute("ALTER KEYSPACE system_distributed WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':'2'};")
 
         # write some data
         node1.stress(['write', 'n=10K', 'no-warmup', '-rate', 'threads=8'])


### PR DESCRIPTION
These tests were recently changed to alter the system_distributed keyspace. This keyspace doesn't exist on 2.1, so that operation will always fail.