### PR TITLE
Add run_dtest.py usage example for disabled vnodes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,3 +132,7 @@ will often need to modify them in some fashion at some later point:
 * To reuse cassandra clusters when possible, set the environment variable REUSE_CLUSTER
 
         REUSE_CLUSTER=true nosetests -s -v cql_tests.py
+
+* Some tests will not run with vnodes enabled (you'll see a "SKIP: Test disabled for vnodes" message in that case). Use the provided runner script instead:
+
+        ./run_dtests.py --vnodes false --nose-options "-x -s -v" topology_test.py:TestTopology.movement_test


### PR DESCRIPTION
Because I always have to start looking at the code how to run those tests... :eyes: 