### PR TITLE
remove the allocate_tokens_for_keyspace in disk_balance_test

### DIFF
--- a/disk_balance_test.py
+++ b/disk_balance_test.py
@@ -18,7 +18,6 @@ class TestDiskBalance(Tester):
 
     def disk_balance_stress_test(self):
         cluster = self.cluster
-        cluster.set_configuration_options(values={'allocate_tokens_for_keyspace': 'keyspace1'})
         if not DISABLE_VNODES:
             cluster.set_configuration_options(values={'num_tokens': 256})
         cluster.populate(4).start(wait_for_binary_proto=True)
@@ -36,7 +35,6 @@ class TestDiskBalance(Tester):
             cluster.set_configuration_options(values={'num_tokens': 256})
         # apparently we have legitimate errors in the log when bootstrapping (see bootstrap_test.py)
         self.allow_log_errors = True
-        cluster.set_configuration_options(values={'allocate_tokens_for_keyspace': 'keyspace1'})
         cluster.populate(4).start(wait_for_binary_proto=True)
         node1 = cluster.nodes['node1']
 
@@ -50,7 +48,6 @@ class TestDiskBalance(Tester):
         cluster = self.cluster
         if not DISABLE_VNODES:
             cluster.set_configuration_options(values={'num_tokens': 256})
-        cluster.set_configuration_options(values={'allocate_tokens_for_keyspace': 'keyspace1'})
         cluster.populate(4).start(wait_for_binary_proto=True)
         node1 = cluster.nodes['node1']
         node4 = cluster.nodes['node4']
@@ -98,7 +95,6 @@ class TestDiskBalance(Tester):
         cluster = self.cluster
         if not DISABLE_VNODES:
             cluster.set_configuration_options(values={'num_tokens': 256})
-        cluster.set_configuration_options(values={'allocate_tokens_for_keyspace': 'keyspace1'})
         cluster.populate(3).start(wait_for_binary_proto=True)
         node1 = cluster.nodes['node1']
         node1.stress(['write', 'n=1', 'no-warmup', '-rate', 'threads=100', '-schema', 'replication(factor=1)'])


### PR DESCRIPTION
It does not make sense to have the allocate_tokens_for_keyspace, because the keyspace is not created at cluster start time yet.

And it will break the test after CASSANDRA-13080.