### PR TITLE
Use decommission --force on hintedhandoff_decom_test

### DIFF
--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -166,8 +166,8 @@ class TestHintedHandoff(Tester):
         insert_c1c2(session, n=100, consistency=ConsistencyLevel.ONE)
         node1.decommission()
         node4.start(wait_for_binary_proto=True)
-        node2.decommission()
-        node3.decommission()
+        node2.nodetool('decommission --force')
+        node3.nodetool('decommission --force')
         time.sleep(5)
         for x in xrange(0, 100):
             query_c1c2(session, x, ConsistencyLevel.ONE)

--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -166,8 +166,11 @@ class TestHintedHandoff(Tester):
         insert_c1c2(session, n=100, consistency=ConsistencyLevel.ONE)
         node1.decommission()
         node4.start(wait_for_binary_proto=True)
-        node2.nodetool('decommission --force')
-        node3.nodetool('decommission --force')
+
+        force = True if self.cluster.version() >= '3.12' else False
+        node2.decommission(force=force)
+        node3.decommission(force=force)
+
         time.sleep(5)
         for x in xrange(0, 100):
             query_c1c2(session, x, ConsistencyLevel.ONE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@
 futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
-
-ccm==2.4.9
+ccm==2.5.1
 cql
 decorator
 docopt


### PR DESCRIPTION
This test is broken on trunk after [CASSANDRA-12510](https://issues.apache.org/jira/browse/CASSANDRA-12510), so we need to use the `--force` flag to allow decommission to happen (dropping below RF is not relevant since we just want to make sure hints are being delivered on this test).