### PR TITLE
Update upgrade test post-CASSANDRA-12694

### DIFF
--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -3828,7 +3828,7 @@ class TestCQL(UpgradeTester):
                            UPDATE test SET v='barfoo' WHERE id=0 AND k='k2';
                            UPDATE test SET version=3 WHERE id=0 IF version=1;
                          APPLY BATCH
-                       """, [False, 0, None, 2])
+                       """, [False, 0, 'k1', 2])
 
             assert_one(cursor,
                        """


### PR DESCRIPTION
CASSANDRA-12694 did slightly change the behavior in that case (for the
better) and updated unit tests accordingly (see the end of
https://github.com/ifesdjeen/cassandra/commit/3b7a2f8479eaafa00d55466fe37e43318b8dadcf,
which is "exactly" the same case) but this upgrade test was missed and
currently fails
(http://cassci.datastax.com/job/cassandra-3.0_dtest_upgrade/lastBuild/testReport/junit/upgrade_tests.cql_tests/TestCQLNodes2RF1_Upgrade_current_3_0_x_To_indev_3_0_x/static_columns_cas_test/).