### PR TITLE
Convert avg compaction throughput to mbs before compaing to threshold

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -269,15 +269,23 @@ class TestCompaction(Tester):
         avgthroughput = m.named['avgthroughput']
         found_units = m.named['units']
 
+        unit_conversion_dct = {
+            "MB": 1,
+            "MiB": 1,
+            "KiB": 1. / 1024,
+            "GiB": 1024
+        }
+
         units = ['MB'] if cluster.version() < LooseVersion('3.6') else ['KiB', 'MiB', 'GiB']
         self.assertIn(found_units, units)
 
         debug(avgthroughput)
+        avgthroughput_mb = unit_conversion_dct[found_units] * float(avgthroughput)
 
         # The throughput in the log is computed independantly from the throttling and on the output files while
         # throttling is on the input files, so while that throughput shouldn't be higher than the one set in
         # principle, a bit of wiggle room is expected
-        self.assertGreaterEqual(float(threshold) + 0.5, float(avgthroughput))
+        self.assertGreaterEqual(float(threshold) + 0.5, avgthroughput_mb)
 
     def compaction_strategy_switching_test(self):
         """Ensure that switching strategies does not result in problems.


### PR DESCRIPTION
Solves https://issues.apache.org/jira/browse/CASSANDRA-13170

The reason for [the test](https://github.com/riptano/cassandra-dtest/blob/master/compaction_test.py#L280) to fail is that 5mb threshold is compared against the first matched `avgthroughput` without unit conversion. In the [node_debug.log](https://issues.apache.org/jira/secure/attachment/12850004/node1_debug.log) attached in the ticket, the threshold was compared against `6.175KiB/s`