### PR TITLE
Use "multi-catch" `assertRaises` call in `replace_address_test` and elsewhere

### DIFF
--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from itertools import chain
 from shutil import rmtree
-from unittest import skipIf, TestCase
+from unittest import skipIf
 
 from cassandra import ConsistencyLevel, ReadTimeout, Unavailable
 from cassandra.query import SimpleStatement

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from itertools import chain
 from shutil import rmtree
-from unittest import skipIf
+from unittest import skipIf, TestCase
 
 from cassandra import ConsistencyLevel, ReadTimeout, Unavailable
 from cassandra.query import SimpleStatement
@@ -111,13 +111,10 @@ class BaseReplaceAddressTest(Tester):
             self.replaced_node.stop(gently=gently, wait_other_notice=True)
 
         debug("Testing node stoppage (query should fail).")
-        with self.assertRaises(NodeUnavailable):
-            try:
-                session = self.patient_cql_connection(self.query_node)
-                query = SimpleStatement('select * from {}'.format(table), consistency_level=cl)
-                session.execute(query)
-            except (Unavailable, ReadTimeout):
-                raise NodeUnavailable("Node could not be queried.")
+        with self.assertRaises((Unavailable, ReadTimeout)):
+            session = self.patient_cql_connection(self.query_node)
+            query = SimpleStatement('select * from {}'.format(table), consistency_level=cl)
+            session.execute(query)
 
     def _insert_data(self, n='1k', rf=3, whitelist=False):
         debug("Inserting {} entries with rf={} with stress...".format(n, rf))


### PR DESCRIPTION
@ptnapoleon to review please. This is for cs690. I could only find one place where `assertRaises` was used in `replace_address_test`. I am assuming the other mention of its use in the JIRA ticket has since been removed or changed. 