### PR TITLE
Use ccm 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
-ccm==2.5.1
+ccm==2.6.0
 cql
 decorator
 docopt


### PR DESCRIPTION
@mshuler to review
Testing CI here: http://cassci.datastax.com/view/Dev/view/ptnapoleon/job/ptnapoleon-test-upgrade-dtest/1/console

(shouldnt be a serious change, is outside of the path of regular dtest usage)