### PR TITLE
set max_version since deprecated repair methods are removed in 4.0

### DIFF
--- a/repair_tests/deprecated_repair_test.py
+++ b/repair_tests/deprecated_repair_test.py
@@ -11,7 +11,7 @@ from tools.jmxutils import (JolokiaAgent, make_mbean,
                             remove_perf_disable_shared_mem)
 
 
-@since("2.2")
+@since("2.2", max_version="4")
 class TestDeprecatedRepairAPI(Tester):
     """
     @jira_ticket CASSANDRA-9570


### PR DESCRIPTION
[CASSANDRA-11530](https://issues.apache.org/jira/browse/CASSANDRA-11530) removes deprecated methods, so once it is committed, we need to patch `deprecated_repair_test` to have max version.