### PR TITLE
Restrict data dir for sstabledump test

### DIFF
--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -389,6 +389,8 @@ class TestOfflineTools(Tester):
         Test that sstabledump functions properly offline to output the contents of a table.
         """
         cluster = self.cluster
+        # disable JBOD conf since the test expects exactly one SSTable to be written.
+        cluster.set_datadir_count(1)
         cluster.populate(1).start(wait_for_binary_proto=True)
         [node1] = cluster.nodelist()
         session = self.patient_cql_connection(node1)


### PR DESCRIPTION
sstabledump test assumes only one SSTable to be written, but in JBOD config multiple SSTables.
This patch strictly set to use only 1 data directory to avoid error. 