### PR TITLE
Fix timeouts at TestAuthUpgrade.upgrade_to_22_test and TestAuthUpgrad…

### DIFF
--- a/tools/assertions.py
+++ b/tools/assertions.py
@@ -147,7 +147,7 @@ def assert_none(session, query, cl=None):
     assert list_res == [], "Expected nothing from {}, but got {}".format(query, list_res)
 
 
-def assert_all(session, query, expected, cl=None, ignore_order=False):
+def assert_all(session, query, expected, cl=None, ignore_order=False, timeout=None):
     """
     Assert query returns all expected items optionally in the correct order
     @param session Session in use
@@ -155,13 +155,14 @@ def assert_all(session, query, expected, cl=None, ignore_order=False):
     @param expected Expected results from query
     @param cl Optional Consistency Level setting. Default ONE
     @param ignore_order Optional boolean flag determining whether response is ordered
+    @param timeout Optional query timeout, in seconds
 
     Examples:
     assert_all(session, "LIST USERS", [['aleksey', False], ['cassandra', True]])
     assert_all(self.session1, "SELECT * FROM ttl_table;", [[1, 42, 1, 1]])
     """
     simple_query = SimpleStatement(query, consistency_level=cl)
-    res = session.execute(simple_query)
+    res = session.execute(simple_query) if timeout is None else session.execute(simple_query, timeout=timeout)
     list_res = _rows_to_list(res)
     if ignore_order:
         expected = sorted(expected)

--- a/upgrade_internal_auth_test.py
+++ b/upgrade_internal_auth_test.py
@@ -145,9 +145,9 @@ class TestAuthUpgrade(Tester):
 
         # we should now be able to drop the old auth tables
         session = self.patient_cql_connection(node1, user='cassandra', password='cassandra')
-        session.execute('DROP TABLE system_auth.users')
-        session.execute('DROP TABLE system_auth.credentials')
-        session.execute('DROP TABLE system_auth.permissions')
+        session.execute('DROP TABLE system_auth.users', timeout=60)
+        session.execute('DROP TABLE system_auth.credentials', timeout=60)
+        session.execute('DROP TABLE system_auth.permissions', timeout=60)
         # and we should still be able to authenticate and check authorization
         self.check_permissions(node1, True)
         debug('Test completed successfully')
@@ -163,12 +163,14 @@ class TestAuthUpgrade(Tester):
             assert_all(klaus,
                        'LIST ALL PERMISSIONS',
                        [['michael', '<table ks.cf1>', 'MODIFY'],
-                        ['michael', '<table ks.cf2>', 'SELECT']])
+                        ['michael', '<table ks.cf2>', 'SELECT']],
+                       timeout=60)
         else:
             assert_all(klaus,
                        'LIST ALL PERMISSIONS',
                        [['michael', 'michael', '<table ks.cf1>', 'MODIFY'],
-                        ['michael', 'michael', '<table ks.cf2>', 'SELECT']])
+                        ['michael', 'michael', '<table ks.cf2>', 'SELECT']],
+                       timeout=60)
 
         klaus.cluster.shutdown()
 


### PR DESCRIPTION
Both `TestAuthUpgrade.upgrade_to_22_test` and `TestAuthUpgrade.upgrade_to_30_test` use to fail due to timeouts.

These tests started to fail with timeouts when the temporary `session.default_timeout = 60.0` in `dtest.py` was removed, see [here](https://github.com/riptano/cassandra-dtest/commit/059bb8cccb5bd8088572fce73053d5500537a5d1). 

To solve the problem restoring the original behaviour, this PR simply specifies larger timeouts for the failing queries. Also, an optional timeout is added to `assertions.py.assert_all`.