### PR TITLE
Restrict data dir for no_anticompaction_of_already_repaired_test

### DIFF
--- a/repair_tests/repair_test.py
+++ b/repair_tests/repair_test.py
@@ -295,6 +295,8 @@ class TestRepair(BaseRepairTest):
 
         cluster = self.cluster
         debug("Starting cluster..")
+        # disable JBOD conf since the test expects sstables to be on the same disk
+        cluster.set_datadir_count(1)
         cluster.populate(3).start(wait_for_binary_proto=True)
         node1, node2, node3 = cluster.nodelist()
         # we use RF to make sure to cover only a set of sub-ranges when doing -full -pr


### PR DESCRIPTION
Simple fix for [no_anticompaction_of_already_repaired_test](http://cassci.datastax.com/view/cassandra-3.11/job/cassandra-3.11_novnode_dtest/38/testReport/repair_tests.repair_test/TestRepair/no_anticompaction_of_already_repaired_test/history/), which is failing only on 3.11 due to JBOD (test is disabled on trunk).