### PR TITLE
Add a test for CASSANDRA-13346

### DIFF
--- a/jmx_test.py
+++ b/jmx_test.py
@@ -13,7 +13,6 @@ from tools.misc import generate_ssl_stores
 
 
 class TestJMX(Tester):
-
     def netstats_test(self):
         """
         Check functioning of nodetool netstats, especially with restarts.
@@ -48,7 +47,8 @@ class TestJMX(Tester):
                 if not isinstance(e, ToolError):
                     raise
                 else:
-                    self.assertRegexpMatches(str(e), "ConnectException: 'Connection refused( \(Connection refused\))?'.")
+                    self.assertRegexpMatches(str(e),
+                                             "ConnectException: 'Connection refused( \(Connection refused\))?'.")
 
         self.assertTrue(running, msg='node1 never started')
 
@@ -69,9 +69,12 @@ class TestJMX(Tester):
         debug('Version {} typeName {}'.format(version, typeName))
 
         # TODO the keyspace and table name are capitalized in 2.0
-        memtable_size = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1', name='AllMemtablesHeapSize')
-        disk_size = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1', name='LiveDiskSpaceUsed')
-        sstable_count = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1', name='LiveSSTableCount')
+        memtable_size = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1',
+                                   name='AllMemtablesHeapSize')
+        disk_size = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1',
+                               name='LiveDiskSpaceUsed')
+        sstable_count = make_mbean('metrics', type=typeName, keyspace='keyspace1', scope='standard1',
+                                   name='LiveSSTableCount')
 
         with JolokiaAgent(node1) as jmx:
             mem_size = jmx.read_attribute(memtable_size, "Value")
@@ -114,17 +117,17 @@ class TestJMX(Tester):
             PRIMARY KEY (foo, bar, baz);""")
 
         table_memtable_size = make_mbean('metrics', type='Table', keyspace='mvtest', scope='testtable',
-                                   name='AllMemtablesHeapSize')
+                                         name='AllMemtablesHeapSize')
         table_view_read_time = make_mbean('metrics', type='Table', keyspace='mvtest', scope='testtable',
-                                         name='ViewReadTime')
+                                          name='ViewReadTime')
         table_view_lock_time = make_mbean('metrics', type='Table', keyspace='mvtest', scope='testtable',
-                                      name='ViewLockAcquireTime')
+                                          name='ViewLockAcquireTime')
         mv_memtable_size = make_mbean('metrics', type='Table', keyspace='mvtest', scope='testmv',
                                       name='AllMemtablesHeapSize')
         mv_view_read_time = make_mbean('metrics', type='Table', keyspace='mvtest', scope='testmv',
-                                          name='ViewReadTime')
+                                       name='ViewReadTime')
         mv_view_lock_time = make_mbean('metrics', type='Table', keyspace='mvtest', scope='testmv',
-                                          name='ViewLockAcquireTime')
+                                       name='ViewLockAcquireTime')
 
         missing_metric_message = "Table metric %s should have been registered after creating table %s" \
                                  "but wasn't!"
@@ -138,18 +141,18 @@ class TestJMX(Tester):
                                  missing_metric_message.format("ViewLockAcquireTime", "testtable"))
             self.assertIsNotNone(jmx.read_attribute(mv_memtable_size, "Value"),
                                  missing_metric_message.format("AllMemtablesHeapSize", "testmv"))
-            self.assertRaisesRegexp(Exception,".*InstanceNotFoundException.*", jmx.read_attribute,
+            self.assertRaisesRegexp(Exception, ".*InstanceNotFoundException.*", jmx.read_attribute,
                                     mbean=mv_view_read_time, attribute="Count", verbose=False)
-            self.assertRaisesRegexp(Exception,".*InstanceNotFoundException.*", jmx.read_attribute,
+            self.assertRaisesRegexp(Exception, ".*InstanceNotFoundException.*", jmx.read_attribute,
                                     mbean=mv_view_lock_time, attribute="Count", verbose=False)
 
         node.run_cqlsh(cmds="DROP KEYSPACE mvtest;")
         with JolokiaAgent(node) as jmx:
-            self.assertRaisesRegexp(Exception,".*InstanceNotFoundException.*", jmx.read_attribute,
+            self.assertRaisesRegexp(Exception, ".*InstanceNotFoundException.*", jmx.read_attribute,
                                     mbean=table_memtable_size, attribute="Value", verbose=False)
-            self.assertRaisesRegexp(Exception,".*InstanceNotFoundException.*", jmx.read_attribute,
+            self.assertRaisesRegexp(Exception, ".*InstanceNotFoundException.*", jmx.read_attribute,
                                     mbean=table_view_lock_time, attribute="Count", verbose=False)
-            self.assertRaisesRegexp(Exception,".*InstanceNotFoundException.*", jmx.read_attribute,
+            self.assertRaisesRegexp(Exception, ".*InstanceNotFoundException.*", jmx.read_attribute,
                                     mbean=table_view_read_time, attribute="Count", verbose=False)
             self.assertRaisesRegexp(Exception, ".*InstanceNotFoundException.*", jmx.read_attribute,
                                     mbean=mv_memtable_size, attribute="Value", verbose=False)
@@ -217,7 +220,8 @@ class TestJMX(Tester):
             start = time.time()
             max_query_timeout = 600
             debug("Waiting for compaction to finish:")
-            while (len(jmx.read_attribute(compaction_manager, 'CompactionSummary')) > 0) and (time.time() - start < max_query_timeout):
+            while (len(jmx.read_attribute(compaction_manager, 'CompactionSummary')) > 0) and (
+                    time.time() - start < max_query_timeout):
                 debug(jmx.read_attribute(compaction_manager, 'CompactionSummary'))
                 time.sleep(2)
 
@@ -254,7 +258,6 @@ class TestJMX(Tester):
 
 @since('3.9')
 class TestJMXSSL(Tester):
-
     keystore_password = 'cassandra'
     truststore_password = 'cassandra'
 
@@ -296,8 +299,10 @@ class TestJMXSSL(Tester):
                           .format(ts=self.truststore(), ts_pwd=self.truststore_password))
 
         # when both truststore and a keystore containing the client key are supplied, connection should succeed
-        node.nodetool("info --ssl -Djavax.net.ssl.trustStore={ts} -Djavax.net.ssl.trustStorePassword={ts_pwd} -Djavax.net.ssl.keyStore={ks} -Djavax.net.ssl.keyStorePassword={ks_pwd}"
-                      .format(ts=self.truststore(), ts_pwd=self.truststore_password, ks=self.keystore(), ks_pwd=self.keystore_password))
+        node.nodetool(
+            "info --ssl -Djavax.net.ssl.trustStore={ts} -Djavax.net.ssl.trustStorePassword={ts_pwd} -Djavax.net.ssl.keyStore={ks} -Djavax.net.ssl.keyStorePassword={ks_pwd}"
+            .format(ts=self.truststore(), ts_pwd=self.truststore_password, ks=self.keystore(),
+                    ks_pwd=self.keystore_password))
 
     def assert_insecure_connection_rejected(self, node):
         """

--- a/tools/jmxutils.py
+++ b/tools/jmxutils.py
@@ -225,7 +225,7 @@ class JolokiaAgent(object):
             print "Output was: %s" % (exc.output,)
             raise
 
-    def _query(self, body):
+    def _query(self, body, verbose=True):
         request_data = json.dumps(body)
         url = 'http://%s:8778/jolokia/' % (self.node.network_interfaces['binary'][0],)
         response = urlopen(url, data=request_data, timeout=10.0)
@@ -236,14 +236,14 @@ class JolokiaAgent(object):
         response = json.loads(raw_response)
         if response['status'] != 200:
             stacktrace = response.get('stacktrace')
-            if stacktrace:
+            if stacktrace and verbose:
                 print "Stacktrace from Jolokia error follows:"
                 for line in stacktrace.splitlines():
                     print line
             raise Exception("Jolokia agent returned non-200 status: %s" % (response,))
         return response
 
-    def read_attribute(self, mbean, attribute, path=None):
+    def read_attribute(self, mbean, attribute, path=None, verbose=True):
         """
         Reads a single JMX attribute.
 
@@ -260,10 +260,10 @@ class JolokiaAgent(object):
                 'attribute': attribute}
         if path:
             body['path'] = path
-        response = self._query(body)
+        response = self._query(body, verbose=verbose)
         return response['value']
 
-    def write_attribute(self, mbean, attribute, value, path=None):
+    def write_attribute(self, mbean, attribute, value, path=None, verbose=True):
         """
         Writes a values to a single JMX attribute.
 
@@ -284,7 +284,7 @@ class JolokiaAgent(object):
                 'value': value}
         if path:
             body['path'] = path
-        self._query(body)
+        self._query(body, verbose=verbose)
 
     def execute_method(self, mbean, operation, arguments=None):
         """


### PR DESCRIPTION
I've optionally made the JMX querying accept a `verbose` flag because the nosetest would print out all stacktraces otherwise...and finally end with an 'OK'. 

Any feedback/comments welcome (Or if you'd rather a patch etc.)