### PR TITLE
Add a sleep after compaction to give it time before checking SSTable directory for files (CASSANDRA-13182)

### DIFF
--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import subprocess
+import time
 
 from ccmlib import common
 from ccmlib.node import ToolError
@@ -40,6 +41,7 @@ class SSTableUtilTest(Tester):
         self.assertEqual(0, len(tmpfiles))
 
         node.compact()
+        time.sleep(5)
         finalfiles, tmpfiles = self._check_files(node, KeyspaceName, TableName)
         self.assertEqual(0, len(tmpfiles))
 


### PR DESCRIPTION
My best guess at the moment is because directly after we call `node.compact()` we instantly compare files. `_check_files` looks at the directory first and then invokes `SSTableUtil`, and then compares the output of them both. The (still existing) old generation SSTables is what the differences in the list are. This commit only introduces a small sleep to give compaction time to actually cleanup the files before we check the directory. 

Previously this test failed some 12 times in the last 30 runs, I've re-run it 45 times and still have yet to get an error, so I think this would fix it or at worse, make it less flaky. 

