### PR TITLE
Hinted handoff setmaxwindow test should only run on versions >= 4.0

### DIFF
--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -121,6 +121,7 @@ class TestHintedHandoffConfig(Tester):
 
         self._do_hinted_handoff(node1, node2, True)
 
+    @since('4.0')
     def hintedhandoff_setmaxwindow_test(self):
         """
         Test global hinted handoff against max_hint_window_in_ms update via nodetool


### PR DESCRIPTION
This test currently fails on versions < 4.0, since it was introduced for CASSANDRA-11720, which only went into 4.0+