### PR TITLE
Bump CCM version to 2.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
-ccm==2.6.0
+ccm==2.6.3
 cql
 decorator
 docopt


### PR DESCRIPTION
2.6.3 brings in several improvements over 2.6.0 that may increase reliability in some environments.