### PR TITLE
Repair preview tests should only run on 4.0+

### DIFF
--- a/repair_tests/preview_repair_test.py
+++ b/repair_tests/preview_repair_test.py
@@ -4,9 +4,10 @@ from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
 from dtest import Tester
-from tools.decorators import no_vnodes
+from tools.decorators import no_vnodes, since
 
 
+@since('4.0')
 class PreviewRepairTest(Tester):
 
     def assert_no_repair_history(self, session):


### PR DESCRIPTION
These tests were added for [CASSANDRA-13257](https://issues.apache.org/jira/browse/CASSANDRA-13257), which is 4.0+ only. We should restrict them to only run on supported versions.