### PR TITLE
Force decommission on topology test where required on 4.0+, run with vnodes

### DIFF
--- a/topology_test.py
+++ b/topology_test.py
@@ -350,7 +350,6 @@ class TestTopology(Tester):
             query_c1c2(session, n, ConsistencyLevel.ONE)
 
     @since('3.0')
-    @no_vnodes()
     def decommissioned_node_cant_rejoin_test(self):
         '''
         @jira_ticket CASSANDRA-8801
@@ -374,7 +373,7 @@ class TestTopology(Tester):
         node1, node2, node3 = self.cluster.nodelist()
 
         debug('decommissioning...')
-        node3.decommission()
+        node3.decommission(force=self.cluster.version() >= '4.0')
         debug('stopping...')
         node3.stop()
         debug('attempting restart...')


### PR DESCRIPTION
This has been failing since [CASSANDRA-12510](https://issues.apache.org/jira/browse/CASSANDRA-12510) was committed. It's safe to force here, so we force on versions 4.0+.

AFAICT, there's no reason this shouldn't run on vnodes. I removed the no_vnodes annotation and tested on 3.0, 3.11, and trunk, which are the only branches where this will run.