### PR TITLE
Restrict size estimates multi-dc test to run on 3.0.11+

### DIFF
--- a/topology_test.py
+++ b/topology_test.py
@@ -31,6 +31,7 @@ class TestTopology(Tester):
 
         node1.stop(gently=False)
 
+    @since('3.0.11')
     def size_estimates_multidc_test(self):
         """
         Test that primary ranges are correctly generated on


### PR DESCRIPTION
This test was introduced for [CASSANDRA-9639](https://issues.apache.org/jira/browse/CASSANDRA-9639), which only went into 3.0.11+. As I understand it, we do not expect the behavior described by this test to occur on 2.1 and 2.2 branches.

Ping @pauloricardomg to verify what I'm saying re: 2.1, 2.2, since I'm not completely certain.