### PR TITLE
Add tests for 'nodetool getbatchlogreplaythrottle' and 'nodetool setbatchlogreplaythrottle'

### DIFF
--- a/jmx_test.py
+++ b/jmx_test.py
@@ -188,7 +188,6 @@ class TestJMX(Tester):
 
         Test that batchlog replay throttle can be set and get through JMX
         """
-
         cluster = self.cluster
         cluster.populate(2)
         node = cluster.nodelist()[0]
@@ -202,6 +201,7 @@ class TestJMX(Tester):
             self.assertTrue(len(node.grep_log('Updating batchlog replay throttle to 4096 KB/s, 2048 KB/s per endpoint',
                                               filename='debug.log')) > 0)
             self.assertEqual(4096, jmx.read_attribute(mbean, 'BatchlogReplayThrottleInKB'))
+
 
 @since('3.9')
 class TestJMXSSL(Tester):

--- a/jmx_test.py
+++ b/jmx_test.py
@@ -181,6 +181,27 @@ class TestJMX(Tester):
         self.assertGreater(endpoint2Phi, 0.0)
         self.assertLess(endpoint2Phi, max_phi)
 
+    @since('4.0')
+    def test_set_get_batchlog_replay_throttle(self):
+        """
+        @jira_ticket CASSANDRA-13614
+
+        Test that batchlog replay throttle can be set and get through JMX
+        """
+
+        cluster = self.cluster
+        cluster.populate(2)
+        node = cluster.nodelist()[0]
+        remove_perf_disable_shared_mem(node)
+        cluster.start()
+
+        # Set and get throttle with JMX, ensuring that the rate change is logged
+        with JolokiaAgent(node) as jmx:
+            mbean = make_mbean('db', 'StorageService')
+            jmx.write_attribute(mbean, 'BatchlogReplayThrottleInKB', 4096)
+            self.assertTrue(len(node.grep_log('Updating batchlog replay throttle to 4096 KB/s, 2048 KB/s per endpoint',
+                                              filename='debug.log')) > 0)
+            self.assertEqual(4096, jmx.read_attribute(mbean, 'BatchlogReplayThrottleInKB'))
 
 @since('3.9')
 class TestJMXSSL(Tester):

--- a/nodetool_test.py
+++ b/nodetool_test.py
@@ -145,19 +145,18 @@ class TestNodetool(Tester):
 
         Test that batchlog replay throttle can be set and get through nodetool
         """
-
         cluster = self.cluster
         cluster.populate(2)
         node = cluster.nodelist()[0]
         cluster.start()
 
         # Test that nodetool help messages are displayed
-        self.assertTrue('Set batchlog replay throttle' in node.nodetool('help setbatchlogreplaythrottlekb').stdout)
-        self.assertTrue('Print batchlog replay throttle' in node.nodetool('help getbatchlogreplaythrottlekb').stdout)
+        self.assertTrue('Set batchlog replay throttle' in node.nodetool('help setbatchlogreplaythrottle').stdout)
+        self.assertTrue('Print batchlog replay throttle' in node.nodetool('help getbatchlogreplaythrottle').stdout)
 
         # Set and get throttle with nodetool, ensuring that the rate change is logged
-        node.nodetool('setbatchlogreplaythrottlekb 2048')
+        node.nodetool('setbatchlogreplaythrottle 2048')
         self.assertTrue(len(node.grep_log('Updating batchlog replay throttle to 2048 KB/s, 1024 KB/s per endpoint',
                                           filename='debug.log')) > 0)
-        self.assertTrue('Batchlog replay throttle: 2048 KB/s' in node.nodetool('getbatchlogreplaythrottlekb').stdout)
+        self.assertTrue('Batchlog replay throttle: 2048 KB/s' in node.nodetool('getbatchlogreplaythrottle').stdout)
 

--- a/nodetool_test.py
+++ b/nodetool_test.py
@@ -4,7 +4,6 @@ from ccmlib.node import ToolError
 
 from dtest import Tester, debug
 from tools.decorators import since
-from tools.jmxutils import JolokiaAgent, make_mbean, remove_perf_disable_shared_mem
 
 
 class TestNodetool(Tester):

--- a/nodetool_test.py
+++ b/nodetool_test.py
@@ -146,7 +146,7 @@ class TestNodetool(Tester):
         Test that nodetool can set the batchlog replay throttle
         """
         cluster = self.cluster
-        cluster.populate(1)
+        cluster.populate(2)
         node = cluster.nodelist()[0]
         remove_perf_disable_shared_mem(node)
         cluster.start()
@@ -157,10 +157,14 @@ class TestNodetool(Tester):
             # Set throttle with nodetool and check with JMX
             node.nodetool('setbatchlogreplaythrottlekb 2048')
             self.assertEqual(2048, jmx.read_attribute(mbean, 'BatchlogReplayThrottleInKB'))
+            self.assertTrue(len(node.grep_log('Updating batchlog replay throttle to 2048 KB/s, 1024 KB/s per endpoint',
+                                              filename='debug.log')) > 0)
 
             # Set throttle with JMX and check with JMX
             jmx.write_attribute(mbean, 'BatchlogReplayThrottleInKB', 4096)
             self.assertEqual(4096, jmx.read_attribute(mbean, 'BatchlogReplayThrottleInKB'))
+            self.assertTrue(len(node.grep_log('Updating batchlog replay throttle to 4096 KB/s, 2048 KB/s per endpoint',
+                                              filename='debug.log')) > 0)
 
         # Test that nodetool help message is displayed
         help = node.nodetool('help setbatchlogreplaythrottlekb')

--- a/nodetool_test.py
+++ b/nodetool_test.py
@@ -158,4 +158,3 @@ class TestNodetool(Tester):
         self.assertTrue(len(node.grep_log('Updating batchlog replay throttle to 2048 KB/s, 1024 KB/s per endpoint',
                                           filename='debug.log')) > 0)
         self.assertTrue('Batchlog replay throttle: 2048 KB/s' in node.nodetool('getbatchlogreplaythrottle').stdout)
-


### PR DESCRIPTION
Tests for the 'nodetool getbatchlogreplaythrottle' and 'nodetool setbatchlogreplaythrottle' commands added at [CASSANDRA-13614](https://issues.apache.org/jira/browse/CASSANDRA-13614)