### PR TITLE
Handle index order in describe output on 2.1

### DIFF
--- a/cqlsh_tests/cqlsh_tests.py
+++ b/cqlsh_tests/cqlsh_tests.py
@@ -913,6 +913,9 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
             return ret + "\n" + col_idx_def
 
     def get_users_table_output(self):
+        quoted_index_output = self.get_index_output('"QuotedNameIndex"', 'test', 'users', 'firstname')
+        myindex_output = self.get_index_output('myindex', 'test', 'users', 'age')
+
         if self.cluster.version() >= LooseVersion('3.9'):
             return """
         CREATE TABLE test.users (
@@ -934,8 +937,7 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
             AND min_index_interval = 128
             AND read_repair_chance = 0.0
             AND speculative_retry = '99PERCENTILE';
-        """ + self.get_index_output('"QuotedNameIndex"', 'test', 'users', 'firstname') \
-                   + "\n" + self.get_index_output('myindex', 'test', 'users', 'age')
+        """ + quoted_index_output + "\n" + myindex_output
         elif self.cluster.version() >= LooseVersion('3.0'):
             return """
         CREATE TABLE test.users (
@@ -957,8 +959,7 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
             AND min_index_interval = 128
             AND read_repair_chance = 0.0
             AND speculative_retry = '99PERCENTILE';
-        """ + self.get_index_output('"QuotedNameIndex"', 'test', 'users', 'firstname') \
-                   + "\n" + self.get_index_output('myindex', 'test', 'users', 'age')
+        """ + quoted_index_output + "\n" + myindex_output
         else:
             return """
         CREATE TABLE test.users (
@@ -979,8 +980,8 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
             AND min_index_interval = 128
             AND read_repair_chance = 0.0
             AND speculative_retry = '99.0PERCENTILE';
-        """ + self.get_index_output('QuotedNameIndex', 'test', 'users', 'firstname') \
-                   + "\n" + self.get_index_output('myindex', 'test', 'users', 'age')
+        """ + (quoted_index_output + "\n" + myindex_output if self.cluster.version() >= LooseVersion('2.2') else
+               myindex_output + "\n" + quoted_index_output)
 
     def get_index_output(self, index, ks, table, col):
         # a quoted index name (e.g. "FooIndex") is only correctly echoed by DESCRIBE


### PR DESCRIPTION
TL;DR: The index return order on 2.1 is different from 2.2+.

For the version of the Python driver bundled with 2.1, when getting describe output, we iterate over the columns and add any indexes found to an ordered dictionary. This means we return indexes in sort order on the name of the indexed column. On 2.2+, we keep track of indexes in a separate dictionary that isn't ordered. This means we get them in iteration order of the dictionary. In Python 2.7, this order is constant across all runs, which is why we don't need to handle both orders. If Python 3.3, the seed used for dicts was randomized, but in 3.6+, dicts maintain insertion order as an implementation detail. If we support Python versions 3.3-3.5 at any point for dtests, we'll need to handle results being returned in an arbitrary order (or ask the driver to use an ordered dict).

I tested the whole file on 2.1 and 2.2, and test_describe on 3.0+.